### PR TITLE
remove unnecessary keccak hardcode value

### DIFF
--- a/contracts/DefiBridgeProxy.sol
+++ b/contracts/DefiBridgeProxy.sol
@@ -12,11 +12,11 @@ import { TokenTransfers } from "./libraries/TokenTransfers.sol";
 import "hardhat/console.sol";
 
 contract DefiBridgeProxy {
-  bytes4 private constant BALANCE_OF_SELECTOR = 0x70a08231; // bytes4(keccak256('balanceOf(address)'));
-  bytes4 private constant TRANSFER_SELECTOR = 0xa9059cbb; // bytes4(keccak256('transfer(address,uint256)'));
-  bytes4 private constant DEPOSIT_SELECTOR = 0xb6b55f25; // bytes4(keccak256('deposit(uint256)'));
-  bytes4 private constant WITHDRAW_SELECTOR = 0x2e1a7d4d; // bytes4(keccak256('withdraw(uint256)'));
-  bytes4 private constant TRANSFER_FROM_SELECTOR = 0x23b872dd; // bytes4(keccak256('transferFrom(address,address,uint256)'));
+  bytes4 private constant BALANCE_OF_SELECTOR = bytes4(keccak256('balanceOf(address)'));
+  bytes4 private constant TRANSFER_SELECTOR = bytes4(keccak256('transfer(address,uint256)'));
+  bytes4 private constant DEPOSIT_SELECTOR = bytes4(keccak256('deposit(uint256)'));
+  bytes4 private constant WITHDRAW_SELECTOR = bytes4(keccak256('withdraw(uint256)'));
+  bytes4 private constant TRANSFER_FROM_SELECTOR = bytes4(keccak256('transferFrom(address,address,uint256)'));
 
   error DEFI_BRIDGE_PROXY_TRANSFER_FAILED();
   error INCORRECT_ASSET_VALUE();

--- a/contracts/MockRollupProcessor.sol
+++ b/contracts/MockRollupProcessor.sol
@@ -25,7 +25,7 @@ contract MockRollupProcessor {
     uint256 auxInputData; // (auxData)
   }
 
-  bytes4 private constant TRANSFER_FROM_SELECTOR = 0x23b872dd; // bytes4(keccak256('transferFrom(address,address,uint256)'));
+  bytes4 private constant TRANSFER_FROM_SELECTOR = bytes4(keccak256('transferFrom(address,address,uint256)'));
   mapping(uint256 => uint256) ethPayments;
   // We need to cap the amount of gas sent to the DeFi bridge contract for two reasons.
   // 1: To provide consistency to rollup providers around costs.

--- a/contracts/libraries/TokenTransfers.sol
+++ b/contracts/libraries/TokenTransfers.sol
@@ -8,8 +8,8 @@ pragma solidity >=0.8.4 <0.8.11;
  * as well as the ability to call `transfer` and `transferFrom` without bubbling up errors
  */
 library TokenTransfers {
-  bytes4 private constant TRANSFER_SELECTOR = 0xa9059cbb; // bytes4(keccak256('transfer(address,uint256)'));
-  bytes4 private constant TRANSFER_FROM_SELECTOR = 0x23b872dd; // bytes4(keccak256('transferFrom(address,address,uint256)'));
+  bytes4 private constant TRANSFER_SELECTOR = bytes4(keccak256('transfer(address,uint256)'));
+  bytes4 private constant TRANSFER_FROM_SELECTOR = bytes4(keccak256('transferFrom(address,address,uint256)'));
 
   /**
    * @dev Safely call ERC20.transfer, handles tokens that do not throw on transfer failure or do not return transfer result


### PR DESCRIPTION
I see this in a few places in the codebase:

```solidity
bytes4 private constant BALANCE_OF_SELECTOR = 0x70a08231; // bytes4(keccak256('balanceOf(address)'));
bytes4 private constant TRANSFER_SELECTOR = 0xa9059cbb; // bytes4(keccak256('transfer(address,uint256)'));
bytes4 private constant DEPOSIT_SELECTOR = 0xb6b55f25; // bytes4(keccak256('deposit(uint256)'));
bytes4 private constant WITHDRAW_SELECTOR = 0x2e1a7d4d; // bytes4(keccak256('withdraw(uint256)'));
bytes4 private constant TRANSFER_FROM_SELECTOR = 0x23b872dd; // bytes4(keccak256('transferFrom(address,address,uint256)'));
```

But constant values are [evaluated at compile time](https://docs.soliditylang.org/en/v0.8.11/contracts.html#constant).

So there's no need to use the hex value, and in fact doing so introduces the possibility of a discrepancy between the intended value and the actual value.