### PR TITLE
Liquity bridges

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -5,5 +5,5 @@ libs = ['lib']
 remappings = ['ds-test/=lib/ds-test/src/', '@openzeppelin/=node_modules/@openzeppelin/']
 fuzz_runs = 256
 gas_reports = ["*"]
-ETH_RPC_URL = 'https://mainnet.infura.io/v3/9928b52099854248b3a096be07a6b23c'
+ETH_RPC_URL = 'https://mainnet.infura.io/v3/737bcb5393b146d7870be2f68a7cea9c'
 # See more config options https://github.com/gakonst/foundry/tree/master/config

--- a/foundry.toml
+++ b/foundry.toml
@@ -5,5 +5,5 @@ libs = ['lib']
 remappings = ['ds-test/=lib/ds-test/src/', '@openzeppelin/=node_modules/@openzeppelin/']
 fuzz_runs = 256
 gas_reports = ["*"]
-ETH_RPC_URL = 'https://mainnet.infura.io/v3/737bcb5393b146d7870be2f68a7cea9c'
+ETH_RPC_URL = 'https://mainnet.infura.io/v3/9928b52099854248b3a096be07a6b23c'
 # See more config options https://github.com/gakonst/foundry/tree/master/config

--- a/src/aztec/DefiBridgeProxy.sol
+++ b/src/aztec/DefiBridgeProxy.sol
@@ -3,7 +3,6 @@
 pragma solidity >=0.8.4 <0.8.11;
 pragma experimental ABIEncoderV2;
 
-import {SafeMath} from "@openzeppelin/contracts/utils/math/SafeMath.sol";
 import {IDefiBridge} from "../interfaces/IDefiBridge.sol";
 import {AztecTypes} from "./AztecTypes.sol";
 

--- a/src/aztec/RollupProcessor.sol
+++ b/src/aztec/RollupProcessor.sol
@@ -3,7 +3,6 @@
 pragma solidity >=0.8.0 <=0.8.10;
 pragma abicoder v2;
 
-import {SafeMath} from "@openzeppelin/contracts/utils/math/SafeMath.sol";
 import {IDefiBridge} from "../interfaces/IDefiBridge.sol";
 import {IERC20} from "../interfaces/IERC20Permit.sol";
 import {DefiBridgeProxy} from "./DefiBridgeProxy.sol";

--- a/src/bridges/liquity/StabilityPoolBridge.sol
+++ b/src/bridges/liquity/StabilityPoolBridge.sol
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright 2020 Spilsbury Holdings Ltd
+pragma solidity >=0.8.0 <=0.8.10;
+pragma abicoder v2;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "../../interfaces/IDefiBridge.sol";
+import "../../interfaces/IWETH.sol";
+import "./interfaces/IStabilityPool.sol";
+import "./interfaces/ISwapRouter.sol";
+
+/**
+ * @title Aztec Connect Bridge for Liquity's StabilityPool.sol
+ * @author Jan Benes (@benesjan on Github and Telegram)
+ * @notice You can use this contract to deposit and withdraw LUSD to and from Liquity's StabilityPool.sol.
+ * @dev Implementation of the IDefiBridge interface for StabilityPool.sol.
+ *
+ * The contract inherits from OpenZeppelin's implementation of ERC20 token because token balances are used to track
+ * the depositor's ownership of the assets controlled by the bridge contract. The token is called StabilityPoolBridge
+ * and the token symbol is SPB. During the first deposits an equal amount of SPB tokens is minted as the amount of LUSD
+ * deposited - 1 SPB is worth 1 LUSD.  1 SPB token stops being worth 1 LUSD once rewards are claimed. There are 2 types
+ * of rewards in the StabilityPool: 1) ETH from liquidations, 2) LQTY from early adopter rewards.
+ *
+ * See https://docs.liquity.org/faq/stability-pool-and-liquidations#how-do-i-benefit-as-a-stability-provider-from-liquidations[Liquity docs]
+ * for more details.
+ *
+ * Rewards are automatically claimed and swapped to LUSD before each deposit and withdrawal. This allows for precise
+ * computation of how much each SPB is worth in terms of LUSD.
+ *
+ * Note: StabilityPoolBridge.sol is very similar to StakingBridge.sol.
+ */
+contract StabilityPoolBridge is IDefiBridge, ERC20("StabilityPoolBridge", "SPB") {
+    address public constant LUSD = 0x5f98805A4E8be255a32880FDeC7F6728C6568bA0;
+    address public constant WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
+    address public constant LQTY = 0x6DEA81C8171D0bA574754EF6F8b412F2Ed88c54D;
+    address public constant USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48; // set here because of multihop on Uni
+
+    IStabilityPool public constant STABILITY_POOL = IStabilityPool(0x66017D22b0f8556afDd19FC67041899Eb65a21bb);
+    ISwapRouter public constant UNI_ROUTER = ISwapRouter(0xE592427A0AEce92De3Edee1F18E0157C05861564);
+
+    address public immutable processor;
+    address public immutable frontEndTag; // see StabilityPool.sol for details
+
+    /**
+     * @notice Set addresses and token approvals.
+     * @param _processor Address of the RollupProcessor.sol
+     * @param _frontEndTag An address/tag identifying to which frontend LQTY frontend rewards should go. Can be zero.
+     * @dev Frontend tag is set here because there can be only 1 frontend tag per msg.sender in the StabilityPool.sol.
+     * See https://docs.liquity.org/faq/frontend-operators#how-do-frontend-tags-work[Liquity docs] for more details.
+     */
+    constructor(address _processor, address _frontEndTag) {
+        processor = _processor;
+        frontEndTag = _frontEndTag;
+    }
+
+    /**
+     * @notice Sets all the important approvals.
+     * @dev StabilityPoolBridge never holds LUSD, LQTY, USDC or WETH after or before an invocation of any of its
+     * functions. For this reason the following is not a security risk and makes the convert() function more gas
+     * efficient.
+     */
+    function setApprovals() public {
+        require(this.approve(processor, type(uint256).max), "StabilityPoolBridge: SPB_APPROVE_FAILED");
+        require(IERC20(LUSD).approve(processor, type(uint256).max), "StabilityPoolBridge: LUSD_APPROVE_FAILED");
+        require(
+            IERC20(LUSD).approve(address(STABILITY_POOL), type(uint256).max),
+            "StabilityPoolBridge: LUSD_APPROVE_FAILED"
+        );
+        require(
+            IERC20(WETH).approve(address(UNI_ROUTER), type(uint256).max),
+            "StabilityPoolBridge: WETH_APPROVE_FAILED"
+        );
+        require(
+            IERC20(LQTY).approve(address(UNI_ROUTER), type(uint256).max),
+            "StabilityPoolBridge: LQTY_APPROVE_FAILED"
+        );
+        require(
+            IERC20(USDC).approve(address(UNI_ROUTER), type(uint256).max),
+            "StabilityPoolBridge: USDC_APPROVE_FAILED"
+        );
+    }
+
+    /**
+     * @notice Function which deposits or withdraws LUSD to/from StabilityBridge.sol.
+     * @dev This method can only be called from the RollupProcessor.sol. If the input asset is LUSD, deposit flow is
+     * executed. If SPB, withdrawal. RollupProcessor.sol has to transfer the tokens to the bridge before calling
+     * the method. If this is not the case, the function will revert (either in STABILITY_POOL.provideToSP(...) or
+     * during SPB burn).
+     *
+     * Note: The function will revert during withdrawal in case there are troves to be liquidated. I am not handling
+     * this scenario because I expect the liquidation bots to be so fast that the scenario will never occur. Checking
+     * for it would only waste gas.
+     *
+     * @param inputAssetA - LUSD (Deposit) or SPB (Withdrawal)
+     * @param outputAssetA - SPB (Deposit) or LUSD (Withdrawal)
+     * @param inputValue - the amount of LUSD to deposit or the amount of SPB to burn and exchange for LUSD
+     * @return outputValueA - the amount of SPB (Deposit) or LUSD (Withdrawal) minted/transferred to
+     * the RollupProcessor.sol
+     */
+    function convert(
+        AztecTypes.AztecAsset calldata inputAssetA,
+        AztecTypes.AztecAsset calldata,
+        AztecTypes.AztecAsset calldata outputAssetA,
+        AztecTypes.AztecAsset calldata,
+        uint256 inputValue,
+        uint256,
+        uint64
+    )
+        external
+        payable
+        override
+        returns (
+            uint256 outputValueA,
+            uint256,
+            bool isAsync
+        )
+    {
+        require(msg.sender == processor, "StabilityPoolBridge: INVALID_CALLER");
+        isAsync = false;
+
+        if (inputAssetA.erc20Address == LUSD) {
+            // Deposit
+            require(outputAssetA.erc20Address == address(this), "StabilityPoolBridge: INCORRECT_DEPOSIT_INPUT");
+            // Deposit LUSD and claim rewards.
+            STABILITY_POOL.provideToSP(inputValue, frontEndTag);
+            _swapRewardsToLUSDAndDeposit();
+            uint256 totalLUSDOwnedBeforeDeposit = STABILITY_POOL.getCompoundedLUSDDeposit(address(this)) - inputValue;
+            // outputValueA = how much SPB should be minted
+            if (this.totalSupply() == 0) {
+                // When the totalSupply is 0, I set the SPB/LUSD ratio to be 1.
+                outputValueA = inputValue;
+            } else {
+                // this.totalSupply() / totalLUSDOwnedBeforeDeposit = how much SPB one LUSD is worth
+                // When I multiply this ^ with the amount of LUSD deposited I get the amount of SPB to be minted.
+                outputValueA = (this.totalSupply() * inputValue) / totalLUSDOwnedBeforeDeposit;
+            }
+            _mint(address(this), outputValueA);
+        } else {
+            // Withdrawal
+            require(
+                inputAssetA.erc20Address == address(this) && outputAssetA.erc20Address == LUSD,
+                "StabilityPoolBridge: INCORRECT_WITHDRAWAL_INPUT"
+            );
+            // Claim rewards and swap them to LUSD.
+            STABILITY_POOL.withdrawFromSP(0);
+            _swapRewardsToLUSDAndDeposit();
+
+            // stabilityPool.getCompoundedLUSDDeposit(address(this)) / this.totalSupply() = how much LUSD is one SPB
+            // outputValueA = amount of LUSD to be withdrawn and sent to RollupProcessor.sol
+            outputValueA = (STABILITY_POOL.getCompoundedLUSDDeposit(address(this)) * inputValue) / this.totalSupply();
+            STABILITY_POOL.withdrawFromSP(outputValueA);
+            _burn(address(this), inputValue);
+        }
+    }
+
+    /*
+     * @notice Swaps any ETH and LQTY currently held by the contract to LUSD and deposits LUSD to the StabilityPool.sol.
+     *
+     * @dev Note: The best route for LQTY -> LUSD is consistently LQTY -> WETH -> USDC -> LUSD. Since I want to swap
+     * liquidations rewards (ETH) to LUSD as well, I will first swap LQTY to WETH and then swap it all through USDC to
+     * LUSD.
+     */
+    function _swapRewardsToLUSDAndDeposit() internal {
+        uint256 lqtyBalance = IERC20(LQTY).balanceOf(address(this));
+        if (lqtyBalance != 0) {
+            UNI_ROUTER.exactInputSingle(
+                ISwapRouter.ExactInputSingleParams(LQTY, WETH, 3000, address(this), block.timestamp, lqtyBalance, 0, 0)
+            );
+        }
+
+        uint256 ethBalance = address(this).balance;
+        if (ethBalance != 0) {
+            // Wrap ETH in WETH
+            IWETH(WETH).deposit{value: ethBalance}();
+        }
+
+        uint256 wethBalance = IERC20(WETH).balanceOf(address(this));
+        if (wethBalance != 0) {
+            uint256 usdcBalance = UNI_ROUTER.exactInputSingle(
+                ISwapRouter.ExactInputSingleParams(WETH, USDC, 500, address(this), block.timestamp, wethBalance, 0, 0)
+            );
+            uint256 lusdBalance = UNI_ROUTER.exactInputSingle(
+                ISwapRouter.ExactInputSingleParams(USDC, LUSD, 500, address(this), block.timestamp, usdcBalance, 0, 0)
+            );
+            if (lusdBalance != 0) {
+                STABILITY_POOL.provideToSP(lusdBalance, frontEndTag);
+            }
+        }
+    }
+
+    // @notice This function always reverts because this contract does not implement async flow.
+    function finalise(
+        AztecTypes.AztecAsset calldata,
+        AztecTypes.AztecAsset calldata,
+        AztecTypes.AztecAsset calldata,
+        AztecTypes.AztecAsset calldata,
+        uint256,
+        uint64
+    )
+        external
+        payable
+        override
+        returns (
+            uint256,
+            uint256,
+            bool
+        )
+    {
+        require(false, "StabilityPoolBridge: ASYNC_MODE_DISABLED");
+    }
+}

--- a/src/bridges/liquity/StabilityPoolBridge.sol
+++ b/src/bridges/liquity/StabilityPoolBridge.sol
@@ -175,12 +175,16 @@ contract StabilityPoolBridge is IDefiBridge, ERC20("StabilityPoolBridge", "SPB")
 
         uint256 wethBalance = IERC20(WETH).balanceOf(address(this));
         if (wethBalance != 0) {
-            uint256 usdcBalance = UNI_ROUTER.exactInputSingle(
-                ISwapRouter.ExactInputSingleParams(WETH, USDC, 500, address(this), block.timestamp, wethBalance, 0, 0)
+            uint256 lusdBalance = UNI_ROUTER.exactInput(
+                ISwapRouter.ExactInputParams({
+                path: abi.encodePacked(WETH, uint24(500), USDC, uint24(500), LUSD),
+                recipient: address(this),
+                deadline: block.timestamp,
+                amountIn: wethBalance,
+                amountOutMinimum: 0
+                })
             );
-            uint256 lusdBalance = UNI_ROUTER.exactInputSingle(
-                ISwapRouter.ExactInputSingleParams(USDC, LUSD, 500, address(this), block.timestamp, usdcBalance, 0, 0)
-            );
+
             if (lusdBalance != 0) {
                 STABILITY_POOL.provideToSP(lusdBalance, frontEndTag);
             }

--- a/src/bridges/liquity/StabilityPoolBridge.sol
+++ b/src/bridges/liquity/StabilityPoolBridge.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-only
-// Copyright 2020 Spilsbury Holdings Ltd
+// Copyright 2022 Spilsbury Holdings Ltd
 pragma solidity >=0.8.0 <=0.8.10;
 pragma abicoder v2;
 

--- a/src/bridges/liquity/StabilityPoolBridge.sol
+++ b/src/bridges/liquity/StabilityPoolBridge.sol
@@ -116,7 +116,6 @@ contract StabilityPoolBridge is IDefiBridge, ERC20("StabilityPoolBridge", "SPB")
         )
     {
         require(msg.sender == processor, "StabilityPoolBridge: INVALID_CALLER");
-        isAsync = false;
 
         if (inputAssetA.erc20Address == LUSD) {
             // Deposit

--- a/src/bridges/liquity/StakingBridge.sol
+++ b/src/bridges/liquity/StakingBridge.sol
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright 2020 Spilsbury Holdings Ltd
+pragma solidity >=0.8.0 <=0.8.10;
+pragma abicoder v2;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "../../interfaces/IDefiBridge.sol";
+import "../../interfaces/IWETH.sol";
+import "./interfaces/ILQTYStaking.sol";
+import "./interfaces/ISwapRouter.sol";
+
+/**
+ * @title Aztec Connect Bridge for Liquity's LQTYStaking.sol
+ * @author Jan Benes (@benesjan on Github and Telegram)
+ * @notice You can use this contract to stake and unstake LQRTY to and from LQTY staking contract.
+ * @dev Implementation of the IDefiBridge interface for LQTYStaking.sol from Liquity protocol.
+ *
+ * The contract inherits from OpenZeppelin's implementation of ERC20 token because token balances are used to track
+ * the depositor's ownership of the assets controlled by the bridge contract. The token is called LQTYStaking and
+ * the token symbol is SB. During the first deposits an equal amount of SB tokens is minted as the amount of LQTY
+ * deposited - 1 SB is worth 1 LQTY.  1 SB token stops being worth 1 LQTY once rewards are claimed. There are 2 types
+ * of rewards in the LQTYStaking.sol: LUSD and ETH (see https://docs.liquity.org/faq/staking[Liquity docs] for more
+ * details).
+ *
+ * Rewards are automatically claimed and swapped to LQTY before staking and unstaking. This allows for precise
+ * computation of how much each SB is worth in terms of LQTY.
+ *
+ * Note: StakingBridge.sol is very similar to StabilityPoolBridge.sol.
+ */
+contract StakingBridge is IDefiBridge, ERC20("StakingBridge", "SB") {
+    address public constant LUSD = 0x5f98805A4E8be255a32880FDeC7F6728C6568bA0;
+    address public constant WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
+    address public constant LQTY = 0x6DEA81C8171D0bA574754EF6F8b412F2Ed88c54D;
+    address public constant USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48; // set here because of multihop on Uni
+
+    ILQTYStaking public constant STAKING_CONTRACT = ILQTYStaking(0x4f9Fbb3f1E99B56e0Fe2892e623Ed36A76Fc605d);
+    ISwapRouter public constant UNI_ROUTER = ISwapRouter(0xE592427A0AEce92De3Edee1F18E0157C05861564);
+
+    address public immutable processor;
+
+    /**
+     * @notice Set the addresses of RollupProcessor.sol and token approvals.
+     * @param _processor Address of the RollupProcessor.sol
+     */
+    constructor(address _processor) {
+        processor = _processor;
+    }
+
+    /**
+     * @notice Sets all the important approvals.
+     * @dev StakingBridge never holds LUSD, LQTY, USDC or WETH after or before an invocation of any of its functions.
+     * For this reason the following is not a security risk and makes the convert() function more gas efficient.
+     */
+    function setApprovals() public {
+        require(this.approve(processor, type(uint256).max), "StakingBridge: SBB_APPROVE_FAILED");
+        require(IERC20(LQTY).approve(processor, type(uint256).max), "StakingBridge: LUSD_APPROVE_FAILED");
+        require(
+            IERC20(LQTY).approve(address(STAKING_CONTRACT), type(uint256).max),
+            "StakingBridge: LQTY_APPROVE_FAILED"
+        );
+        require(IERC20(WETH).approve(address(UNI_ROUTER), type(uint256).max), "StakingBridge: WETH_APPROVE_FAILED");
+        require(IERC20(LUSD).approve(address(UNI_ROUTER), type(uint256).max), "StakingBridge: LUSD_APPROVE_FAILED");
+        require(IERC20(USDC).approve(address(UNI_ROUTER), type(uint256).max), "StakingBridge: USDC_APPROVE_FAILED");
+    }
+
+    /**
+     * @notice Function which stakes or unstakes LQTY to/from LQTYStaking.sol.
+     * @dev This method can only be called from the RollupProcessor.sol. If the input asset is LQTY, staking flow is
+     * executed. If SB, unstaking. RollupProcessor.sol has to transfer the tokens to the bridge before calling
+     * the method. If this is not the case, the function will revert (either in STAKING_CONTRACT.stake(...) or during
+     * SB burn).
+     *
+     * @param inputAssetA - LQTY (Staking) or SB (Unstaking)
+     * @param outputAssetA - SB (Staking) or LQTY (Unstaking)
+     * @param inputValue - the amount of LQTY to stake or the amount of SB to burn and exchange for LQTY
+     * @return outputValueA - the amount of SB (Staking) or LQTY (Unstaking) minted/transferred to
+     * the RollupProcessor.sol
+     */
+    function convert(
+        AztecTypes.AztecAsset calldata inputAssetA,
+        AztecTypes.AztecAsset calldata,
+        AztecTypes.AztecAsset calldata outputAssetA,
+        AztecTypes.AztecAsset calldata,
+        uint256 inputValue,
+        uint256,
+        uint64
+    )
+        external
+        payable
+        override
+        returns (
+            uint256 outputValueA,
+            uint256,
+            bool isAsync
+        )
+    {
+        require(msg.sender == processor, "StakingBridge: INVALID_CALLER");
+        isAsync = false;
+
+        if (inputAssetA.erc20Address == LQTY) {
+            // Deposit
+            require(outputAssetA.erc20Address == address(this), "StakingBridge: INCORRECT_DEPOSIT_INPUT");
+            // Stake and claim rewards
+            STAKING_CONTRACT.stake(inputValue);
+            _swapRewardsToLQTYAndStake();
+            // outputValueA = how much SB should be minted
+            if (this.totalSupply() == 0) {
+                // When the totalSupply is 0, I set the SB/LQTY ratio to be 1.
+                outputValueA = inputValue;
+            } else {
+                uint256 totalLQTYOwnedBeforeDeposit = STAKING_CONTRACT.stakes(address(this)) - inputValue;
+                // this.totalSupply() / totalLQTYOwnedBeforeDeposit = how much SB one LQTY is worth
+                // When I multiply this ^ with the amount of LQTY deposited I get the amount of SB to be minted.
+                outputValueA = (this.totalSupply() * inputValue) / totalLQTYOwnedBeforeDeposit;
+            }
+            _mint(address(this), outputValueA);
+        } else {
+            // Withdrawal
+            require(
+                inputAssetA.erc20Address == address(this) && outputAssetA.erc20Address == LQTY,
+                "StakingBridge: INCORRECT_WITHDRAWAL_INPUT"
+            );
+            // Claim rewards
+            STAKING_CONTRACT.unstake(0);
+            _swapRewardsToLQTYAndStake();
+
+            // STAKING_CONTRACT.stakes(address(this)) / this.totalSupply() = how much LQTY is one SB
+            // outputValueA = amount of LQTY to be withdrawn and sent to rollupProcessor
+            outputValueA = (STAKING_CONTRACT.stakes(address(this)) * inputValue) / this.totalSupply();
+            STAKING_CONTRACT.unstake(outputValueA);
+            _burn(address(this), inputValue);
+        }
+    }
+
+    /*
+     * @notice Swaps any ETH and LUSD currently held by the contract to LQTY and stakes LQTY in LQTYStaking.sol.
+     *
+     * @dev Note: The best route for LUSD -> LQTY is consistently LUSD -> USDC -> WETH -> LQTY. Since I want to swap
+     * liquidation rewards (ETH) to LQTY as well, I will first swap LUSD to WETH through USDC and then swap it all
+     * to LQTY
+     */
+    function _swapRewardsToLQTYAndStake() internal {
+        uint256 lusdBalance = IERC20(LUSD).balanceOf(address(this));
+        if (lusdBalance != 0) {
+            uint256 usdcBalance = UNI_ROUTER.exactInputSingle(
+                ISwapRouter.ExactInputSingleParams(LUSD, USDC, 500, address(this), block.timestamp, lusdBalance, 0, 0)
+            );
+            UNI_ROUTER.exactInputSingle(
+                ISwapRouter.ExactInputSingleParams(USDC, WETH, 500, address(this), block.timestamp, usdcBalance, 0, 0)
+            );
+        }
+
+        uint256 ethBalance = address(this).balance;
+        if (ethBalance != 0) {
+            // Wrap ETH in WETH
+            IWETH(WETH).deposit{value: ethBalance}();
+        }
+
+        uint256 wethBalance = IERC20(WETH).balanceOf(address(this));
+        if (wethBalance != 0) {
+            uint256 amountLQTYOut = UNI_ROUTER.exactInputSingle(
+                ISwapRouter.ExactInputSingleParams(WETH, LQTY, 3000, address(this), block.timestamp, wethBalance, 0, 0)
+            );
+            if (amountLQTYOut != 0) {
+                STAKING_CONTRACT.stake(amountLQTYOut);
+            }
+        }
+    }
+
+    // @notice This function always reverts because this contract does not implement async flow.
+    function finalise(
+        AztecTypes.AztecAsset calldata,
+        AztecTypes.AztecAsset calldata,
+        AztecTypes.AztecAsset calldata,
+        AztecTypes.AztecAsset calldata,
+        uint256,
+        uint64
+    )
+        external
+        payable
+        override
+        returns (
+            uint256,
+            uint256,
+            bool
+        )
+    {
+        require(false, "StakingBridge: ASYNC_MODE_DISABLED");
+    }
+
+    receive() external payable {}
+
+    fallback() external payable {}
+}

--- a/src/bridges/liquity/StakingBridge.sol
+++ b/src/bridges/liquity/StakingBridge.sol
@@ -141,11 +141,14 @@ contract StakingBridge is IDefiBridge, ERC20("StakingBridge", "SB") {
     function _swapRewardsToLQTYAndStake() internal {
         uint256 lusdBalance = IERC20(LUSD).balanceOf(address(this));
         if (lusdBalance != 0) {
-            uint256 usdcBalance = UNI_ROUTER.exactInputSingle(
-                ISwapRouter.ExactInputSingleParams(LUSD, USDC, 500, address(this), block.timestamp, lusdBalance, 0, 0)
-            );
-            UNI_ROUTER.exactInputSingle(
-                ISwapRouter.ExactInputSingleParams(USDC, WETH, 500, address(this), block.timestamp, usdcBalance, 0, 0)
+            UNI_ROUTER.exactInput(
+                ISwapRouter.ExactInputParams({
+                    path: abi.encodePacked(LUSD, uint24(500), USDC, uint24(500), WETH),
+                    recipient: address(this),
+                    deadline: block.timestamp,
+                    amountIn: lusdBalance,
+                    amountOutMinimum: 0
+                })
             );
         }
 

--- a/src/bridges/liquity/StakingBridge.sol
+++ b/src/bridges/liquity/StakingBridge.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-only
-// Copyright 2020 Spilsbury Holdings Ltd
+// Copyright 2022 Spilsbury Holdings Ltd
 pragma solidity >=0.8.0 <=0.8.10;
 pragma abicoder v2;
 

--- a/src/bridges/liquity/StakingBridge.sol
+++ b/src/bridges/liquity/StakingBridge.sol
@@ -95,7 +95,6 @@ contract StakingBridge is IDefiBridge, ERC20("StakingBridge", "SB") {
         )
     {
         require(msg.sender == processor, "StakingBridge: INVALID_CALLER");
-        isAsync = false;
 
         if (inputAssetA.erc20Address == LQTY) {
             // Deposit

--- a/src/bridges/liquity/TroveBridge.sol
+++ b/src/bridges/liquity/TroveBridge.sol
@@ -1,0 +1,282 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright 2020 Spilsbury Holdings Ltd
+pragma solidity >=0.8.0 <=0.8.10;
+pragma abicoder v2;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/utils/Strings.sol";
+import "../../interfaces/IDefiBridge.sol";
+import "../../interfaces/IRollupProcessor.sol";
+import "./interfaces/IBorrowerOperations.sol";
+import "./interfaces/ITroveManager.sol";
+import "./interfaces/ISortedTroves.sol";
+
+/**
+ * @title Aztec Connect Bridge for opening and closing Liquity's troves
+ * @author Jan Benes (@benesjan on Github and Telegram)
+ * @notice You can use this contract to borrow and repay LUSD
+ * @dev The contract inherits from OpenZeppelin's implementation of ERC20 token because token balances are used to track
+ * the depositor's ownership of the assets controlled by the bridge contract. The token is called TroveBridge and
+ * the token symbol is TB-[initial ICR] (ICR is an acronym for individual collateral ratio). 1 TB token always
+ * represents 1 LUSD worth of debt. In case the trove is not closed by redemption or liquidation, users can withdraw
+ * their collateral by supplying TB and an equal amount of LUSD to the bridge. 1 deployment of the bridge contract
+ * controls 1 trove. The bridge keeps precise accounting of debt by making sure that no user can change the trove's ICR.
+ * This means that when a price goes down the only way how a user can avoid liquidation penalty is to repay their debt.
+ *
+ * In case the trove gets liquidated, the bridge no longer controls any ETH and all the TB balances are irrelevant.
+ * At this point the bridge is defunct unless owner is the only one who borrowed. If owner is the only who borrowed
+ * calling closeTrove() will succeed and owner's balance will get burned making TB total supply 0.
+ *
+ * If the trove is closed by redemption, users can withdraw their remaining collateral by supplying their TB.
+ */
+contract TroveBridge is IDefiBridge, ERC20, Ownable {
+    using Strings for uint256;
+
+    address public constant LUSD = 0x5f98805A4E8be255a32880FDeC7F6728C6568bA0;
+
+    IBorrowerOperations public constant operations = IBorrowerOperations(0x24179CD81c9e782A4096035f7eC97fB8B783e007);
+    ITroveManager public constant troveManager = ITroveManager(0xA39739EF8b0231DbFA0DcdA07d7e29faAbCf4bb2);
+    ISortedTroves public constant sortedTroves = ISortedTroves(0x8FdD3fbFEb32b28fb73555518f8b361bCeA741A6);
+
+    address public immutable processor;
+    uint256 public immutable initialICR;
+    uint256 public immutable maxFee;
+
+    // Used to check whether collateral has already been claimed during redemptions.
+    bool private _collateralClaimed = false;
+
+    // Trove status taken from TroveManager.sol
+    enum Status {
+        nonExistent,
+        active,
+        closedByOwner,
+        closedByLiquidation,
+        closedByRedemption
+    }
+
+    /**
+     * @notice Set the address of RollupProcessor.sol and initial ICR
+     * @param _processor Address of the RollupProcessor.sol
+     * @param _initialICRPerc Collateral ratio denominated in percents to be used when opening the Trove
+     */
+    constructor(
+        address _processor,
+        uint256 _initialICRPerc,
+        uint256 _maxFee
+    ) ERC20("TroveBridge", string(abi.encodePacked("TB-", _initialICRPerc.toString()))) {
+        processor = _processor;
+        initialICR = _initialICRPerc * 1e16;
+        maxFee = _maxFee;
+    }
+
+    /**
+     * @notice A function which opens the trove.
+     * @param _upperHint Address of a Trove with a position in the sorted list before the correct insert position.
+     * @param _lowerHint Address of a Trove with a position in the sorted list after the correct insert position.
+     * See https://github.com/liquity/dev#supplying-hints-to-trove-operations for more details about hints.
+     * @dev Sufficient amount of ETH has to be send so that at least 2000 LUSD gets borrowed. 2000 LUSD is a minimum
+     * amount allowed by Liquity.
+     */
+    function openTrove(address _upperHint, address _lowerHint) external payable onlyOwner {
+        // Checks whether the trove can be safely opened/reopened
+        require(this.totalSupply() == 0, "TroveBridge: INCORRECT_TOTAL_SUPPLY");
+
+        require(IERC20(LUSD).approve(processor, type(uint256).max), "TroveBridge: LUSD_APPROVE_FAILED");
+        require(this.approve(processor, type(uint256).max), "TroveBridge: TB_APPROVE_FAILED");
+
+        uint256 amtToBorrow = computeAmtToBorrow(msg.value);
+
+        (uint256 debtBefore, , , ) = troveManager.getEntireDebtAndColl(address(this));
+        operations.openTrove{value: msg.value}(maxFee, amtToBorrow, _upperHint, _lowerHint);
+        (uint256 debtAfter, , , ) = troveManager.getEntireDebtAndColl(address(this));
+
+        IERC20(LUSD).transfer(msg.sender, IERC20(LUSD).balanceOf(address(this)));
+        // I mint TB token to msg.sender to be able to track collateral ownership. Minted amount equals debt increase.
+        _mint(msg.sender, debtAfter - debtBefore);
+    }
+
+    /**
+     * @notice A function which stakes or unstakes LQTY to/from LQTYStaking.sol.
+     * @dev This method can only be called from the RollupProcessor.sol. If the input asset is ETH, borrowing flow is
+     * executed. If TB, repaying. RollupProcessor.sol has to transfer the tokens to the bridge before calling
+     * the method. If this is not the case, the function will revert.
+     *
+     *                              Borrowing               Repaying                Redeeming
+     * @param inputAssetA -         ETH                     TB                      TB
+     * @param inputAssetB -         None                    LUSD                    None
+     * @param outputAssetA -        TB                      ETH                     ETH
+     * @param outputAssetB -        LUSD                    None                    None
+     * @param inputValue -          amount of ETH           amount of TB and LUSD   amount of TB
+     * @return outputValueA -       amount of TB            amount of ETH           amount of ETH
+     * @return outputValueB -       amount of LUSD          0                       0
+     */
+    function convert(
+        AztecTypes.AztecAsset calldata inputAssetA,
+        AztecTypes.AztecAsset calldata inputAssetB,
+        AztecTypes.AztecAsset calldata outputAssetA,
+        AztecTypes.AztecAsset calldata outputAssetB,
+        uint256 inputValue,
+        uint256 interactionNonce,
+        uint64
+    )
+        external
+        payable
+        override
+        returns (
+            uint256 outputValueA,
+            uint256 outputValueB,
+            bool isAsync
+        )
+    {
+        require(msg.sender == processor, "TroveBridge: INVALID_CALLER");
+        isAsync = false;
+        Status troveStatus = Status(troveManager.getTroveStatus(address(this)));
+
+        address upperHint = sortedTroves.getPrev(address(this));
+        address lowerHint = sortedTroves.getNext(address(this));
+
+        if (
+            inputAssetA.assetType == AztecTypes.AztecAssetType.ETH &&
+            outputAssetA.erc20Address == address(this) &&
+            outputAssetB.erc20Address == LUSD
+        ) {
+            // Borrowing
+            require(troveStatus == Status.active, "TroveBridge: INACTIVE_TROVE");
+            // outputValueA = by how much debt will increase and how much TB to mint
+            outputValueB = computeAmtToBorrow(inputValue); // LUSD amount to borrow
+
+            (uint256 debtBefore, , , ) = troveManager.getEntireDebtAndColl(address(this));
+            operations.adjustTrove{value: inputValue}(maxFee, 0, outputValueB, true, upperHint, lowerHint);
+            (uint256 debtAfter, , , ) = troveManager.getEntireDebtAndColl(address(this));
+
+            // outputValueA = debt increase = amount of TB to mint
+            outputValueA = debtAfter - debtBefore;
+            _mint(address(this), outputValueA);
+        } else if (
+            inputAssetA.erc20Address == address(this) &&
+            inputAssetB.erc20Address == LUSD &&
+            outputAssetA.assetType == AztecTypes.AztecAssetType.ETH
+        ) {
+            // Repaying
+            require(troveStatus == Status.active, "TroveBridge: INACTIVE_TROVE");
+            (, uint256 coll, , ) = troveManager.getEntireDebtAndColl(address(this));
+            outputValueA = (coll * inputValue) / this.totalSupply(); // Amount of collateral to withdraw
+            operations.adjustTrove(maxFee, outputValueA, inputValue, false, upperHint, lowerHint);
+            _burn(address(this), inputValue);
+            IRollupProcessor(processor).receiveEthFromBridge{value: outputValueA}(interactionNonce);
+        } else if (
+            inputAssetA.erc20Address == address(this) && outputAssetA.assetType == AztecTypes.AztecAssetType.ETH
+        ) {
+            // Redeeming
+            require(troveStatus == Status.closedByRedemption, "TroveBridge: INCORRECT_STATUS");
+            if (!_collateralClaimed) {
+                operations.claimCollateral();
+                _collateralClaimed = true;
+            }
+            outputValueA = (address(this).balance * inputValue) / this.totalSupply();
+            _burn(address(this), inputValue);
+            IRollupProcessor(processor).receiveEthFromBridge{value: outputValueA}(interactionNonce);
+        } else {
+            require(false, "TroveBridge: INCORRECT_INPUT");
+        }
+    }
+
+    /**
+     * @notice A function which closes the trove.
+     * @dev LUSD allowance has to be at least (remaining debt - 200).
+     */
+    function closeTrove() public onlyOwner {
+        address payable owner = payable(owner());
+        uint256 ownerTBBalance = balanceOf(owner);
+        require(ownerTBBalance == totalSupply(), "TroveBridge: OWNER_MUST_BE_LAST");
+
+        _burn(owner, ownerTBBalance);
+
+        Status troveStatus = Status(troveManager.getTroveStatus(address(this)));
+        if (troveStatus == Status.active) {
+            (uint256 remainingDebt, , , ) = troveManager.getEntireDebtAndColl(address(this));
+            // 200e18 is a part of debt which gets repaid from LUSD_GAS_COMPENSATION.
+            require(
+                IERC20(LUSD).transferFrom(owner, address(this), remainingDebt - 200e18),
+                "TroveBridge: LUSD_TRANSFER_FAILED"
+            );
+            operations.closeTrove();
+        } else if (troveStatus == Status.closedByRedemption) {
+            if (!_collateralClaimed) {
+                operations.claimCollateral();
+            }
+            _collateralClaimed = true;
+        }
+
+        owner.transfer(address(this).balance);
+    }
+
+    /**
+     * @notice Compute how much LUSD to borrow against collateral in order to keep ICR constant and by how much total
+     * trove debt will increase.
+     * @param _coll Amount of ETH denominated in Wei
+     * @return amtToBorrow Amount of LUSD to borrow to keep ICR constant.
+     * + borrowing fee)
+     * @dev I don't use view modifier here because the function updates PriceFeed state.
+     *
+     * Since the Trove opening and adjustment processes have desired amount of LUSD to borrow on the input and not
+     * the desired ICR I have to do the computation of borrowing fee "backwards". Here are the operations I did in order
+     * to get the final formula:
+     *      1) debtIncrease = amtToBorrow + amtToBorrow * BORROWING_RATE / DECIMAL_PRECISION + 200LUSD
+     *      2) debtIncrease - 200LUSD = amtToBorrow * (1 + BORROWING_RATE / DECIMAL_PRECISION)
+     *      3) amtToBorrow = (debtIncrease - 200LUSD) / (1 + BORROWING_RATE / DECIMAL_PRECISION)
+     *      4) amtToBorrow = (debtIncrease - 200LUSD) * DECIMAL_PRECISION / (DECIMAL_PRECISION + BORROWING_RATE)
+     * Note1: For trove adjustments (not opening) remove the 200 LUSD fee compensation from the formulas above.
+     * Note2: Step 4 is necessary to avoid loss of precision. BORROWING_RATE / DECIMAL_PRECISION was rounded to 0.
+     * Note3: The borrowing fee computation is on this line in Liquity code: https://github.com/liquity/dev/blob/cb583ddf5e7de6010e196cfe706bd0ca816ea40e/packages/contracts/contracts/TroveManager.sol#L1433
+     */
+    function computeAmtToBorrow(uint256 _coll) public returns (uint256 amtToBorrow) {
+        uint256 price = troveManager.priceFeed().fetchPrice();
+        bool isRecoveryMode = troveManager.checkRecoveryMode(price);
+        if (troveManager.getTroveStatus(address(this)) == 1) {
+            // Trove is active - use current ICR and not the initial one
+            uint256 icr = troveManager.getCurrentICR(address(this), price);
+            amtToBorrow = (_coll * price) / icr;
+            if (!isRecoveryMode) {
+                // Liquity is not in recovery mode so borrowing fee applies
+                uint256 borrowingRate = troveManager.getBorrowingRateWithDecay();
+                amtToBorrow = (amtToBorrow * 1e18) / (borrowingRate + 1e18);
+            }
+        } else {
+            // Trove is inactive - I will use initial ICR to compute debt
+            // 200e18 - 200 LUSD gas compensation to liquidators
+            amtToBorrow = (_coll * price) / initialICR - 200e18;
+            if (!isRecoveryMode) {
+                // Liquity is not in recovery mode so borrowing fee applies
+                uint256 borrowingRate = troveManager.getBorrowingRateWithDecay();
+                amtToBorrow = (amtToBorrow * 1e18) / (borrowingRate + 1e18);
+            }
+        }
+    }
+
+    // @notice This function always reverts because this contract does not implement async flow.
+    function finalise(
+        AztecTypes.AztecAsset calldata,
+        AztecTypes.AztecAsset calldata,
+        AztecTypes.AztecAsset calldata,
+        AztecTypes.AztecAsset calldata,
+        uint256,
+        uint64
+    )
+        external
+        payable
+        override
+        returns (
+            uint256,
+            uint256,
+            bool
+        )
+    {
+        require(false, "TroveBridge: ASYNC_MODE_DISABLED");
+    }
+
+    receive() external payable {}
+
+    fallback() external payable {}
+}

--- a/src/bridges/liquity/TroveBridge.sol
+++ b/src/bridges/liquity/TroveBridge.sol
@@ -44,7 +44,7 @@ contract TroveBridge is IDefiBridge, ERC20, Ownable {
     uint256 public immutable maxFee;
 
     // Used to check whether collateral has already been claimed during redemptions.
-    bool private _collateralClaimed = false;
+    bool private _collateralClaimed;
 
     // Trove status taken from TroveManager.sol
     enum Status {
@@ -130,7 +130,6 @@ contract TroveBridge is IDefiBridge, ERC20, Ownable {
         )
     {
         require(msg.sender == processor, "TroveBridge: INVALID_CALLER");
-        isAsync = false;
         Status troveStatus = Status(troveManager.getTroveStatus(address(this)));
 
         address upperHint = sortedTroves.getPrev(address(this));

--- a/src/bridges/liquity/TroveBridge.sol
+++ b/src/bridges/liquity/TroveBridge.sol
@@ -204,8 +204,9 @@ contract TroveBridge is IDefiBridge, ERC20, Ownable {
         } else if (troveStatus == Status.closedByRedemption) {
             if (!_collateralClaimed) {
                 operations.claimCollateral();
+            } else {
+                _collateralClaimed = false;
             }
-            _collateralClaimed = true;
         }
 
         owner.transfer(address(this).balance);

--- a/src/bridges/liquity/interfaces/IBorrowerOperations.sol
+++ b/src/bridges/liquity/interfaces/IBorrowerOperations.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0 <=0.8.10;
+
+interface IBorrowerOperations {
+    function openTrove(uint _maxFee, uint _LUSDAmount, address _upperHint, address _lowerHint) external payable;
+
+    function closeTrove() external;
+
+    function adjustTrove(uint _maxFee, uint _collWithdrawal, uint _debtChange, bool isDebtIncrease, address _upperHint, address _lowerHint) external payable;
+
+    function claimCollateral() external;
+}

--- a/src/bridges/liquity/interfaces/ILQTYStaking.sol
+++ b/src/bridges/liquity/interfaces/ILQTYStaking.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0 <=0.8.10;
+
+interface ILQTYStaking {
+    function stakes(address _user) external view returns (uint);
+
+    function stake(uint _LQTYamount) external;
+
+    function unstake(uint _LQTYamount) external;
+}

--- a/src/bridges/liquity/interfaces/ILiquityBase.sol
+++ b/src/bridges/liquity/interfaces/ILiquityBase.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0 <=0.8.10;
+
+import "./IPriceFeed.sol";
+
+
+interface ILiquityBase {
+    function priceFeed() external view returns (IPriceFeed);
+}

--- a/src/bridges/liquity/interfaces/IPriceFeed.sol
+++ b/src/bridges/liquity/interfaces/IPriceFeed.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0 <=0.8.10;
+
+interface IPriceFeed {
+    function fetchPrice() external returns (uint);
+}

--- a/src/bridges/liquity/interfaces/ISortedTroves.sol
+++ b/src/bridges/liquity/interfaces/ISortedTroves.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0 <=0.8.10;
+
+interface ISortedTroves {
+    function getNext(address _id) external view returns (address);
+
+    function getPrev(address _id) external view returns (address);
+
+    function findInsertPosition(uint256 _ICR, address _prevId, address _nextId) external view returns (address, address);
+}

--- a/src/bridges/liquity/interfaces/IStabilityPool.sol
+++ b/src/bridges/liquity/interfaces/IStabilityPool.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0 <=0.8.10;
+
+interface IStabilityPool {
+    function provideToSP(uint256 _amount, address _frontEndTag) external;
+
+    function withdrawFromSP(uint256 _amount) external;
+
+    function getCompoundedLUSDDeposit(address _depositor) external view returns (uint256);
+}

--- a/src/bridges/liquity/interfaces/ISwapRouter.sol
+++ b/src/bridges/liquity/interfaces/ISwapRouter.sol
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.7.5;
+pragma abicoder v2;
+
+/// @title Router token swapping functionality
+/// @notice Functions for swapping tokens via Uniswap V3
+interface ISwapRouter {
+    struct ExactInputSingleParams {
+        address tokenIn;
+        address tokenOut;
+        uint24 fee;
+        address recipient;
+        uint256 deadline;
+        uint256 amountIn;
+        uint256 amountOutMinimum;
+        uint160 sqrtPriceLimitX96;
+    }
+
+    /// @notice Swaps `amountIn` of one token for as much as possible of another token
+    /// @param params The parameters necessary for the swap, encoded as `ExactInputSingleParams` in calldata
+    /// @return amountOut The amount of the received token
+    function exactInputSingle(ExactInputSingleParams calldata params) external payable returns (uint256 amountOut);
+
+    struct ExactInputParams {
+        bytes path;
+        address recipient;
+        uint256 deadline;
+        uint256 amountIn;
+        uint256 amountOutMinimum;
+    }
+
+    /// @notice Swaps `amountIn` of one token for as much as possible of another along the specified path
+    /// @param params The parameters necessary for the multi-hop swap, encoded as `ExactInputParams` in calldata
+    /// @return amountOut The amount of the received token
+    function exactInput(ExactInputParams calldata params) external payable returns (uint256 amountOut);
+
+    struct ExactOutputSingleParams {
+        address tokenIn;
+        address tokenOut;
+        uint24 fee;
+        address recipient;
+        uint256 deadline;
+        uint256 amountOut;
+        uint256 amountInMaximum;
+        uint160 sqrtPriceLimitX96;
+    }
+
+    /// @notice Swaps as little as possible of one token for `amountOut` of another token
+    /// @param params The parameters necessary for the swap, encoded as `ExactOutputSingleParams` in calldata
+    /// @return amountIn The amount of the input token
+    function exactOutputSingle(ExactOutputSingleParams calldata params) external payable returns (uint256 amountIn);
+
+    struct ExactOutputParams {
+        bytes path;
+        address recipient;
+        uint256 deadline;
+        uint256 amountOut;
+        uint256 amountInMaximum;
+    }
+
+    /// @notice Swaps as little as possible of one token for `amountOut` of another along the specified path (reversed)
+    /// @param params The parameters necessary for the multi-hop swap, encoded as `ExactOutputParams` in calldata
+    /// @return amountIn The amount of the input token
+    function exactOutput(ExactOutputParams calldata params) external payable returns (uint256 amountIn);
+}

--- a/src/bridges/liquity/interfaces/ITroveManager.sol
+++ b/src/bridges/liquity/interfaces/ITroveManager.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0 <=0.8.10;
+
+import "./ILiquityBase.sol";
+import "./IStabilityPool.sol";
+import "./ILQTYStaking.sol";
+
+
+// Common interface for the Trove Manager.
+interface ITroveManager is ILiquityBase {
+    function getCurrentICR(address _borrower, uint _price) external view returns (uint);
+
+    function liquidate(address _borrower) external;
+
+    function redeemCollateral(
+        uint _LUSDAmount,
+        address _firstRedemptionHint,
+        address _upperPartialRedemptionHint,
+        address _lowerPartialRedemptionHint,
+        uint _partialRedemptionHintNICR,
+        uint _maxIterations,
+        uint _maxFee
+    ) external;
+
+    function getEntireDebtAndColl(address _borrower) external view returns (
+        uint debt, 
+        uint coll, 
+        uint pendingLUSDDebtReward, 
+        uint pendingETHReward
+    );
+
+    function closeTrove(address _borrower) external;
+
+    function getBorrowingRateWithDecay() external view returns (uint);
+
+    function getTroveStatus(address _borrower) external view returns (uint);
+    
+    function checkRecoveryMode(uint _price) external view returns (bool);
+}

--- a/src/interfaces/IWETH.sol
+++ b/src/interfaces/IWETH.sol
@@ -2,7 +2,7 @@
 pragma solidity >=0.7.5;
 pragma abicoder v2;
 
-interface WETH {
+interface IWETH {
   function deposit() external payable;
 
   function approve(address spender, uint256 amount) external returns (bool);

--- a/src/test/liquity/StabilityPoolBridge.t.sol
+++ b/src/test/liquity/StabilityPoolBridge.t.sol
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright 2020 Spilsbury Holdings Ltd
+pragma solidity >=0.8.0 <=0.8.10;
+pragma abicoder v2;
+
+import "./utils/TestUtil.sol";
+import "../../bridges/liquity/StabilityPoolBridge.sol";
+
+contract StabilityPoolBridgeTest is TestUtil {
+    StabilityPoolBridge private bridge;
+
+    function setUp() public {
+        _aztecPreSetup();
+        setUpTokens();
+
+        bridge = new StabilityPoolBridge(address(rollupProcessor), address(0));
+        bridge.setApprovals();
+    }
+
+    function testInitialERC20Params() public {
+        assertEq(bridge.name(), "StabilityPoolBridge");
+        assertEq(bridge.symbol(), "SPB");
+        assertEq(uint256(bridge.decimals()), 18);
+    }
+
+    function testFullDepositWithdrawalFlow() public {
+        // I will deposit and withdraw 1 million LUSD
+        uint256 depositAmount = 1e24;
+
+        // 1. Mint the deposit amount of LUSD to the bridge
+        mint("LUSD", address(rollupProcessor), depositAmount);
+
+        // 2. Deposit LUSD to the StabilityPool contract through the bridge
+        rollupProcessor.convert(
+            address(bridge),
+            AztecTypes.AztecAsset(1, tokens["LUSD"].addr, AztecTypes.AztecAssetType.ERC20),
+            AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
+            AztecTypes.AztecAsset(2, address(bridge), AztecTypes.AztecAssetType.ERC20),
+            AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
+            depositAmount,
+            0,
+            0
+        );
+
+        // 3. Check the total supply of SPB token is equal to the amount of LUSD deposited
+        assertEq(bridge.totalSupply(), depositAmount);
+
+        // 4. Check the SPB balance of rollupProcessor is equal to the amount of LUSD deposited
+        assertEq(bridge.balanceOf(address(rollupProcessor)), depositAmount);
+
+        // 5. Check the LUSD balance of the StabilityPoolBridge in the StabilityPool contract is equal to the amount
+        // of LUSD deposited
+        assertEq(bridge.STABILITY_POOL().getCompoundedLUSDDeposit(address(bridge)), depositAmount);
+
+        // 6. withdrawAmount is equal to depositAmount because there were no rewards claimed -> LUSD/SPB ratio stayed 1
+        uint256 withdrawAmount = depositAmount;
+
+        // 8. Withdraw LUSD from StabilityPool through the bridge
+        rollupProcessor.convert(
+            address(bridge),
+            AztecTypes.AztecAsset(2, address(bridge), AztecTypes.AztecAssetType.ERC20),
+            AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
+            AztecTypes.AztecAsset(1, tokens["LUSD"].addr, AztecTypes.AztecAssetType.ERC20),
+            AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
+            withdrawAmount,
+            1,
+            0
+        );
+
+        // 9. Check the total supply of SPB token is 0
+        assertEq(bridge.totalSupply(), 0);
+
+        // 10. Check the LUSD balance of rollupProcessor is equal to the initial LUSD deposit
+        assertEq(tokens["LUSD"].erc.balanceOf(address(rollupProcessor)), depositAmount);
+    }
+
+    function test5DepositsWithdrawals() public {
+        uint256 i = 0;
+        uint256 numIters = 5;
+        uint256 depositAmount = 203;
+        uint256[] memory spbBalances = new uint256[](numIters);
+
+        while (i < numIters) {
+            depositAmount = rand(depositAmount);
+            // 1. Mint deposit amount of LUSD to the rollupProcessor
+            mint("LUSD", address(rollupProcessor), depositAmount);
+            // 2. Mint rewards to the bridge
+            mint("LQTY", address(bridge), 1e20);
+            mint("WETH", address(bridge), 1e18);
+
+            // 3. Deposit LUSD to StabilityPool through the bridge
+            (uint256 outputValueA, , ) = rollupProcessor.convert(
+                address(bridge),
+                AztecTypes.AztecAsset(1, tokens["LUSD"].addr, AztecTypes.AztecAssetType.ERC20),
+                AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
+                AztecTypes.AztecAsset(2, address(bridge), AztecTypes.AztecAssetType.ERC20),
+                AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
+                depositAmount,
+                i,
+                0
+            );
+
+            spbBalances[i] = outputValueA;
+            i++;
+        }
+
+        i = 0;
+        while (i < numIters) {
+            // 4. Withdraw LUSD from StabilityPool through the bridge
+            rollupProcessor.convert(
+                address(bridge),
+                AztecTypes.AztecAsset(2, address(bridge), AztecTypes.AztecAssetType.ERC20),
+                AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
+                AztecTypes.AztecAsset(1, tokens["LUSD"].addr, AztecTypes.AztecAssetType.ERC20),
+                AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
+                spbBalances[i],
+                numIters + i,
+                0
+            );
+            i++;
+        }
+
+        // 5. Check the total supply of SPB token is 0
+        assertEq(bridge.totalSupply(), 0);
+    }
+}

--- a/src/test/liquity/StabilityPoolBridgeInternal.t.sol
+++ b/src/test/liquity/StabilityPoolBridgeInternal.t.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright 2020 Spilsbury Holdings Ltd
+pragma solidity >=0.8.0 <=0.8.10;
+pragma abicoder v2;
+
+import "./utils/TestUtil.sol";
+import "../../bridges/liquity/StabilityPoolBridge.sol";
+
+contract StabilityPoolBridgeTestInternal is TestUtil, StabilityPoolBridge(address(0), address(0)) {
+    function setUp() public {
+        _aztecPreSetup();
+        setUpTokens();
+
+        require(
+            IERC20(WETH).approve(address(UNI_ROUTER), type(uint256).max),
+            "StabilityPoolBridge: WETH_APPROVE_FAILED"
+        );
+        require(
+            IERC20(LQTY).approve(address(UNI_ROUTER), type(uint256).max),
+            "StabilityPoolBridge: LQTY_APPROVE_FAILED"
+        );
+        require(
+            IERC20(USDC).approve(address(UNI_ROUTER), type(uint256).max),
+            "StabilityPoolBridge: USDC_APPROVE_FAILED"
+        );
+    }
+
+    function testSwapRewardsOnUni() public {
+        mint("LQTY", address(this), 1e21);
+
+        // Note: to make the tests faster I will burn most of the ETH. This contract gets 79 million ETH by default.
+        // This makes swapping through Uni v3 slow as it has the loop through the ticks for many seconds
+        payable(address(0)).transfer(address(this).balance - 1 ether);
+
+        uint256 depositedLUSDBeforeSwap = STABILITY_POOL.getCompoundedLUSDDeposit(address(this));
+        _swapRewardsToLUSDAndDeposit();
+        uint256 depositedLUSDAfterSwap = STABILITY_POOL.getCompoundedLUSDDeposit(address(this));
+
+        // Verify that rewards were swapped for non-zero amount and correctly staked
+        assertGt(depositedLUSDAfterSwap, depositedLUSDBeforeSwap);
+
+        // Verify that all the rewards were swapped to LUSD
+        assertEq(tokens["WETH"].erc.balanceOf(address(this)), 0);
+        assertEq(tokens["LQTY"].erc.balanceOf(address(this)), 0);
+        assertEq(tokens["LUSD"].erc.balanceOf(address(this)), 0);
+        assertEq(address(this).balance, 0);
+    }
+}

--- a/src/test/liquity/StakingBridge.t.sol
+++ b/src/test/liquity/StakingBridge.t.sol
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright 2020 Spilsbury Holdings Ltd
+pragma solidity >=0.8.0 <=0.8.10;
+pragma abicoder v2;
+
+import "./utils/TestUtil.sol";
+import "../../bridges/liquity/StakingBridge.sol";
+
+contract StakingBridgeTest is TestUtil {
+    StakingBridge private bridge;
+
+    function setUp() public {
+        _aztecPreSetup();
+        setUpTokens();
+        bridge = new StakingBridge(address(rollupProcessor));
+        bridge.setApprovals();
+    }
+
+    function testInitialERC20Params() public {
+        assertEq(bridge.name(), "StakingBridge");
+        assertEq(bridge.symbol(), "SB");
+        assertEq(uint256(bridge.decimals()), 18);
+    }
+
+    function testFullDepositWithdrawalFlow() public {
+        // I will deposit and withdraw 1 million LQTY
+        uint256 depositAmount = 1e24;
+
+        // 1. Mint the deposit amount of LQTY to the bridge
+        mint("LQTY", address(rollupProcessor), depositAmount);
+
+        // 2. Deposit LQTY to the staking contract through the bridge
+        rollupProcessor.convert(
+            address(bridge),
+            AztecTypes.AztecAsset(1, tokens["LQTY"].addr, AztecTypes.AztecAssetType.ERC20),
+            AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
+            AztecTypes.AztecAsset(2, address(bridge), AztecTypes.AztecAssetType.ERC20),
+            AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
+            depositAmount,
+            0,
+            0
+        );
+
+        // 3. Check the total supply of SB token is equal to the amount of LQTY deposited
+        assertEq(bridge.totalSupply(), depositAmount);
+
+        // 4. Check the SB balance of rollupProcessor is equal to the amount of LQTY deposited
+        assertEq(bridge.balanceOf(address(rollupProcessor)), depositAmount);
+
+        // 5. Check the LQTY balance of StakingBridge in the staking contract is equal to the amount of LQTY deposited
+        assertEq(bridge.STAKING_CONTRACT().stakes(address(bridge)), depositAmount);
+
+        // 6. withdrawAmount is equal to depositAmount because there were no rewards claimed -> LQTY/SB ratio stayed 1
+        uint256 withdrawAmount = depositAmount;
+
+        // 7. Withdraw LQTY from the staking contract through the bridge
+        rollupProcessor.convert(
+            address(bridge),
+            AztecTypes.AztecAsset(2, address(bridge), AztecTypes.AztecAssetType.ERC20),
+            AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
+            AztecTypes.AztecAsset(1, tokens["LQTY"].addr, AztecTypes.AztecAssetType.ERC20),
+            AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
+            depositAmount,
+            1,
+            0
+        );
+
+        // 8. Check the total supply of SPB token is 0
+        assertEq(bridge.totalSupply(), 0);
+
+        // 9. Check the LQTY balance of rollupProcessor is equal to the initial LQTY deposit
+        assertEq(tokens["LQTY"].erc.balanceOf(address(rollupProcessor)), depositAmount);
+    }
+
+    function test5DepositsWithdrawals() public {
+        uint256 i = 0;
+        uint256 numIters = 5;
+        uint256 depositAmount = 203;
+        uint256[] memory sbBalances = new uint256[](numIters);
+
+        while (i < numIters) {
+            depositAmount = rand(depositAmount);
+            // 1. Mint deposit amount of LQTY to the rollupProcessor
+            mint("LQTY", address(rollupProcessor), depositAmount);
+            // 2. Mint rewards to the bridge
+            mint("LUSD", address(bridge), 1e20);
+            mint("WETH", address(bridge), 1e18);
+
+            // 3. Deposit LQTY to the staking contract through the bridge
+            (uint256 outputValueA, , ) = rollupProcessor.convert(
+                address(bridge),
+                AztecTypes.AztecAsset(1, tokens["LQTY"].addr, AztecTypes.AztecAssetType.ERC20),
+                AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
+                AztecTypes.AztecAsset(2, address(bridge), AztecTypes.AztecAssetType.ERC20),
+                AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
+                depositAmount,
+                i,
+                0
+            );
+
+            sbBalances[i] = outputValueA;
+            i++;
+        }
+
+        i = 0;
+        while (i < numIters) {
+            // 4. Withdraw LQTY from Staking through the bridge
+            rollupProcessor.convert(
+                address(bridge),
+                AztecTypes.AztecAsset(2, address(bridge), AztecTypes.AztecAssetType.ERC20),
+                AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
+                AztecTypes.AztecAsset(1, tokens["LQTY"].addr, AztecTypes.AztecAssetType.ERC20),
+                AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
+                sbBalances[i],
+                numIters + i,
+                0
+            );
+            i++;
+        }
+
+        // 6. Check the total supply of SPB token is 0
+        assertEq(bridge.totalSupply(), 0);
+    }
+}

--- a/src/test/liquity/StakingBridgeInternal.t.sol
+++ b/src/test/liquity/StakingBridgeInternal.t.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright 2020 Spilsbury Holdings Ltd
+pragma solidity >=0.8.0 <=0.8.10;
+pragma abicoder v2;
+
+import "./utils/TestUtil.sol";
+import "../../bridges/liquity/StakingBridge.sol";
+
+contract StakingBridgeTestInternal is TestUtil, StakingBridge(address(0)) {
+    function setUp() public {
+        _aztecPreSetup();
+        setUpTokens();
+
+        require(IERC20(WETH).approve(address(UNI_ROUTER), type(uint256).max), "StakingBridge: WETH_APPROVE_FAILED");
+        require(IERC20(LUSD).approve(address(UNI_ROUTER), type(uint256).max), "StakingBridge: LUSD_APPROVE_FAILED");
+        require(IERC20(USDC).approve(address(UNI_ROUTER), type(uint256).max), "StakingBridge: USDC_APPROVE_FAILED");
+    }
+
+    function testSwapRewardsToLQTY() public {
+        mint("LUSD", address(this), 1e21);
+
+        // Note: to make the tests faster I will burn most of the ETH. This contract gets 79 million ETH by default.
+        // This makes swapping through Uni v3 slow as it has the loop through the ticks for many seconds
+        payable(address(0)).transfer(address(this).balance - 1 ether);
+
+        uint256 stakedLQTYBeforeSwap = STAKING_CONTRACT.stakes(address(this));
+        _swapRewardsToLQTYAndStake();
+        uint256 stakedLQTYAfterSwap = STAKING_CONTRACT.stakes(address(this));
+
+        // Verify that rewards were swapped for non-zero amount and correctly staked
+        assertGt(stakedLQTYAfterSwap, stakedLQTYBeforeSwap);
+
+        // Verify that all the rewards were swapped and staked
+        assertEq(tokens["WETH"].erc.balanceOf(address(this)), 0);
+        assertEq(tokens["LUSD"].erc.balanceOf(address(this)), 0);
+        assertEq(tokens["LQTY"].erc.balanceOf(address(this)), 0);
+        assertEq(address(this).balance, 0);
+    }
+}

--- a/src/test/liquity/TroveBridge.t.sol
+++ b/src/test/liquity/TroveBridge.t.sol
@@ -133,13 +133,12 @@ contract TroveBridgeTest is TestUtil {
         _openTrove();
         _borrow();
 
-        // Mint 40 million LUSD and redeem
-        uint256 amountToRedeem = 4e25;
-        mint("LUSD", address(this), amountToRedeem);
-
-        bridge.troveManager().redeemCollateral(amountToRedeem, address(0), address(0), address(0), 0, 0, 5e16);
-        Status troveStatus = Status(bridge.troveManager().getTroveStatus(address(bridge)));
-        assertTrue(troveStatus == Status.closedByRedemption);
+        // Keep on redeeming 20 million LUSD until the trove is in the closedByRedemption status
+        uint256 amountToRedeem = 2e25;
+        do {
+            mint("LUSD", address(this), amountToRedeem);
+            bridge.troveManager().redeemCollateral(amountToRedeem, address(0), address(0), address(0), 0, 0, 1e18);
+        } while (Status(bridge.troveManager().getTroveStatus(address(bridge))) != Status.closedByRedemption);
 
         _redeem();
     }

--- a/src/test/liquity/TroveBridge.t.sol
+++ b/src/test/liquity/TroveBridge.t.sol
@@ -1,0 +1,332 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright 2020 Spilsbury Holdings Ltd
+pragma solidity >=0.8.0 <=0.8.10;
+pragma abicoder v2;
+
+import "./utils/TestUtil.sol";
+import "./interfaces/IHintHelpers.sol";
+import "../../bridges/liquity/TroveBridge.sol";
+
+contract TroveBridgeTest is TestUtil {
+    TroveBridge private bridge;
+
+    IHintHelpers private constant hintHelpers = IHintHelpers(0xE84251b93D9524E0d2e621Ba7dc7cb3579F997C0);
+    ISortedTroves private constant sortedTroves = ISortedTroves(0x8FdD3fbFEb32b28fb73555518f8b361bCeA741A6);
+
+    address private constant OWNER = address(24);
+
+    uint256 private constant OWNER_WEI_BALANCE = 5e18; // 5 ETH
+    uint256 private constant ROLLUP_PROCESSOR_WEI_BALANCE = 1e18; // 1 ETH
+
+    // From LiquityMath.sol
+    uint256 private constant NICR_PRECISION = 1e20;
+
+    enum Status {
+        nonExistent,
+        active,
+        closedByOwner,
+        closedByLiquidation,
+        closedByRedemption
+    }
+
+    function setUp() public {
+        _aztecPreSetup();
+        setUpTokens();
+
+        uint256 initialCollateralRatio = 160;
+        uint256 maxFee = 5e16; // Slippage protection: 5%
+
+        vm.prank(OWNER);
+        bridge = new TroveBridge(address(rollupProcessor), initialCollateralRatio, maxFee);
+
+        // Set OWNER's and ROLLUP_PROCESSOR's balances
+        vm.deal(OWNER, OWNER_WEI_BALANCE);
+        vm.deal(address(rollupProcessor), ROLLUP_PROCESSOR_WEI_BALANCE);
+    }
+
+    function testInitialERC20Params() public {
+        assertEq(bridge.name(), "TroveBridge");
+        assertEq(bridge.symbol(), "TB-160");
+        assertEq(uint256(bridge.decimals()), 18);
+    }
+
+    function testIncorrectTroveState() public {
+        // Attempt borrowing when trove was not opened - state 0
+        vm.prank(address(rollupProcessor));
+        try
+            bridge.convert(
+                AztecTypes.AztecAsset(3, address(0), AztecTypes.AztecAssetType.ETH),
+                AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
+                AztecTypes.AztecAsset(2, address(bridge), AztecTypes.AztecAssetType.ERC20),
+                AztecTypes.AztecAsset(1, tokens["LUSD"].addr, AztecTypes.AztecAssetType.ERC20),
+                ROLLUP_PROCESSOR_WEI_BALANCE,
+                0,
+                0
+            )
+        {
+            assertTrue(false, "convert(...) has to revert when trove is in an incorrect state.");
+        } catch Error(string memory reason) {
+            assertEq(reason, "TroveBridge: INACTIVE_TROVE");
+        }
+    }
+
+    function testIncorrectInput() public {
+        // Call convert with incorrect input
+        vm.prank(address(rollupProcessor));
+        try
+            bridge.convert(
+                AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
+                AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
+                AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
+                AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
+                0,
+                0,
+                0
+            )
+        {
+            assertTrue(false, "convert(...) has to revert on incorrect input.");
+        } catch Error(string memory reason) {
+            assertEq(reason, "TroveBridge: INCORRECT_INPUT");
+        }
+    }
+
+    function testFullFlow() public {
+        // This is the only way how to make 1 part of test depend on another in DSTest because tests are otherwise ran
+        // in parallel in different EVM instances. For this reason these parts of tests can't be evaluated individually
+        // unless ran repeatedly.
+        _openTrove();
+        _borrow();
+        _repay();
+        _closeTrove();
+    }
+
+    function testLiquidationFlow() public {
+        _openTrove();
+        _borrow();
+
+        // Drop price and liquidate the trove
+        dropLiquityPriceByHalf();
+        bridge.troveManager().liquidate(address(bridge));
+        Status troveStatus = Status(bridge.troveManager().getTroveStatus(address(bridge)));
+        assertTrue(troveStatus == Status.closedByLiquidation);
+
+        // Set msg.sender to OWNER
+        vm.startPrank(OWNER);
+
+        // Bridge is now defunct so check that closing and reopening fails with appropriate errors
+        try bridge.closeTrove() {
+            assertTrue(false, "closeTrove() has to revert in case owner's balance != TB total supply.");
+        } catch Error(string memory reason) {
+            assertEq(reason, "TroveBridge: OWNER_MUST_BE_LAST");
+        }
+
+        try bridge.openTrove(address(0), address(0)) {
+            assertTrue(false, "openTrove() has to revert in case TB total supply != 0.");
+        } catch Error(string memory reason) {
+            assertEq(reason, "TroveBridge: INCORRECT_TOTAL_SUPPLY");
+        }
+
+        vm.stopPrank();
+    }
+
+    function testRedeemFlow() public {
+        _openTrove();
+        _borrow();
+
+        // Mint 40 million LUSD and redeem
+        uint256 amountToRedeem = 4e25;
+        mint("LUSD", address(this), amountToRedeem);
+
+        bridge.troveManager().redeemCollateral(amountToRedeem, address(0), address(0), address(0), 0, 0, 5e16);
+        Status troveStatus = Status(bridge.troveManager().getTroveStatus(address(bridge)));
+        assertTrue(troveStatus == Status.closedByRedemption);
+
+        _redeem();
+    }
+
+    function _openTrove() private {
+        // Set msg.sender to OWNER
+        vm.startPrank(OWNER);
+
+        uint256 amtToBorrow = bridge.computeAmtToBorrow(OWNER_WEI_BALANCE);
+        uint256 nicr = (OWNER_WEI_BALANCE * NICR_PRECISION) / amtToBorrow;
+
+        // The following is Solidity implementation of https://github.com/liquity/dev#opening-a-trove
+        uint256 numTrials = 15;
+        uint256 randomSeed = 42;
+        (address approxHint, , ) = hintHelpers.getApproxHint(nicr, numTrials, randomSeed);
+        (address upperHint, address lowerHint) = sortedTroves.findInsertPosition(nicr, approxHint, approxHint);
+
+        // Open the trove
+        bridge.openTrove{value: OWNER_WEI_BALANCE}(upperHint, lowerHint);
+
+        uint256 price = bridge.troveManager().priceFeed().fetchPrice();
+        uint256 icr = bridge.troveManager().getCurrentICR(address(bridge), price);
+        // Verify the ICR equals the one specified in the bridge constructor
+        assertEq(icr, 160e16);
+
+        (uint256 debtAfterBorrowing, uint256 collAfterBorrowing, , ) = bridge.troveManager().getEntireDebtAndColl(
+            address(bridge)
+        );
+        // Check the TB total supply equals totalDebt
+        assertEq(bridge.totalSupply(), debtAfterBorrowing);
+        // Check the trove's collateral equals deposit amount
+        assertEq(collAfterBorrowing, OWNER_WEI_BALANCE);
+
+        uint256 lusdBalance = tokens["LUSD"].erc.balanceOf(OWNER);
+        assertEq(lusdBalance, amtToBorrow);
+
+        // Check the bridge doesn't hold any ETH or LUSD
+        assertEq(address(bridge).balance, 0);
+        assertEq(tokens["LUSD"].erc.balanceOf(address(bridge)), 0);
+
+        vm.stopPrank();
+    }
+
+    function _borrow() private {
+        uint256 price = bridge.troveManager().priceFeed().fetchPrice();
+        uint256 icrBeforeBorrowing = bridge.troveManager().getCurrentICR(address(bridge), price);
+
+        (, uint256 collBeforeBorrowing, , ) = bridge.troveManager().getEntireDebtAndColl(address(bridge));
+
+        // Borrow against ROLLUP_PROCESSOR_WEI_BALANCE
+        rollupProcessor.convert(
+            address(bridge),
+            AztecTypes.AztecAsset(3, address(0), AztecTypes.AztecAssetType.ETH),
+            AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
+            AztecTypes.AztecAsset(2, address(bridge), AztecTypes.AztecAssetType.ERC20),
+            AztecTypes.AztecAsset(1, tokens["LUSD"].addr, AztecTypes.AztecAssetType.ERC20),
+            ROLLUP_PROCESSOR_WEI_BALANCE,
+            0,
+            0
+        );
+
+        (uint256 debtAfterBorrowing, uint256 collAfterBorrowing, , ) = bridge.troveManager().getEntireDebtAndColl(
+            address(bridge)
+        );
+        // Check the collateral increase equals ROLLUP_PROCESSOR_WEI_BALANCE
+        assertEq(collAfterBorrowing - collBeforeBorrowing, ROLLUP_PROCESSOR_WEI_BALANCE);
+
+        uint256 icrAfterBorrowing = bridge.troveManager().getCurrentICR(address(bridge), price);
+        // Check the the ICR didn't change
+        assertEq(icrBeforeBorrowing, icrAfterBorrowing);
+
+        // Check the TB total supply equals totalDebt
+        assertEq(bridge.totalSupply(), debtAfterBorrowing);
+
+        // Check the bridge doesn't hold any ETH or LUSD
+        assertEq(address(bridge).balance, 0);
+        assertEq(tokens["LUSD"].erc.balanceOf(address(bridge)), 0);
+
+        // Check the tokens were successfully sent to the rollupProcessor
+        assertGt(bridge.balanceOf(address(rollupProcessor)), 0);
+        assertGt(tokens["LUSD"].erc.balanceOf(address(rollupProcessor)), 0);
+    }
+
+    function _repay() private {
+        uint256 processorTBBalance = bridge.balanceOf(address(rollupProcessor));
+        uint256 processorLUSDBalance = tokens["LUSD"].erc.balanceOf(address(rollupProcessor));
+
+        uint256 borrowerFee = processorTBBalance - processorLUSDBalance;
+        // Mint the borrower fee to ROLLUP_PROCESSOR in order to have a big enough balance for repaying
+        mint("LUSD", address(rollupProcessor), borrowerFee);
+
+        rollupProcessor.convert(
+            address(bridge),
+            AztecTypes.AztecAsset(2, address(bridge), AztecTypes.AztecAssetType.ERC20),
+            AztecTypes.AztecAsset(1, tokens["LUSD"].addr, AztecTypes.AztecAssetType.ERC20),
+            AztecTypes.AztecAsset(3, address(0), AztecTypes.AztecAssetType.ETH),
+            AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
+            processorTBBalance,
+            1,
+            0
+        );
+
+        // Check the bridge doesn't hold any ETH or LUSD
+        assertEq(address(bridge).balance, 0);
+        assertEq(tokens["LUSD"].erc.balanceOf(address(bridge)), 0);
+
+        // I want to check whether withdrawn amount of ETH is the same as the ROLLUP_PROCESSOR_WEI_BALANCE.
+        // There is some imprecision so the amount is allowed to be different by 1 wei.
+        uint256 diffInETH = address(rollupProcessor).balance < ROLLUP_PROCESSOR_WEI_BALANCE
+            ? ROLLUP_PROCESSOR_WEI_BALANCE - address(rollupProcessor).balance
+            : address(rollupProcessor).balance - ROLLUP_PROCESSOR_WEI_BALANCE;
+        assertLe(diffInETH, 1);
+    }
+
+    function _closeTrove() private {
+        // Set msg.sender to OWNER
+        vm.startPrank(OWNER);
+
+        uint256 ownerTBBalance = bridge.balanceOf(OWNER);
+        uint256 ownerLUSDBalance = tokens["LUSD"].erc.balanceOf(OWNER);
+
+        uint256 borrowerFee = ownerTBBalance - ownerLUSDBalance - 200e18;
+        uint256 amountToRepay = ownerLUSDBalance + borrowerFee;
+
+        mint("LUSD", OWNER, borrowerFee);
+        tokens["LUSD"].erc.approve(address(bridge), amountToRepay);
+
+        bridge.closeTrove();
+
+        Status troveStatus = Status(bridge.troveManager().getTroveStatus(address(bridge)));
+        assertTrue(troveStatus == Status.closedByOwner);
+
+        // Check the bridge doesn't hold any ETH or LUSD
+        assertEq(address(bridge).balance, 0);
+        assertEq(tokens["LUSD"].erc.balanceOf(address(bridge)), 0);
+
+        // I want to check whether withdrawn amount of ETH is the same as the ROLLUP_PROCESSOR_WEI_BALANCE.
+        // There is some imprecision so the amount is allowed to be different by 1 wei.
+        uint256 diffInETH = OWNER.balance < OWNER_WEI_BALANCE
+            ? OWNER_WEI_BALANCE - OWNER.balance
+            : OWNER.balance - OWNER_WEI_BALANCE;
+        assertLe(diffInETH, 1);
+
+        // Check the TB total supply is 0
+        assertEq(bridge.totalSupply(), 0);
+
+        vm.stopPrank();
+    }
+
+    function _redeem() private {
+        uint256 processorTBBalance = bridge.balanceOf(address(rollupProcessor));
+
+        rollupProcessor.convert(
+            address(bridge),
+            AztecTypes.AztecAsset(2, address(bridge), AztecTypes.AztecAssetType.ERC20),
+            AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
+            AztecTypes.AztecAsset(3, address(0), AztecTypes.AztecAssetType.ETH),
+            AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
+            processorTBBalance,
+            0,
+            0
+        );
+
+        // Check that non-zero amount of ETH has been redeemed
+        assertGt(address(rollupProcessor).balance, 0);
+    }
+
+    function _closeRedeem() private {
+        // Set msg.sender to OWNER
+        vm.startPrank(OWNER);
+
+        bridge.closeTrove();
+
+        // Check the bridge doesn't hold any ETH or LUSD
+        assertEq(address(bridge).balance, 0);
+
+        // Check that non-zero amount of ETH has been redeemed
+        assertGt(OWNER.balance, 0);
+
+        // Check the TB total supply is 0
+        assertEq(bridge.totalSupply(), 0);
+
+        vm.stopPrank();
+    }
+
+    receive() external payable {}
+
+    // Here so that I can successfully liquidate a trove from within this contract.
+    fallback() external payable {}
+}

--- a/src/test/liquity/interfaces/IHintHelpers.sol
+++ b/src/test/liquity/interfaces/IHintHelpers.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0 <=0.8.10;
+
+interface IHintHelpers {
+    function getApproxHint(
+        uint256 _CR,
+        uint256 _numTrials,
+        uint256 _inputRandomSeed
+    )
+        external
+        view
+        returns (
+            address hintAddress,
+            uint256 diff,
+            uint256 latestRandomSeed
+        );
+}

--- a/src/test/liquity/utils/MockPriceFeed.sol
+++ b/src/test/liquity/utils/MockPriceFeed.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-2.0-only
+pragma solidity >=0.8.0 <=0.8.10;
+
+import "../../../bridges/liquity/interfaces/IPriceFeed.sol";
+
+
+contract MockPriceFeed is IPriceFeed {
+    uint256 public immutable lastGoodPrice;
+
+    constructor(uint256 _price) {
+        lastGoodPrice = _price;
+    }
+
+    function fetchPrice() external override returns (uint256) {
+        return lastGoodPrice;
+    }
+}

--- a/src/test/liquity/utils/TestUtil.sol
+++ b/src/test/liquity/utils/TestUtil.sol
@@ -7,7 +7,7 @@ import "./MockPriceFeed.sol";
 import "../../Vm.sol";
 import "../../../../lib/ds-test/src/test.sol";
 import "../../../aztec/DefiBridgeProxy.sol";
-import "../../../aztec/MockRollupProcessor.sol";
+import "../../../aztec/RollupProcessor.sol";
 import "../../../bridges/liquity/interfaces/IPriceFeed.sol";
 
 
@@ -15,7 +15,7 @@ contract TestUtil is DSTest {
     Vm internal vm = Vm(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     DefiBridgeProxy internal defiBridgeProxy;
-    MockRollupProcessor internal rollupProcessor;
+    RollupProcessor internal rollupProcessor;
 
     struct Token {
         address addr; // ERC20 Mainnet address
@@ -80,6 +80,6 @@ contract TestUtil is DSTest {
 
     function _aztecPreSetup() internal {
         defiBridgeProxy = new DefiBridgeProxy();
-        rollupProcessor = new MockRollupProcessor(address(defiBridgeProxy));
+        rollupProcessor = new RollupProcessor(address(defiBridgeProxy));
     }
 }

--- a/src/test/liquity/utils/TestUtil.sol
+++ b/src/test/liquity/utils/TestUtil.sol
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright 2020 Spilsbury Holdings Ltd
+pragma solidity >=0.8.0 <=0.8.10;
+pragma abicoder v2;
+
+import "./MockPriceFeed.sol";
+import "../../Vm.sol";
+import "../../../../lib/ds-test/src/test.sol";
+import "../../../aztec/DefiBridgeProxy.sol";
+import "../../../aztec/MockRollupProcessor.sol";
+import "../../../bridges/liquity/interfaces/IPriceFeed.sol";
+
+
+contract TestUtil is DSTest {
+    Vm internal vm = Vm(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
+
+    DefiBridgeProxy internal defiBridgeProxy;
+    MockRollupProcessor internal rollupProcessor;
+
+    struct Token {
+        address addr; // ERC20 Mainnet address
+        uint256 slot; // Balance storage slot
+        IERC20 erc;
+    }
+
+    address internal constant LIQUITY_PRICE_FEED_ADDR = 0x4c517D4e2C851CA76d7eC94B805269Df0f2201De;
+
+    mapping(bytes32 => Token) internal tokens;
+
+    function setUpTokens() public {
+        tokens["LUSD"].addr = 0x5f98805A4E8be255a32880FDeC7F6728C6568bA0;
+        tokens["LUSD"].erc = IERC20(tokens["LUSD"].addr);
+        tokens["LUSD"].slot = 2;
+
+        tokens["WETH"].addr = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
+        tokens["WETH"].erc = IERC20(tokens["WETH"].addr);
+        tokens["WETH"].slot = 3;
+
+        tokens["LQTY"].addr = 0x6DEA81C8171D0bA574754EF6F8b412F2Ed88c54D;
+        tokens["LQTY"].erc = IERC20(tokens["LQTY"].addr);
+        tokens["LQTY"].slot = 0;
+    }
+
+    // Manipulate mainnet ERC20 balance
+    function mint(
+        bytes32 symbol,
+        address account,
+        uint256 amt
+    ) public {
+        address addr = tokens[symbol].addr;
+        uint256 slot = tokens[symbol].slot;
+        uint256 bal = IERC20(addr).balanceOf(account);
+
+        vm.store(
+            addr,
+            keccak256(abi.encode(account, slot)), // Mint tokens
+            bytes32(bal + amt)
+        );
+
+        assertEq(IERC20(addr).balanceOf(account), bal + amt);
+        // Assert new balance
+    }
+
+    function rand(uint256 seed) public pure returns (uint256) {
+        // I want a number between 1 WAD and 10 million WAD
+        return uint256(keccak256(abi.encodePacked(seed))) % 10**25;
+    }
+
+    function setLiquityPrice(uint256 price) public {
+        IPriceFeed mockFeed = new MockPriceFeed(price);
+        vm.etch(LIQUITY_PRICE_FEED_ADDR, address(mockFeed).code);
+        IPriceFeed feed = IPriceFeed(LIQUITY_PRICE_FEED_ADDR);
+        assertEq(feed.fetchPrice(), price);
+    }
+
+    function dropLiquityPriceByHalf() public {
+        uint256 currentPrice = IPriceFeed(LIQUITY_PRICE_FEED_ADDR).fetchPrice();
+        setLiquityPrice(currentPrice / 2);
+    }
+
+    function _aztecPreSetup() internal {
+        defiBridgeProxy = new DefiBridgeProxy();
+        rollupProcessor = new MockRollupProcessor(address(defiBridgeProxy));
+    }
+}


### PR DESCRIPTION
This PR contains implementions of the bridges for Liquity's stability pool, LQTY staking contract and troves.

All the tests are passing but for them to pass I had to replace the provided Infura endpoint with my own. I think the provided endpoint is being rate limited.

<img width="719" alt="Screen Shot 2022-02-08 at 12 31 58" src="https://user-images.githubusercontent.com/13470840/153053230-2a8ae24c-6286-4324-a12b-00557176f4ca.png">
.

To make my contracts work I had to do some changes out of my codebase:
1) I renamed WETH to IWETH in the IWETH.sol file. I checked and this change didn't affect any other code.
2) I removed SafeMath dependency from DefiBridgeProxy.sol and MockRollupProcessor.sol since it was causing errors in my code. The code is in Solidity ^0.8.0 so SafeMath is not necessary anymore.

I did gas profiling and these are the average results on the most important functions:

StabilityPoolBridge.convert(...): 503389 gas
StakingBridge.convert(...): 127544 gas
TroveBridge.convert(...): 145223 gas
