### PR TITLE
Add Lido bridge

### DIFF
--- a/src/bridges/lido/LidoBridge.sol
+++ b/src/bridges/lido/LidoBridge.sol
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: GPLv2
+
+pragma solidity >=0.6.10 <=0.8.10;
+pragma experimental ABIEncoderV2;
+
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IDefiBridge} from "../../interfaces/IDefiBridge.sol";
+import {AztecTypes} from "../../aztec/AztecTypes.sol";
+
+interface ICurvePool {
+    function get_dy(
+        int128 i,
+        int128 j,
+        uint256 dx
+    ) external view returns (uint256);
+
+    function exchange(
+        int128 i,
+        int128 j,
+        uint256 dx,
+        uint256 min_dy
+    ) external payable returns (uint256);
+}
+
+interface ILido {
+    function submit(address _referral) external payable returns (uint256);
+}
+
+interface IWstETH {
+    function wrap(uint256 _stETHAmount) external returns (uint256);
+    function unwrap(uint256 _wstETHAmount) external returns (uint256);
+    function getStETHByWstETH(uint256 _wstETHAmount) external view returns (uint256);
+}
+
+interface IRollupProcessor {
+    function receiveEthFromBridge(uint256 interactionNonce) external payable;
+}
+
+contract LidoBridge is IDefiBridge {
+    using SafeERC20 for IERC20;
+
+    address public immutable rollupProcessor;
+    address public referral;
+
+    ILido public lido = ILido(0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84);
+    IWstETH public wrappedStETH = IWstETH(0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0);
+    ICurvePool public curvePool = ICurvePool(0xDC24316b9AE028F1497c275EB9192a3Ea0f67022);
+
+    int128 private curveETHIndex = 0;
+    int128 private curveStETHIndex = 1;
+
+    constructor(address _rollupProcessor, address _referral) {
+        rollupProcessor = _rollupProcessor;
+        referral = _referral;
+    }
+
+    receive() external payable {}
+
+    function convert(
+        AztecTypes.AztecAsset calldata inputAssetA,
+        AztecTypes.AztecAsset calldata,
+        AztecTypes.AztecAsset calldata outputAssetA,
+        AztecTypes.AztecAsset calldata,
+        uint256 inputValue,
+        uint256 interactionNonce,
+        uint64
+    )
+        external
+        payable
+        override
+        returns (
+            uint256 outputValueA,
+            uint256,
+            bool isAsync
+        )
+    {
+        require(msg.sender == rollupProcessor, "LidoBridge: Invalid Caller");
+
+        bool isETHInput = inputAssetA.assetType == AztecTypes.AztecAssetType.ETH;
+        bool isWstETHInput = inputAssetA.assetType == AztecTypes.AztecAssetType.ERC20 && inputAssetA.erc20Address == address(wrappedStETH);
+
+        require(isETHInput || isWstETHInput, "LidoBridge: Invalid Input");
+
+        isAsync = false;
+        outputValueA = isETHInput ? wrapETH(inputValue, outputAssetA) : unwrapETH(inputValue, outputAssetA, interactionNonce);
+    }
+
+    /**
+        Convert ETH -> wstETH
+     */
+    function wrapETH(uint256 inputValue, AztecTypes.AztecAsset calldata outputAsset) private returns (uint256 outputValue) {
+        require(
+            outputAsset.assetType == AztecTypes.AztecAssetType.ERC20 && outputAsset.erc20Address == address(wrappedStETH),
+            "LidoBridge: Invalid Output Token"
+        );
+
+        // the minimum should be 1ETH:1STETH
+        uint256 minOutput = inputValue;
+
+        // Check with curve to see if we can get better exchange rate than 1 ETH : 1 STETH
+        // Yes: use curve
+        // No: deposit to Lido correct
+
+        uint256 curveStETHBalance = curvePool.get_dy(curveETHIndex, curveStETHIndex, inputValue);
+
+        if (curveStETHBalance > minOutput) {
+            // exchange via curve since we can get a better rate
+            curvePool.exchange{value: inputValue}(curveETHIndex, curveStETHIndex, inputValue, minOutput);
+        } else {
+            // deposit directly through lido since we cannot get better rate
+            lido.submit{value: inputValue}(referral);
+        }
+
+        // since stETH is a rebase token, lets wrap it to wstETH before sending it back to the rollupProcessor
+        uint256 outputStETHBalance = IERC20(address(lido)).balanceOf(address(this));
+
+        IERC20(address(lido)).safeIncreaseAllowance(address(wrappedStETH), outputStETHBalance);
+        outputValue = wrappedStETH.wrap(outputStETHBalance);
+
+        // Give allowance for rollup processor to withdraw
+        IERC20(address(wrappedStETH)).safeIncreaseAllowance(rollupProcessor, outputValue);
+    }
+
+    /**
+        Convert wstETH to ETH
+     */
+    function unwrapETH(uint256 inputValue, AztecTypes.AztecAsset calldata outputAsset, uint256 interactionNonce) private returns (uint256 outputValue) {
+        require(outputAsset.assetType == AztecTypes.AztecAssetType.ETH, "LidoBridge: Invalid Output Token");
+
+        // Convert wstETH to stETH so we can exchange it on curve
+        uint256 stETH = wrappedStETH.unwrap(inputValue);
+
+        // Exchange stETH to ETH via curve
+        IERC20(address(lido)).safeIncreaseAllowance(address(curvePool), stETH);
+        outputValue = curvePool.exchange(curveStETHIndex, curveETHIndex, stETH, 0);
+
+        // Send ETH to rollup processor
+        IRollupProcessor(rollupProcessor).receiveEthFromBridge{value: outputValue}(interactionNonce);
+    }
+
+  function finalise(
+    AztecTypes.AztecAsset calldata,
+    AztecTypes.AztecAsset calldata,
+    AztecTypes.AztecAsset calldata,
+    AztecTypes.AztecAsset calldata,
+    uint256,
+    uint64
+  ) external payable override returns (uint256, uint256, bool) {
+    require(false);
+  }
+}

--- a/src/client/lido/lido-bridge-data.test.ts
+++ b/src/client/lido/lido-bridge-data.test.ts
@@ -1,0 +1,106 @@
+import { LidoBridgeData } from './lido-bridge-data';
+import { IWstETH, ICurvePool } from '../../../typechain-types';
+import { AztecAsset, AztecAssetType } from '../bridge-data';
+import { BigNumber } from 'ethers';
+
+type Mockify<T> = {
+  [P in keyof T]: jest.Mock;
+};
+
+describe('lido bridge data', () => {
+  let lidoBridgeData: LidoBridgeData;
+  let wstethContract: Mockify<IWstETH>;
+  let curvePoolContract: Mockify<ICurvePool>;
+  let ethAsset: AztecAsset;
+  let wstETHAsset: AztecAsset;
+  let emptyAsset: AztecAsset;
+
+  beforeAll(() => {
+    ethAsset = {
+      id: 1n,
+      assetType: AztecAssetType.ETH,
+      erc20Address: '0x0',
+    };
+    wstETHAsset = {
+      id: 2n,
+      assetType: AztecAssetType.ERC20,
+      erc20Address: '0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0',
+    };
+    emptyAsset = {
+      id: 0n,
+      assetType: AztecAssetType.NOT_USED,
+      erc20Address: '0x0',
+    };
+  });
+
+  it('should get wstETH when deposit small amount of ETH - curve route', async () => {
+    const depositAmount = BigInt(10e18);
+    const expectedOutput = depositAmount + 1n;
+
+    curvePoolContract = {
+      ...curvePoolContract,
+      get_dy: jest.fn().mockResolvedValue(BigNumber.from(expectedOutput)),
+    };
+
+    lidoBridgeData = new LidoBridgeData(wstethContract as any, curvePoolContract as any);
+
+    const output = await lidoBridgeData.getExpectedOutput(
+      ethAsset,
+      emptyAsset,
+      wstETHAsset,
+      emptyAsset,
+      0n,
+      depositAmount,
+    );
+    expect(expectedOutput == output[0]).toBeTruthy();
+  });
+  it('should get wstETH when deposit a large amount of ETH - lido route', async () => {
+    const depositAmount = BigInt(10000000e18);
+    const expectedOutput = depositAmount;
+
+    curvePoolContract = {
+      ...curvePoolContract,
+      get_dy: jest.fn().mockResolvedValue(BigNumber.from(depositAmount - 1n)),
+    };
+
+    lidoBridgeData = new LidoBridgeData(wstethContract as any, curvePoolContract as any);
+
+    const output = await lidoBridgeData.getExpectedOutput(
+      ethAsset,
+      emptyAsset,
+      wstETHAsset,
+      emptyAsset,
+      0n,
+      depositAmount,
+    );
+    expect(expectedOutput == output[0]).toBeTruthy();
+  });
+  it('should exit to ETH when deposit WstETH', async () => {
+    const depositAmount = BigInt(100e18);
+    const stethOutputAmount = BigInt(101e18);
+    const expectedOutput = BigInt(105e18);
+
+    wstethContract = {
+      ...wstethContract,
+      getStETHByWstETH: jest.fn().mockResolvedValue(BigNumber.from(stethOutputAmount)),
+    };
+
+    curvePoolContract = {
+      ...curvePoolContract,
+      get_dy: jest.fn().mockResolvedValue(BigNumber.from(expectedOutput)),
+    };
+
+    lidoBridgeData = new LidoBridgeData(wstethContract as any, curvePoolContract as any);
+
+    const output = await lidoBridgeData.getExpectedOutput(
+      wstETHAsset,
+      emptyAsset,
+      ethAsset,
+      emptyAsset,
+      0n,
+      depositAmount,
+    );
+
+    expect(expectedOutput == output[0]).toBeTruthy();
+  });
+});

--- a/src/client/lido/lido-bridge-data.ts
+++ b/src/client/lido/lido-bridge-data.ts
@@ -1,0 +1,65 @@
+import { AssetValue, AuxDataConfig, AztecAsset, SolidityType, BridgeData, AztecAssetType } from '../bridge-data';
+
+import { IWstETH, RollupProcessor, ICurvePool } from '../../../typechain-types';
+
+export class LidoBridgeData implements BridgeData {
+  private wstETHContract: IWstETH;
+  private curvePoolContract: ICurvePool;
+
+  constructor(wstETHContract: IWstETH, curvePoolContract: ICurvePool) {
+    this.wstETHContract = wstETHContract;
+    this.curvePoolContract = curvePoolContract;
+  }
+
+  // Unused
+  public auxDataConfig: AuxDataConfig[] = [
+    {
+      start: 0,
+      length: 64,
+      solidityType: SolidityType.uint64,
+      description: 'Not Used',
+    },
+  ];
+
+  // Lido bridge contract is stateless
+  async getInteractionPresentValue(interactionNonce: bigint): Promise<AssetValue[]> {
+    return [];
+  }
+
+  // Not applicable
+  async getAuxData(
+    inputAssetA: AztecAsset,
+    inputAssetB: AztecAsset,
+    outputAssetA: AztecAsset,
+    outputAssetB: AztecAsset,
+  ): Promise<bigint[]> {
+    return [0n];
+  }
+
+  async getExpectedOutput(
+    inputAssetA: AztecAsset,
+    inputAssetB: AztecAsset,
+    outputAssetA: AztecAsset,
+    outputAssetB: AztecAsset,
+    auxData: bigint,
+    inputValue: bigint,
+  ): Promise<bigint[]> {
+    // ETH -> wstETH
+    if (inputAssetA.assetType == AztecAssetType.ETH) {
+      const curveMinOutput = await this.curvePoolContract.get_dy(0, 1, inputValue);
+      if (curveMinOutput.toBigInt() > inputValue) {
+        return [curveMinOutput.toBigInt()];
+      } else {
+        return [inputValue];
+      }
+    }
+
+    // wstETH -> ETH
+    if (inputAssetA.assetType == AztecAssetType.ERC20) {
+      const stETHBalance = await this.wstETHContract.getStETHByWstETH(inputValue);
+      const ETHBalance = await this.curvePoolContract.get_dy(1, 0, stETHBalance);
+      return [ETHBalance.toBigInt()];
+    }
+    return [0n];
+  }
+}

--- a/src/test/lido/Lido.t.sol
+++ b/src/test/lido/Lido.t.sol
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.10;
+
+import "../../../lib/ds-test/src/test.sol";
+
+import {Vm} from "../Vm.sol";
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import {DefiBridgeProxy} from "./../../aztec/DefiBridgeProxy.sol";
+import {RollupProcessor} from "./../../aztec/RollupProcessor.sol";
+
+import {LidoBridge} from "./../../bridges/lido/LidoBridge.sol";
+import {AztecTypes} from "./../../aztec/AztecTypes.sol";
+
+contract LidoTest is DSTest {
+    Vm private vm = Vm(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
+    IERC20 private wstETH = IERC20(0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0);
+
+    DefiBridgeProxy private defiBridgeProxy;
+    RollupProcessor private rollupProcessor;
+
+    LidoBridge private bridge;
+
+    AztecTypes.AztecAsset private empty;
+    AztecTypes.AztecAsset private ethAsset = AztecTypes.AztecAsset({
+        id: 1,
+        erc20Address: address(0),
+        assetType: AztecTypes.AztecAssetType.ETH
+    });
+    AztecTypes.AztecAsset private wstETHAsset = AztecTypes.AztecAsset({
+        id: 2,
+        erc20Address: address(wstETH),
+        assetType: AztecTypes.AztecAssetType.ERC20
+    });
+
+    function _aztecPreSetup() internal {
+        defiBridgeProxy = new DefiBridgeProxy();
+        rollupProcessor = new RollupProcessor(address(defiBridgeProxy));
+    }
+
+    function setUp() public {
+        _aztecPreSetup();
+        bridge = new LidoBridge(address(rollupProcessor));
+    }
+
+    function testLidoBridge() public {
+        validateLidoBridge(100e18, 50e18);
+        validateLidoBridge(500000e18, 400000e18);
+    }
+
+    /**
+        Testing flow:
+        1. Send ETH to bridge
+        2. Get back wstETH
+        3. Send wstETH to bridge
+        4. Get back ETH
+     */
+    function validateLidoBridge(uint256 balance, uint256 depositAmount) public {
+        // Send ETH to bridge
+
+        vm.deal(address(rollupProcessor), balance);
+
+        // Convert ETH to wstETH
+        validateETHToWstETH(balance, depositAmount);
+        
+        // convert wstETH back to ETH using the same bridge
+        validateWstETHToETH(wstETH.balanceOf(address(rollupProcessor)));
+
+    }
+
+    function validateWstETHToETH(uint256 depositAmount) public {
+        uint256 beforeETHBalance = address(rollupProcessor).balance;
+        
+        (
+            uint256 outputValueA,
+            uint256 outputValueB,
+            bool isAsync
+        ) = rollupProcessor.convert(
+            address(bridge),
+            wstETHAsset,
+            empty,
+            ethAsset,
+            empty,
+            depositAmount,
+            2,
+            0
+        );
+
+        uint256 afterETHBalance = address(rollupProcessor).balance;
+        uint256 wstETHBalance = wstETH.balanceOf(address(rollupProcessor));
+
+        emit log_named_uint("After Exit ETH Balance ", afterETHBalance);
+        emit log_named_uint("After Exit WstETH Balance", wstETHBalance);
+
+        assertTrue(isAsync == false);
+        assertTrue(outputValueB == 0);
+
+        assertTrue(outputValueA != 0);
+        assertTrue(wstETHBalance == 0);
+        assertTrue(afterETHBalance > beforeETHBalance);
+    }
+
+    function validateETHToWstETH(uint256 balance, uint256 depositAmount) public {
+        uint256 beforeETHBalance = address(rollupProcessor).balance;
+        uint256 beforeWstETHBalance = wstETH.balanceOf(address(rollupProcessor));
+
+        emit log_named_uint("Before ETH Balance", beforeETHBalance);
+        emit log_named_uint("Before WstETHBalance", beforeWstETHBalance);
+
+        (
+            uint256 outputValueA,
+            uint256 outputValueB,
+            bool isAsync
+        ) = rollupProcessor.convert(
+                address(bridge),
+                ethAsset,
+                empty,
+                wstETHAsset,
+                empty,
+                depositAmount,
+                1,
+                0
+        );
+
+        uint256 afterETHBalance = address(rollupProcessor).balance;
+        uint256 afterWstETHBalance = wstETH.balanceOf(address(rollupProcessor));
+
+        emit log_named_uint("After ETH Balance", afterETHBalance);
+        emit log_named_uint("After WstETHBalance", afterWstETHBalance);
+
+        assertTrue(isAsync == false);
+        assertTrue(outputValueB == 0);
+        assertTrue(afterETHBalance == balance - depositAmount);
+        assertTrue(outputValueA > 0 && outputValueA <= depositAmount);
+    }
+
+}

--- a/src/test/lido/Lido.t.sol
+++ b/src/test/lido/Lido.t.sol
@@ -41,7 +41,7 @@ contract LidoTest is DSTest {
 
     function setUp() public {
         _aztecPreSetup();
-        bridge = new LidoBridge(address(rollupProcessor));
+        bridge = new LidoBridge(address(rollupProcessor), address(rollupProcessor));
     }
 
     function testLidoBridge() public {


### PR DESCRIPTION
**Author**
0xinugami

**Description**
This bridge enables users to stake their ETH and earn interest from Lido. The users can also use this bridge to exchange their wstETH back to ETH.

**Usage**
To stake ETH
- Input: ETH
- Output: ERC20 and wstETH address

To get back ETH from wstETH
- Input: ERC20 and wstETH address
- Output: ETH

**Contract Test**
File: `Lido.t.sol`
Run: `forge test -m Lido.t.sol`

**Client Test**
File: `lido-bridge-data.test.ts`
Run: `yarn test:client`
