### PR TITLE
Change test command to use correct client test cmd

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "compile:client-dest:watch": "yarn compile:typechain && tsc --project tsconfig.client-dest.json --watch",
     "compile:client-dest": "yarn compile:typechain && tsc --project tsconfig.client-dest.json && node package-client-dest.js",
     "clean": "rm -rf ./cache ./dest ./out ./artifacts ./typechain-types",
-    "test": "yarn test:contracts && yarn test:clients",
+    "test": "yarn test:contracts && yarn test:client",
     "test:client": "jest test",
     "test:element": "forge test --fork-block-number 14000000 --match-contract Element -vvv",
     "test:contracts:block": "forge test --fork-block-number",


### PR DESCRIPTION
## What is this change? Why do we need it?

- `yarn test` currently produces this error:
```
error Command "test:clients" not found. Did you mean "test:client"?
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

In order to fix the command , we need to change "test:clients" in the command to "test:client" to conform to the correct package.json command.