### PR TITLE
test: added fuzzing to Element Heap tests

### DIFF
--- a/src/test/element/Heap.t.sol
+++ b/src/test/element/Heap.t.sol
@@ -4,10 +4,13 @@ import { HeapTestContract } from './HeapTestContract.sol';
 import "../../../lib/ds-test/src/test.sol";
 
 import { console } from '../console.sol';
+import {Vm} from  'forge-std/Vm.sol';
 
 contract HeapTest is DSTest {
     HeapTestContract heap;
+    Vm vm;
 
+    // randomInts default initalization
     uint64[] randomInts = [
         207, 628, 47, 920, 864, 132, 942, 684, 573, 451, 476, 594, 152, 466, 885, 300, 357, 266, 803, 320, 80, 184, 318, 949, 983, 917, 925, 808, 270,
         757, 981, 336, 458, 973, 907, 586, 869, 194, 418, 824, 847, 28, 575, 400, 249, 956, 216, 548, 699, 461, 914, 95, 482, 265, 617, 208, 954, 685,
@@ -15,8 +18,16 @@ contract HeapTest is DSTest {
         304, 497, 665, 245, 953, 262, 398, 743, 363, 639, 723, 935, 807
     ];
 
+    function genRandomInts(uint64 salt) public {
+        // generate randomInts based on a salt 
+        for (uint i = 0; i < randomInts.length; i++) {
+            randomInts[i] = uint64(uint256(keccak256(abi.encode(salt, i))));
+        }
+    }
+    
     function setUp() public {
         heap = new HeapTestContract(100);
+        vm = Vm(HEVM_ADDRESS);
     }
 
     function testCanAddToHeap() public {
@@ -108,7 +119,8 @@ contract HeapTest is DSTest {
         }
     }
 
-    function testAddAndRemoveMinMultiples() public {
+    function testAddAndRemoveMinMultiples(uint64 randomSalt) public {
+        genRandomInts(randomSalt);
         uint64[] memory values = new uint64[](randomInts.length);
         uint64[] memory sortedValues = new uint64[](randomInts.length);
         for (uint256 i = 0; i < randomInts.length; i++) {
@@ -116,7 +128,7 @@ contract HeapTest is DSTest {
             sortedValues[i] = randomInts[i];
         }
         sortArray(sortedValues);
-        uint64 minimum = 10000;
+        uint64 minimum = type(uint64).max;
         for (uint256 i = 0; i < values.length; i++) {
             heap.add(values[i]);
             if (values[i] < minimum) {
@@ -135,7 +147,8 @@ contract HeapTest is DSTest {
         assertEq(heap.size(), 0);
     }
 
-    function testAddAndRemoveNonMinMultiples() public {
+    function testAddAndRemoveNonMinMultiples(uint64 randomSalt) public {
+        genRandomInts(randomSalt);
         uint64[] memory values = new uint64[](randomInts.length);
         uint64[] memory sortedValues = new uint64[](randomInts.length);
         for (uint256 i = 0; i < randomInts.length; i++) {
@@ -143,7 +156,7 @@ contract HeapTest is DSTest {
             sortedValues[i] = randomInts[i];
         }
         sortArray(sortedValues);
-        uint64 minimum = 10000;
+        uint64 minimum = type(uint64).max;
         for (uint256 i = 0; i < values.length; i++) {
             heap.add(values[i]);
             if (values[i] < minimum) {
@@ -162,7 +175,8 @@ contract HeapTest is DSTest {
         assertEq(heap.min(), randomInts[0]);
     }
 
-    function testAddAndRemoveMinViaSearch() public {
+    function testAddAndRemoveMinViaSearch(uint64 randomSalt) public {
+        genRandomInts(randomSalt);
         uint64[] memory values = new uint64[](randomInts.length);
         uint64[] memory sortedValues = new uint64[](randomInts.length);
         for (uint256 i = 0; i < randomInts.length; i++) {
@@ -170,7 +184,7 @@ contract HeapTest is DSTest {
             sortedValues[i] = randomInts[i];
         }
         sortArray(sortedValues);
-        uint64 minimum = 10000;
+        uint64 minimum = type(uint64).max;
         for (uint256 i = 0; i < values.length; i++) {
             heap.add(values[i]);
             if (values[i] < minimum) {
@@ -192,7 +206,8 @@ contract HeapTest is DSTest {
         assertEq(heap.size(), 0);
     }
 
-    function testCanBuildHeapGreaterThanInitialised() public {
+    function testCanBuildHeapGreaterThanInitialised(uint64 randomSalt) public {
+        genRandomInts(randomSalt);
         HeapTestContract newHeap = new HeapTestContract(1);
         uint64[] memory values = new uint64[](randomInts.length);
         uint64[] memory sortedValues = new uint64[](randomInts.length);
@@ -201,7 +216,7 @@ contract HeapTest is DSTest {
             sortedValues[i] = randomInts[i];
         }
         sortArray(sortedValues);
-        uint64 minimum = 10000;
+        uint64 minimum = type(uint64).max;
         for (uint256 i = 0; i < values.length; i++) {
             newHeap.add(values[i]);
             if (values[i] < minimum) {
@@ -221,7 +236,7 @@ contract HeapTest is DSTest {
     }
 
     function getMinOfRandomInts(uint256 upperBound) internal view returns (uint64 min) {
-        min = 10000;
+        min = type(uint64).max;
         for (uint256 i = 0; i < upperBound; i++) {
             if (randomInts[i] < min) {
                 min = randomInts[i];

--- a/src/test/element/Heap.t.sol
+++ b/src/test/element/Heap.t.sol
@@ -4,13 +4,11 @@ import { HeapTestContract } from './HeapTestContract.sol';
 import "../../../lib/ds-test/src/test.sol";
 
 import { console } from '../console.sol';
-import {Vm} from  'forge-std/Vm.sol';
 
 contract HeapTest is DSTest {
     HeapTestContract heap;
-    Vm vm;
 
-    // randomInts default initalization
+    // default randomInts
     uint64[] randomInts = [
         207, 628, 47, 920, 864, 132, 942, 684, 573, 451, 476, 594, 152, 466, 885, 300, 357, 266, 803, 320, 80, 184, 318, 949, 983, 917, 925, 808, 270,
         757, 981, 336, 458, 973, 907, 586, 869, 194, 418, 824, 847, 28, 575, 400, 249, 956, 216, 548, 699, 461, 914, 95, 482, 265, 617, 208, 954, 685,
@@ -18,16 +16,15 @@ contract HeapTest is DSTest {
         304, 497, 665, 245, 953, 262, 398, 743, 363, 639, 723, 935, 807
     ];
 
+    function setUp() public {
+        heap = new HeapTestContract(100);
+    }
+
     function genRandomInts(uint64 salt) public {
         // generate randomInts based on a salt 
         for (uint i = 0; i < randomInts.length; i++) {
             randomInts[i] = uint64(uint256(keccak256(abi.encode(salt, i))));
         }
-    }
-    
-    function setUp() public {
-        heap = new HeapTestContract(100);
-        vm = Vm(HEVM_ADDRESS);
     }
 
     function testCanAddToHeap() public {


### PR DESCRIPTION
Hi,

It requires only a few changes to fuzz your Heap tests with different random arrays.

The default amount fuzz runs can be set in the `foundry.toml` or by setting `FOUNDRY_FUZZ_RUNS`.
