### PR TITLE
add notional bridge

### DIFF
--- a/src/bridges/notional/AztecFCash.sol
+++ b/src/bridges/notional/AztecFCash.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.0;
+pragma experimental ABIEncoderV2;
+
+import {ERC20Burnable} from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+
+contract FCashToken is ERC20Burnable {
+    address public immutable owner;
+    uint8 public immutable setDecimals;
+    uint public maturity;
+    constructor(
+        string memory _name,
+        string memory _symbol,
+        uint8 _decimals,
+        uint _maturity 
+    ) ERC20(_name, _symbol) {
+        owner = msg.sender;
+        setDecimals = _decimals;
+        maturity = _maturity;
+    }
+
+    function decimals() public view virtual override returns (uint8) {
+        return setDecimals;
+    }
+
+    function mint(address to, uint256 amount) external {
+        require(owner == msg.sender, "ZkAToken: INVALID OWNER");
+        _mint(to, amount);
+    }
+}

--- a/src/bridges/notional/AztecNotionalLending.sol
+++ b/src/bridges/notional/AztecNotionalLending.sol
@@ -1,0 +1,259 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.0;
+import {BalanceActionWithTrades, DepositActionType, BalanceAction, TradeActionType, MarketParameters, AssetRateParameters} from "./interfaces/NotionalTypes.sol";
+import {IDefiBridge} from "../../interfaces/IDefiBridge.sol";
+import { AztecTypes }  from "../../aztec/AztecTypes.sol";
+import {NotionalProxy} from "./interfaces/notional/NotionalProxy.sol";
+import {NotionalViews} from "./interfaces/notional/NotionalViews.sol";
+import {CTokenInterface} from "./interfaces/compound/CTokenInterface.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {FCashToken} from "./AztecFCash.sol";
+import "@openzeppelin/contracts/utils/Strings.sol";
+
+
+struct TradeData {
+    uint16 currencyId;
+    uint8 marketIndex;
+    uint40 maturity;
+}
+
+interface IRollupProcessor {
+    function receiveEthFromBridge(uint256 interactionNonce) external payable;
+}
+
+contract NotionalLendingBridge is IDefiBridge {
+    address public immutable rollupProcessor;
+    NotionalProxy public immutable notionalProxy;
+    NotionalViews public immutable notionalView;
+    ERC20[] public underlyingTokens;
+    CTokenInterface[] public cTokens;
+    int256 private constant ASSET_RATE_DECIMAL_DIFFERENCE = 1e10;
+    int256 private constant SECOND_IN_YEAR = 360 days;
+    mapping(address => mapping(uint => address)) public cashTokenFcashToken;
+    mapping(address => address) public fcashTokenCashToken;
+    constructor(address _rollupProcessor){
+        rollupProcessor = _rollupProcessor;
+        notionalProxy = NotionalProxy(0x1344A36A1B56144C3Bc62E7757377D288fDE0369);
+        notionalView = NotionalViews(0x1344A36A1B56144C3Bc62E7757377D288fDE0369);
+    }
+
+    function insertToken(ERC20 underlying, CTokenInterface cToken) external {
+        underlyingTokens.push(underlying);
+        cTokens.push(cToken);
+    }
+
+    function findToken (address token) public view returns (int, bool) {
+        int index = -1;
+        bool isCtoken = false;
+        for (uint i = 0; i < cTokens.length; i++) {
+            if (token == address(underlyingTokens[i])) {
+                index = int(i);
+                break;
+            }
+            else if(token == address(cTokens[i])){
+                index = int(i);
+                isCtoken = true;
+                break;
+            } 
+        }
+        return (index, isCtoken);
+    }
+
+    function canFinalise(uint256) external view returns (bool) {
+        return false;
+    }
+
+    function convertFromUnderlying(AssetRateParameters memory ar, int256 underlyingBalance)
+    internal
+    pure
+    returns (int256){
+    // Calculation here represents:
+    // rateDecimals * balance * underlyingPrecision / rate * internalPrecision
+    int256 assetBalance = underlyingBalance * ASSET_RATE_DECIMAL_DIFFERENCE * ar.underlyingDecimals / ar.rate;
+    return assetBalance;
+}
+    
+    receive() external payable {
+    }
+    
+    function finalise(
+        AztecTypes.AztecAsset calldata ,
+        AztecTypes.AztecAsset calldata ,
+        AztecTypes.AztecAsset calldata ,
+        AztecTypes.AztecAsset calldata ,
+        uint256,
+        uint64
+      ) external payable virtual returns (uint256 outputValueA, uint256 outputValueB, bool interactionComplete) {
+          return (0, 0, false);
+      }
+    
+    function setUnderlyingToFCashToken(address cToken, uint maturity) public returns(address fcash) {
+        require(
+            cashTokenFcashToken[cToken][maturity] == address(0),
+            "FCASH_TOKEN_SET"
+        );
+        ERC20 cTokenERC20 = ERC20(cToken);
+        fcash = address(new FCashToken(string(abi.encodePacked(cTokenERC20.name(), Strings.toString(maturity))), cTokenERC20.symbol(), 8, maturity));
+        cashTokenFcashToken[cToken][maturity] = fcash;
+        fcashTokenCashToken[fcash] = cToken;
+    }
+
+    function _computeUnderlyingAmt(ERC20 underlyingAddr, CTokenInterface cToken, uint inputAmt,bool isCToken) internal returns(int88 cashAmt) {
+        cToken.accrueInterest();
+        uint underlyingDecimal = address(underlyingAddr) == address(0) ? 18 : underlyingAddr.decimals();
+        if (isCToken) {
+            uint exchangeRateCurrent = cToken.exchangeRateCurrent();
+            uint mantissa = 10 + underlyingDecimal;
+            cashAmt = int88(int(inputAmt * exchangeRateCurrent/(10 ** mantissa)));
+        }  else{
+            cashAmt = underlyingDecimal > 8 ? int88(int(inputAmt / (10 ** (underlyingDecimal-8)))): int88(int(inputAmt * (10 ** (8 - underlyingDecimal)))) ;
+        }
+    }
+
+
+    function decodeAuxData(uint64 auxData) internal pure returns(TradeData memory tradeData) {
+        tradeData.currencyId = uint16(auxData >> 48 & 0xFFFF);
+        tradeData.marketIndex = uint8(auxData >> 40 & 0xFF);
+    }
+
+    function _enter(ERC20 underlyingAddress, CTokenInterface cToken, FCashToken fcash, uint inputAmount, bool isCToken, uint64 auxData) internal returns(uint88) {
+        if (isCToken){
+            cToken.approve(address(notionalProxy), inputAmount);
+        } else {
+            if (address(underlyingAddress) != address(0x0)){
+                underlyingAddress.approve(address(notionalProxy), inputAmount);
+            } else{
+                require(msg.value >= inputAmount, "PROVIDE ETH");
+            }
+        }
+        BalanceActionWithTrades memory action;
+        action.actionType = isCToken ? DepositActionType.DepositAsset : DepositActionType.DepositUnderlying;
+        action.depositActionAmount = inputAmount;
+        action.withdrawEntireCashBalance = false;
+        action.redeemToUnderlying = false;
+        action.withdrawAmountInternalPrecision = 0;
+        int88 cashAmt = _computeUnderlyingAmt(underlyingAddress, cToken, inputAmount, isCToken);
+        TradeData memory tradeData = decodeAuxData(auxData);
+        action.currencyId = tradeData.currencyId;
+        int256 fCashAmt = notionalView.getfCashAmountGivenCashAmount( 
+            action.currencyId, 
+            -cashAmt, 
+            uint256(tradeData.marketIndex),
+            block.timestamp);
+        // accounts for slippage
+        fCashAmt = fCashAmt * (100000 - int256(fcash.maturity()-block.timestamp) * 500/ SECOND_IN_YEAR) /100000;
+        bytes32 trade = bytes32(uint256(tradeData.marketIndex) << 240 |  uint256(fCashAmt) << 152);
+        action.trades = new bytes32[](1);
+        action.trades[0] = trade;
+        BalanceActionWithTrades[] memory actions = new BalanceActionWithTrades[](1);
+        actions[0] = action;
+        if (address(underlyingAddress) == address(0x0) && !isCToken ){
+            notionalProxy.batchBalanceAndTradeAction{value: inputAmount}(address(this), actions);
+        } else{
+            notionalProxy.batchBalanceAndTradeAction(address(this), actions);
+        }
+        fcash.mint(rollupProcessor, uint256(fCashAmt));
+        return uint88(uint256(fCashAmt));        
+    }
+
+    function _exit(uint index,FCashToken fcash, uint inputValue, bool isCToken, uint64 auxData, uint interactionNonce) internal returns(uint) {
+        // first find whether outputAsset is an underlying token or ctoken
+        CTokenInterface cToken = cTokens[index];
+        ERC20 underlyingAddress = underlyingTokens[index];
+        TradeData memory tradeData = decodeAuxData(auxData);
+        int cOutputAmount;
+        uint prevBalance;
+        tradeData.maturity = uint40(fcash.maturity());
+        //fcash.transferFrom(msg.sender, address(this), inputValue);
+        fcash.burn(inputValue);
+        if (isCToken) {
+            prevBalance = cToken.balanceOf(address(this));
+        } else {
+            if (address(underlyingAddress) == address(0)) {
+                prevBalance = address(this).balance;
+            } else{
+                prevBalance = underlyingAddress.balanceOf(address(this));
+            }
+        }
+        if (block.timestamp < tradeData.maturity){
+            // under maturity
+            (cOutputAmount, ) = notionalView.getCashAmountGivenfCashAmount(tradeData.currencyId, -int88(int256(inputValue)), tradeData.marketIndex,block.timestamp);
+            BalanceActionWithTrades memory action;
+            action.withdrawAmountInternalPrecision = uint(cOutputAmount);
+            action.redeemToUnderlying = !isCToken;
+            action.currencyId  = tradeData.currencyId;
+            BalanceActionWithTrades[] memory actions = new BalanceActionWithTrades[](1);
+            actions[0] = action;
+            bytes32 trade = bytes32((1 << 248) | uint256(tradeData.marketIndex) << 240 |  uint256(inputValue) << 152 | 0 << 120);
+            action.trades = new bytes32[](1);
+            action.trades[0] = trade;
+            actions[0] = action;
+            notionalProxy.batchBalanceAndTradeAction(address(this), actions);
+            //transfer tokens back to rollup processor
+        } else {
+            AssetRateParameters memory ar = notionalView.getSettlementRate(tradeData.currencyId, tradeData.maturity);
+            cOutputAmount = convertFromUnderlying(ar, int256(inputValue));
+            BalanceAction memory action;
+            action.withdrawAmountInternalPrecision = uint(cOutputAmount);
+            action.redeemToUnderlying = !isCToken;
+            action.currencyId  = tradeData.currencyId;
+            BalanceAction[] memory actions = new BalanceAction[](1);
+            actions[0] = action;
+            notionalProxy.batchBalanceAction(address(this), actions);
+        }
+        if (isCToken){
+            // reuse the input to save gas
+            inputValue = cToken.balanceOf(address(this)) - prevBalance;
+            cToken.approve(rollupProcessor, inputValue);
+        } else {
+            if (address(underlyingAddress) == address(0)) {
+                inputValue = address(this).balance - prevBalance;
+                IRollupProcessor(rollupProcessor).receiveEthFromBridge{value: inputValue}(interactionNonce);
+            }
+            else {
+                inputValue = underlyingAddress.balanceOf(address(this)) - prevBalance;
+                underlyingAddress.approve(rollupProcessor,inputValue);
+            }
+        }
+        return inputValue;
+    }
+
+
+    function convert(AztecTypes.AztecAsset calldata inputAsset,AztecTypes.AztecAsset calldata, AztecTypes.AztecAsset calldata outputAsset,
+        AztecTypes.AztecAsset calldata,
+        uint256 inputValue,
+        uint256 interactionNonce,
+        uint64 auxData,
+        address
+        )
+        external
+        payable
+        returns (
+            uint256 outputValue,
+            uint256,
+            bool isAsync
+        )
+        {   
+            isAsync = false;
+            bool isCToken = false;
+            int index = -1;
+            (index, isCToken) = findToken(inputAsset.erc20Address);
+            require(msg.sender == rollupProcessor, "INVALID_CALLER");
+            if (index != -1) {
+                CTokenInterface cToken = cTokens[uint(index)];
+                uint maturity = notionalView.getActiveMarkets(uint16((auxData >> 48)& 0xFFFF))[uint8((auxData >> 40) & 0xFF) - 1].maturity;
+                address fCashAddress = cashTokenFcashToken[address(cToken)][maturity];
+                if (fCashAddress == address(0)) {
+                    fCashAddress = setUnderlyingToFCashToken(address(cToken), maturity);
+                }
+                outputValue = _enter(underlyingTokens[uint(index)], cToken, FCashToken(fCashAddress),inputValue, isCToken, auxData);
+            } else {
+                if (fcashTokenCashToken[inputAsset.erc20Address] != address(0)){
+                    (index, isCToken) = findToken(outputAsset.erc20Address);
+                    outputValue = _exit(uint(index), FCashToken(inputAsset.erc20Address), inputValue, isCToken,auxData,interactionNonce);
+                } else {
+                    revert("INVALID INPUT");
+                }
+            }
+        }
+}

--- a/src/bridges/notional/interfaces/IUniswapV2Router01.sol
+++ b/src/bridges/notional/interfaces/IUniswapV2Router01.sol
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+pragma solidity >=0.6.2;
+
+interface IUniswapV2Router01 {
+    function factory() external pure returns (address);
+    function WETH() external pure returns (address);
+
+    function addLiquidity(
+        address tokenA,
+        address tokenB,
+        uint amountADesired,
+        uint amountBDesired,
+        uint amountAMin,
+        uint amountBMin,
+        address to,
+        uint deadline
+    ) external returns (uint amountA, uint amountB, uint liquidity);
+    function addLiquidityETH(
+        address token,
+        uint amountTokenDesired,
+        uint amountTokenMin,
+        uint amountETHMin,
+        address to,
+        uint deadline
+    ) external payable returns (uint amountToken, uint amountETH, uint liquidity);
+    function removeLiquidity(
+        address tokenA,
+        address tokenB,
+        uint liquidity,
+        uint amountAMin,
+        uint amountBMin,
+        address to,
+        uint deadline
+    ) external returns (uint amountA, uint amountB);
+    function removeLiquidityETH(
+        address token,
+        uint liquidity,
+        uint amountTokenMin,
+        uint amountETHMin,
+        address to,
+        uint deadline
+    ) external returns (uint amountToken, uint amountETH);
+    function removeLiquidityWithPermit(
+        address tokenA,
+        address tokenB,
+        uint liquidity,
+        uint amountAMin,
+        uint amountBMin,
+        address to,
+        uint deadline,
+        bool approveMax, uint8 v, bytes32 r, bytes32 s
+    ) external returns (uint amountA, uint amountB);
+    function removeLiquidityETHWithPermit(
+        address token,
+        uint liquidity,
+        uint amountTokenMin,
+        uint amountETHMin,
+        address to,
+        uint deadline,
+        bool approveMax, uint8 v, bytes32 r, bytes32 s
+    ) external returns (uint amountToken, uint amountETH);
+    function swapExactTokensForTokens(
+        uint amountIn,
+        uint amountOutMin,
+        address[] calldata path,
+        address to,
+        uint deadline
+    ) external returns (uint[] memory amounts);
+    function swapTokensForExactTokens(
+        uint amountOut,
+        uint amountInMax,
+        address[] calldata path,
+        address to,
+        uint deadline
+    ) external returns (uint[] memory amounts);
+    function swapExactETHForTokens(uint amountOutMin, address[] calldata path, address to, uint deadline)
+        external
+        payable
+        returns (uint[] memory amounts);
+    function swapTokensForExactETH(uint amountOut, uint amountInMax, address[] calldata path, address to, uint deadline)
+        external
+        returns (uint[] memory amounts);
+    function swapExactTokensForETH(uint amountIn, uint amountOutMin, address[] calldata path, address to, uint deadline)
+        external
+        returns (uint[] memory amounts);
+    function swapETHForExactTokens(uint amountOut, address[] calldata path, address to, uint deadline)
+        external
+        payable
+        returns (uint[] memory amounts);
+
+    function quote(uint amountA, uint reserveA, uint reserveB) external pure returns (uint amountB);
+    function getAmountOut(uint amountIn, uint reserveIn, uint reserveOut) external pure returns (uint amountOut);
+    function getAmountIn(uint amountOut, uint reserveIn, uint reserveOut) external pure returns (uint amountIn);
+    function getAmountsOut(uint amountIn, address[] calldata path) external view returns (uint[] memory amounts);
+    function getAmountsIn(uint amountOut, address[] calldata path) external view returns (uint[] memory amounts);
+}

--- a/src/bridges/notional/interfaces/IUniswapV2Router02.sol
+++ b/src/bridges/notional/interfaces/IUniswapV2Router02.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity >=0.6.2;
+import './IUniswapV2Router01.sol';
+
+interface IUniswapV2Router02 is IUniswapV2Router01 {
+    function removeLiquidityETHSupportingFeeOnTransferTokens(
+        address token,
+        uint liquidity,
+        uint amountTokenMin,
+        uint amountETHMin,
+        address to,
+        uint deadline
+    ) external returns (uint amountETH);
+    function removeLiquidityETHWithPermitSupportingFeeOnTransferTokens(
+        address token,
+        uint liquidity,
+        uint amountTokenMin,
+        uint amountETHMin,
+        address to,
+        uint deadline,
+        bool approveMax, uint8 v, bytes32 r, bytes32 s
+    ) external returns (uint amountETH);
+
+    function swapExactTokensForTokensSupportingFeeOnTransferTokens(
+        uint amountIn,
+        uint amountOutMin,
+        address[] calldata path,
+        address to,
+        uint deadline
+    ) external;
+    function swapExactETHForTokensSupportingFeeOnTransferTokens(
+        uint amountOutMin,
+        address[] calldata path,
+        address to,
+        uint deadline
+    ) external payable;
+    function swapExactTokensForETHSupportingFeeOnTransferTokens(
+        uint amountIn,
+        uint amountOutMin,
+        address[] calldata path,
+        address to,
+        uint deadline
+    ) external;
+}

--- a/src/bridges/notional/interfaces/NotionalTypes.sol
+++ b/src/bridges/notional/interfaces/NotionalTypes.sol
@@ -1,0 +1,422 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.0;
+pragma experimental ABIEncoderV2;
+import "./chainlink/AggregatorV2V3Interface.sol";
+import "./notional/AssetRateAdapter.sol";
+
+/// @notice Different types of internal tokens
+///  - UnderlyingToken: underlying asset for a cToken (except for Ether)
+///  - cToken: Compound interest bearing token
+///  - cETH: Special handling for cETH tokens
+///  - Ether: the one and only
+///  - NonMintable: tokens that do not have an underlying (therefore not cTokens)
+enum TokenType {UnderlyingToken, cToken, cETH, Ether, NonMintable}
+
+/// @notice Specifies the different trade action types in the system. Each trade action type is
+/// encoded in a tightly packed bytes32 object. Trade action type is the first big endian byte of the
+/// 32 byte trade action object. The schemas for each trade action type are defined below.
+enum TradeActionType {
+    // (uint8 TradeActionType, uint8 MarketIndex, uint88 fCashAmount, uint32 minImpliedRate, uint120 unused)
+    Lend,
+    // (uint8 TradeActionType, uint8 MarketIndex, uint88 fCashAmount, uint32 maxImpliedRate, uint128 unused)
+    Borrow,
+    // (uint8 TradeActionType, uint8 MarketIndex, uint88 assetCashAmount, uint32 minImpliedRate, uint32 maxImpliedRate, uint88 unused)
+    AddLiquidity,
+    // (uint8 TradeActionType, uint8 MarketIndex, uint88 tokenAmount, uint32 minImpliedRate, uint32 maxImpliedRate, uint88 unused)
+    RemoveLiquidity,
+    // (uint8 TradeActionType, uint32 Maturity, int88 fCashResidualAmount, uint128 unused)
+    PurchaseNTokenResidual,
+    // (uint8 TradeActionType, address CounterpartyAddress, int88 fCashAmountToSettle)
+    SettleCashDebt
+}
+
+/// @notice Specifies different deposit actions that can occur during BalanceAction or BalanceActionWithTrades
+enum DepositActionType {
+    // No deposit action
+    None,
+    // Deposit asset cash, depositActionAmount is specified in asset cash external precision
+    DepositAsset,
+    // Deposit underlying tokens that are mintable to asset cash, depositActionAmount is specified in underlying token
+    // external precision
+    DepositUnderlying,
+    // Deposits specified asset cash external precision amount into an nToken and mints the corresponding amount of
+    // nTokens into the account
+    DepositAssetAndMintNToken,
+    // Deposits specified underlying in external precision, mints asset cash, and uses that asset cash to mint nTokens
+    DepositUnderlyingAndMintNToken,
+    // Redeems an nToken balance to asset cash. depositActionAmount is specified in nToken precision. Considered a deposit action
+    // because it deposits asset cash into an account. If there are fCash residuals that cannot be sold off, will revert.
+    RedeemNToken,
+    // Converts specified amount of asset cash balance already in Notional to nTokens. depositActionAmount is specified in
+    // Notional internal 8 decimal precision.
+    ConvertCashToNToken
+}
+
+/// @notice Used internally for PortfolioHandler state
+enum AssetStorageState {NoChange, Update, Delete, RevertIfStored}
+
+/****** Calldata objects ******/
+
+/// @notice Defines a balance action for batchAction
+struct BalanceAction {
+    // Deposit action to take (if any)
+    DepositActionType actionType;
+    uint16 currencyId;
+    // Deposit action amount must correspond to the depositActionType, see documentation above.
+    uint256 depositActionAmount;
+    // Withdraw an amount of asset cash specified in Notional internal 8 decimal precision
+    uint256 withdrawAmountInternalPrecision;
+    // If set to true, will withdraw entire cash balance. Useful if there may be an unknown amount of asset cash
+    // residual left from trading.
+    bool withdrawEntireCashBalance;
+    // If set to true, will redeem asset cash to the underlying token on withdraw.
+    bool redeemToUnderlying;
+}
+
+/// @notice Defines a balance action with a set of trades to do as well
+struct BalanceActionWithTrades {
+    DepositActionType actionType;
+    uint16 currencyId;
+    uint256 depositActionAmount;
+    uint256 withdrawAmountInternalPrecision;
+    bool withdrawEntireCashBalance;
+    bool redeemToUnderlying;
+    // Array of tightly packed 32 byte objects that represent trades. See TradeActionType documentation
+    bytes32[] trades;
+}
+
+/****** In memory objects ******/
+/// @notice Internal object that represents settled cash balances
+struct SettleAmount {
+    uint256 currencyId;
+    int256 netCashChange;
+}
+
+/// @notice Internal object that represents a token
+struct Token {
+    address tokenAddress;
+    bool hasTransferFee;
+    int256 decimals;
+    TokenType tokenType;
+    uint256 maxCollateralBalance;
+}
+
+/// @notice Internal object that represents an nToken portfolio
+struct nTokenPortfolio {
+    CashGroupParameters cashGroup;
+    PortfolioState portfolioState;
+    int256 totalSupply;
+    int256 cashBalance;
+    uint256 lastInitializedTime;
+    bytes6 parameters;
+    address tokenAddress;
+}
+
+/// @notice Internal object used during liquidation
+struct LiquidationFactors {
+    address account;
+    // Aggregate free collateral of the account denominated in ETH underlying, 8 decimal precision
+    int256 netETHValue;
+    // Amount of net local currency asset cash before haircuts and buffers available
+    int256 localAssetAvailable;
+    // Amount of net collateral currency asset cash before haircuts and buffers available
+    int256 collateralAssetAvailable;
+    // Haircut value of nToken holdings denominated in asset cash, will be local or collateral nTokens based
+    // on liquidation type
+    int256 nTokenHaircutAssetValue;
+    // nToken parameters for calculating liquidation amount
+    bytes6 nTokenParameters;
+    // ETH exchange rate from local currency to ETH
+    ETHRate localETHRate;
+    // ETH exchange rate from collateral currency to ETH
+    ETHRate collateralETHRate;
+    // Asset rate for the local currency, used in cross currency calculations to calculate local asset cash required
+    AssetRateParameters localAssetRate;
+    // Used during currency liquidations if the account has liquidity tokens
+    CashGroupParameters collateralCashGroup;
+    // Used during currency liquidations if it is only a calculation, defaults to false
+    bool isCalculation;
+}
+
+/// @notice Internal asset array portfolio state
+struct PortfolioState {
+    // Array of currently stored assets
+    PortfolioAsset[] storedAssets;
+    // Array of new assets to add
+    PortfolioAsset[] newAssets;
+    uint256 lastNewAssetIndex;
+    // Holds the length of stored assets after accounting for deleted assets
+    uint256 storedAssetLength;
+}
+
+/// @notice In memory ETH exchange rate used during free collateral calculation.
+struct ETHRate {
+    // The decimals (i.e. 10^rateDecimalPlaces) of the exchange rate, defined by the rate oracle
+    int256 rateDecimals;
+    // The exchange rate from base to ETH (if rate invert is required it is already done)
+    int256 rate;
+    // Amount of buffer as a multiple with a basis of 100 applied to negative balances.
+    int256 buffer;
+    // Amount of haircut as a multiple with a basis of 100 applied to positive balances
+    int256 haircut;
+    // Liquidation discount as a multiple with a basis of 100 applied to the exchange rate
+    // as an incentive given to liquidators.
+    int256 liquidationDiscount;
+}
+
+/// @notice Internal object used to handle balance state during a transaction
+struct BalanceState {
+    uint16 currencyId;
+    // Cash balance stored in balance state at the beginning of the transaction
+    int256 storedCashBalance;
+    // nToken balance stored at the beginning of the transaction
+    int256 storedNTokenBalance;
+    // The net cash change as a result of asset settlement or trading
+    int256 netCashChange;
+    // Net asset transfers into or out of the account
+    int256 netAssetTransferInternalPrecision;
+    // Net token transfers into or out of the account
+    int256 netNTokenTransfer;
+    // Net token supply change from minting or redeeming
+    int256 netNTokenSupplyChange;
+    // The last time incentives were claimed for this currency
+    uint256 lastClaimTime;
+    // The last integral supply amount when tokens were claimed
+    uint256 lastClaimIntegralSupply;
+}
+
+/// @dev Asset rate used to convert between underlying cash and asset cash
+struct AssetRateParameters {
+    // Address of the asset rate oracle
+    AssetRateAdapter rateOracle;
+    // The exchange rate from base to quote (if invert is required it is already done)
+    int256 rate;
+    // The decimals of the underlying, the rate converts to the underlying decimals
+    int256 underlyingDecimals;
+}
+
+/// @dev Cash group when loaded into memory
+struct CashGroupParameters {
+    uint16 currencyId;
+    uint256 maxMarketIndex;
+    AssetRateParameters assetRate;
+    bytes32 data;
+}
+
+/// @dev A portfolio asset when loaded in memory
+struct PortfolioAsset {
+    // Asset currency id
+    uint256 currencyId;
+    uint256 maturity;
+    // Asset type, fCash or liquidity token.
+    uint256 assetType;
+    // fCash amount or liquidity token amount
+    int256 notional;
+    // Used for managing portfolio asset state
+    uint256 storageSlot;
+    // The state of the asset for when it is written to storage
+    AssetStorageState storageState;
+}
+
+/// @dev Market object as represented in memory
+struct MarketParameters {
+    bytes32 storageSlot;
+    uint256 maturity;
+    // Total amount of fCash available for purchase in the market.
+    int256 totalfCash;
+    // Total amount of cash available for purchase in the market.
+    int256 totalAssetCash;
+    // Total amount of liquidity tokens (representing a claim on liquidity) in the market.
+    int256 totalLiquidity;
+    // This is the previous annualized interest rate in RATE_PRECISION that the market traded
+    // at. This is used to calculate the rate anchor to smooth interest rates over time.
+    uint256 lastImpliedRate;
+    // Time lagged version of lastImpliedRate, used to value fCash assets at market rates while
+    // remaining resistent to flash loan attacks.
+    uint256 oracleRate;
+    // This is the timestamp of the previous trade
+    uint256 previousTradeTime;
+}
+
+/****** Storage objects ******/
+
+/// @dev Token object in storage:
+///  20 bytes for token address
+///  1 byte for hasTransferFee
+///  1 byte for tokenType
+///  1 byte for tokenDecimals
+///  9 bytes for maxCollateralBalance (may not always be set)
+struct TokenStorage {
+    // Address of the token
+    address tokenAddress;
+    // Transfer fees will change token deposit behavior
+    bool hasTransferFee;
+    TokenType tokenType;
+    uint8 decimalPlaces;
+    // Upper limit on how much of this token the contract can hold at any time
+    uint72 maxCollateralBalance;
+}
+
+/// @dev Exchange rate object as it is represented in storage, total storage is 25 bytes.
+struct ETHRateStorage {
+    // Address of the rate oracle
+    AggregatorV2V3Interface rateOracle;
+    // The decimal places of precision that the rate oracle uses
+    uint8 rateDecimalPlaces;
+    // True of the exchange rate must be inverted
+    bool mustInvert;
+    // NOTE: both of these governance values are set with BUFFER_DECIMALS precision
+    // Amount of buffer to apply to the exchange rate for negative balances.
+    uint8 buffer;
+    // Amount of haircut to apply to the exchange rate for positive balances
+    uint8 haircut;
+    // Liquidation discount in percentage point terms, 106 means a 6% discount
+    uint8 liquidationDiscount;
+}
+
+/// @dev Asset rate oracle object as it is represented in storage, total storage is 21 bytes.
+struct AssetRateStorage {
+    // Address of the rate oracle
+    AssetRateAdapter rateOracle;
+    // The decimal places of the underlying asset
+    uint8 underlyingDecimalPlaces;
+}
+
+/// @dev Governance parameters for a cash group, total storage is 9 bytes + 7 bytes for liquidity token haircuts
+/// and 7 bytes for rate scalars, total of 23 bytes. Note that this is stored packed in the storage slot so there
+/// are no indexes stored for liquidityTokenHaircuts or rateScalars, maxMarketIndex is used instead to determine the
+/// length.
+struct CashGroupSettings {
+    // Index of the AMMs on chain that will be made available. Idiosyncratic fCash
+    // that is dated less than the longest AMM will be tradable.
+    uint8 maxMarketIndex;
+    // Time window in 5 minute increments that the rate oracle will be averaged over
+    uint8 rateOracleTimeWindow5Min;
+    // Total fees per trade, specified in BPS
+    uint8 totalFeeBPS;
+    // Share of the fees given to the protocol, denominated in percentage
+    uint8 reserveFeeShare;
+    // Debt buffer specified in 5 BPS increments
+    uint8 debtBuffer5BPS;
+    // fCash haircut specified in 5 BPS increments
+    uint8 fCashHaircut5BPS;
+    // If an account has a negative cash balance, it can be settled by incurring debt at the 3 month market. This
+    // is the basis points for the penalty rate that will be added the current 3 month oracle rate.
+    uint8 settlementPenaltyRate5BPS;
+    // If an account has fCash that is being liquidated, this is the discount that the liquidator can purchase it for
+    uint8 liquidationfCashHaircut5BPS;
+    // If an account has fCash that is being liquidated, this is the discount that the liquidator can purchase it for
+    uint8 liquidationDebtBuffer5BPS;
+    // Liquidity token haircut applied to cash claims, specified as a percentage between 0 and 100
+    uint8[] liquidityTokenHaircuts;
+    // Rate scalar used to determine the slippage of the market
+    uint8[] rateScalars;
+}
+
+/// @dev Holds account level context information used to determine settlement and
+/// free collateral actions. Total storage is 28 bytes
+struct AccountContext {
+    // Used to check when settlement must be triggered on an account
+    uint40 nextSettleTime;
+    // For lenders that never incur debt, we use this flag to skip the free collateral check.
+    bytes1 hasDebt;
+    // Length of the account's asset array
+    uint8 assetArrayLength;
+    // If this account has bitmaps set, this is the corresponding currency id
+    uint16 bitmapCurrencyId;
+    // 9 total active currencies possible (2 bytes each)
+    bytes18 activeCurrencies;
+}
+
+/// @dev Holds nToken context information mapped via the nToken address, total storage is
+/// 16 bytes
+struct nTokenContext {
+    // Currency id that the nToken represents
+    uint16 currencyId;
+    // Annual incentive emission rate denominated in WHOLE TOKENS (multiply by
+    // INTERNAL_TOKEN_PRECISION to get the actual rate)
+    uint32 incentiveAnnualEmissionRate;
+    // The last block time at utc0 that the nToken was initialized at, zero if it
+    // has never been initialized
+    uint32 lastInitializedTime;
+    // Length of the asset array, refers to the number of liquidity tokens an nToken
+    // currently holds
+    uint8 assetArrayLength;
+    // Each byte is a specific nToken parameter
+    bytes5 nTokenParameters;
+}
+
+/// @dev Holds account balance information, total storage 32 bytes
+struct BalanceStorage {
+    // Number of nTokens held by the account
+    uint80 nTokenBalance;
+    // Last time the account claimed their nTokens
+    uint32 lastClaimTime;
+    // The total integral supply of the nToken at the last claim time packed into
+    // 56 bits. There is some loss of precision here but it is acceptable
+    uint56 packedLastClaimIntegralSupply;
+    // Cash balance of the account
+    int88 cashBalance;
+}
+
+/// @dev Holds information about a settlement rate, total storage 25 bytes
+struct SettlementRateStorage {
+    uint40 blockTime;
+    uint128 settlementRate;
+    uint8 underlyingDecimalPlaces;
+}
+
+/// @dev Holds information about a market, total storage is 42 bytes so this spans
+/// two storage words
+struct MarketStorage {
+    // Total fCash in the market
+    uint80 totalfCash;
+    // Total asset cash in the market
+    uint80 totalAssetCash;
+    // Last annualized interest rate the market traded at
+    uint32 lastImpliedRate;
+    // Last recorded oracle rate for the market
+    uint32 oracleRate;
+    // Last time a trade was made
+    uint32 previousTradeTime;
+    // This is stored in slot + 1
+    uint80 totalLiquidity;
+}
+
+struct ifCashStorage {
+    // Notional amount of fCash at the slot, limited to int128 to allow for
+    // future expansion
+    int128 notional;
+}
+
+/// @dev A single portfolio asset in storage, total storage of 19 bytes
+struct PortfolioAssetStorage {
+    // Currency Id for the asset
+    uint16 currencyId;
+    // Maturity of the asset
+    uint40 maturity;
+    // Asset type (fCash or Liquidity Token marker)
+    uint8 assetType;
+    // Notional
+    int88 notional;
+}
+
+/// @dev nToken total supply factors for the nToken, includes factors related
+/// to claiming incentives, total storage 32 bytes
+struct nTokenTotalSupplyStorage {
+    // Total supply of the nToken
+    uint96 totalSupply;
+    // Integral of the total supply used for calculating the average total supply
+    uint128 integralTotalSupply;
+    // Last timestamp the supply value changed, used for calculating the integralTotalSupply
+    uint32 lastSupplyChangeTime;
+}
+
+/// @dev Used in view methods to return account balances in a developer friendly manner
+struct AccountBalance {
+    uint16 currencyId;
+    int256 cashBalance;
+    int256 nTokenBalance;
+    uint256 lastClaimTime;
+    uint256 lastClaimIntegralSupply;
+}

--- a/src/bridges/notional/interfaces/chainlink/AggregatorInterface.sol
+++ b/src/bridges/notional/interfaces/chainlink/AggregatorInterface.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.6.0;
+
+interface AggregatorInterface {
+  function latestAnswer() external view returns (int256);
+  function latestTimestamp() external view returns (uint256);
+  function latestRound() external view returns (uint256);
+  function getAnswer(uint256 roundId) external view returns (int256);
+  function getTimestamp(uint256 roundId) external view returns (uint256);
+
+  event AnswerUpdated(int256 indexed current, uint256 indexed roundId, uint256 updatedAt);
+  event NewRound(uint256 indexed roundId, address indexed startedBy, uint256 startedAt);
+}

--- a/src/bridges/notional/interfaces/chainlink/AggregatorV2V3Interface.sol
+++ b/src/bridges/notional/interfaces/chainlink/AggregatorV2V3Interface.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.6.0;
+
+import "./AggregatorInterface.sol";
+import "./AggregatorV3Interface.sol";
+
+interface AggregatorV2V3Interface is AggregatorInterface, AggregatorV3Interface
+{
+}

--- a/src/bridges/notional/interfaces/chainlink/AggregatorV3Interface.sol
+++ b/src/bridges/notional/interfaces/chainlink/AggregatorV3Interface.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.6.0;
+
+interface AggregatorV3Interface {
+
+  function decimals() external view returns (uint8);
+  function description() external view returns (string memory);
+  function version() external view returns (uint256);
+
+  // getRoundData and latestRoundData should both raise "No data present"
+  // if they do not have data to report, instead of returning unset values
+  // which could be misinterpreted as actual reported values.
+  function getRoundData(uint80 _roundId)
+    external
+    view
+    returns (
+      uint80 roundId,
+      int256 answer,
+      uint256 startedAt,
+      uint256 updatedAt,
+      uint80 answeredInRound
+    );
+
+  function latestRoundData()
+    external
+    view
+    returns (
+      uint80 roundId,
+      int256 answer,
+      uint256 startedAt,
+      uint256 updatedAt,
+      uint80 answeredInRound
+    );
+
+}

--- a/src/bridges/notional/interfaces/compound/CErc20Interface.sol
+++ b/src/bridges/notional/interfaces/compound/CErc20Interface.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: BSD-3-Clause
+pragma solidity ^0.8.0;
+
+import "./CTokenInterface.sol";
+
+interface CErc20Interface {
+
+    /*** User Interface ***/
+
+    function mint(uint mintAmount) external returns (uint);
+    function redeem(uint redeemTokens) external returns (uint);
+    function redeemUnderlying(uint redeemAmount) external returns (uint);
+    function borrow(uint borrowAmount) external returns (uint);
+    function repayBorrow(uint repayAmount) external returns (uint);
+    function repayBorrowBehalf(address borrower, uint repayAmount) external returns (uint);
+    function liquidateBorrow(address borrower, uint repayAmount, CTokenInterface cTokenCollateral) external returns (uint);
+}

--- a/src/bridges/notional/interfaces/compound/CEtherInterface.sol
+++ b/src/bridges/notional/interfaces/compound/CEtherInterface.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: BSD-3-Clause
+pragma solidity ^0.8.0;
+
+interface CEtherInterface {
+    function mint() external payable;
+}

--- a/src/bridges/notional/interfaces/compound/CTokenInterface.sol
+++ b/src/bridges/notional/interfaces/compound/CTokenInterface.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: BSD-3-Clause
+pragma solidity ^0.8.0;
+
+interface CTokenInterface {
+
+    /*** User Interface ***/
+
+    function underlying() external view returns (address);
+    function transfer(address dst, uint amount) external returns (bool);
+    function transferFrom(address src, address dst, uint amount) external returns (bool);
+    function approve(address spender, uint amount) external returns (bool);
+    function allowance(address owner, address spender) external view returns (uint);
+    function balanceOf(address owner) external view returns (uint);
+    function balanceOfUnderlying(address owner) external returns (uint);
+    function getAccountSnapshot(address account) external view returns (uint, uint, uint, uint);
+    function borrowRatePerBlock() external view returns (uint);
+    function supplyRatePerBlock() external view returns (uint);
+    function totalBorrowsCurrent() external returns (uint);
+    function borrowBalanceCurrent(address account) external returns (uint);
+    function borrowBalanceStored(address account) external view returns (uint);
+    function exchangeRateCurrent() external returns (uint);
+    function exchangeRateStored() external view returns (uint);
+    function getCash() external view returns (uint);
+    function accrueInterest() external returns (uint);
+    function seize(address liquidator, address borrower, uint seizeTokens) external returns (uint);
+}

--- a/src/bridges/notional/interfaces/notional/AssetRateAdapter.sol
+++ b/src/bridges/notional/interfaces/notional/AssetRateAdapter.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-v3
+pragma solidity >=0.8.0;
+
+/// @notice Used as a wrapper for tokens that are interest bearing for an
+/// underlying token. Follows the cToken interface, however, can be adapted
+/// for other interest bearing tokens.
+interface AssetRateAdapter {
+    function token() external view returns (address);
+
+    function decimals() external view returns (uint8);
+
+    function description() external view returns (string memory);
+
+    function version() external view returns (uint256);
+
+    function underlying() external view returns (address);
+
+    function getExchangeRateStateful() external returns (int256);
+
+    function getExchangeRateView() external view returns (int256);
+
+    function getAnnualizedSupplyRate() external view returns (uint256);
+}

--- a/src/bridges/notional/interfaces/notional/CashMarketInterface.sol
+++ b/src/bridges/notional/interfaces/notional/CashMarketInterface.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface CashMarketInterface {
+    function getActiveMaturities() external view returns (uint32[] memory);
+}

--- a/src/bridges/notional/interfaces/notional/INoteERC20.sol
+++ b/src/bridges/notional/interfaces/notional/INoteERC20.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.0;
+
+interface INoteERC20 {
+    function symbol() external view returns (string memory);
+    function getPriorVotes(address account, uint256 blockNumber) external view returns (uint96);
+}

--- a/src/bridges/notional/interfaces/notional/NotionalCallback.sol
+++ b/src/bridges/notional/interfaces/notional/NotionalCallback.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.0;
+
+interface NotionalCallback {
+    function notionalCallback(address sender, address account, bytes calldata callbackdata) external;
+}

--- a/src/bridges/notional/interfaces/notional/NotionalGovernance.sol
+++ b/src/bridges/notional/interfaces/notional/NotionalGovernance.sol
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.0;
+pragma experimental ABIEncoderV2;
+import "../NotionalTypes.sol";
+import "../chainlink/AggregatorV2V3Interface.sol";
+
+interface NotionalGovernance {
+    event ListCurrency(uint16 newCurrencyId);
+    event UpdateETHRate(uint16 currencyId);
+    event UpdateAssetRate(uint16 currencyId);
+    event UpdateCashGroup(uint16 currencyId);
+    event DeployNToken(uint16 currencyId, address nTokenAddress);
+    event UpdateDepositParameters(uint16 currencyId);
+    event UpdateInitializationParameters(uint16 currencyId);
+    event UpdateIncentiveEmissionRate(uint16 currencyId, uint32 newEmissionRate);
+    event UpdateTokenCollateralParameters(uint16 currencyId);
+    event UpdateGlobalTransferOperator(address operator, bool approved);
+    event UpdateAuthorizedCallbackContract(address operator, bool approved);
+    event UpdateMaxCollateralBalance(uint16 currencyId, uint72 maxCollateralBalance);
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+    event PauseRouterAndGuardianUpdated(address indexed pauseRouter, address indexed pauseGuardian);
+
+    function transferOwnership(address newOwner) external;
+
+    function setPauseRouterAndGuardian(address pauseRouter_, address pauseGuardian_) external;
+
+    function listCurrency(
+        TokenStorage calldata assetToken,
+        TokenStorage calldata underlyingToken,
+        AggregatorV2V3Interface rateOracle,
+        bool mustInvert,
+        uint8 buffer,
+        uint8 haircut,
+        uint8 liquidationDiscount
+    ) external returns (uint16 currencyId);
+
+    function updateMaxCollateralBalance(
+        uint16 currencyId,
+        uint72 maxCollateralBalanceInternalPrecision
+    ) external;
+
+    function enableCashGroup(
+        uint16 currencyId,
+        AssetRateAdapter assetRateOracle,
+        CashGroupSettings calldata cashGroup,
+        string calldata underlyingName,
+        string calldata underlyingSymbol
+    ) external;
+
+    function updateDepositParameters(
+        uint16 currencyId,
+        uint32[] calldata depositShares,
+        uint32[] calldata leverageThresholds
+    ) external;
+
+    function updateInitializationParameters(
+        uint16 currencyId,
+        uint32[] calldata annualizedAnchorRates,
+        uint32[] calldata proportions
+    ) external;
+
+    function updateIncentiveEmissionRate(uint16 currencyId, uint32 newEmissionRate) external;
+
+    function updateTokenCollateralParameters(
+        uint16 currencyId,
+        uint8 residualPurchaseIncentive10BPS,
+        uint8 pvHaircutPercentage,
+        uint8 residualPurchaseTimeBufferHours,
+        uint8 cashWithholdingBuffer10BPS,
+        uint8 liquidationHaircutPercentage
+    ) external;
+
+    function updateCashGroup(uint16 currencyId, CashGroupSettings calldata cashGroup) external;
+
+    function updateAssetRate(uint16 currencyId, AssetRateAdapter rateOracle) external;
+
+    function updateETHRate(
+        uint16 currencyId,
+        AggregatorV2V3Interface rateOracle,
+        bool mustInvert,
+        uint8 buffer,
+        uint8 haircut,
+        uint8 liquidationDiscount
+    ) external;
+
+    function updateGlobalTransferOperator(address operator, bool approved) external;
+
+    function updateAuthorizedCallbackContract(address operator, bool approved) external;
+}

--- a/src/bridges/notional/interfaces/notional/NotionalProxy.sol
+++ b/src/bridges/notional/interfaces/notional/NotionalProxy.sol
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.0;
+pragma experimental ABIEncoderV2;
+
+import "../NotionalTypes.sol";
+import "./nTokenERC20.sol";
+import "./nERC1155Interface.sol";
+import "./NotionalGovernance.sol";
+import "./NotionalViews.sol";
+
+interface NotionalProxy is nTokenERC20, nERC1155Interface, NotionalGovernance, NotionalViews {
+    /** User trading events */
+    event CashBalanceChange(address indexed account, uint16 indexed currencyId, int256 netCashChange);
+    event nTokenSupplyChange(address indexed account, uint16 indexed currencyId, int256 tokenSupplyChange);
+    event MarketsInitialized(uint16 currencyId);
+    event SweepCashIntoMarkets(uint16 currencyId, int256 cashIntoMarkets);
+    event SettledCashDebt(
+        address indexed settledAccount,
+        uint16 indexed currencyId,
+        address indexed settler,
+        int256 amountToSettleAsset,
+        int256 fCashAmount
+    );
+    event nTokenResidualPurchase(
+        uint16 indexed currencyId,
+        uint40 indexed maturity,
+        address indexed purchaser,
+        int256 fCashAmountToPurchase,
+        int256 netAssetCashNToken
+    );
+    event LendBorrowTrade(
+        address indexed account,
+        uint16 indexed currencyId,
+        uint40 maturity,
+        int256 netAssetCash,
+        int256 netfCash
+    );
+    event AddRemoveLiquidity(
+        address indexed account,
+        uint16 indexed currencyId,
+        uint40 maturity,
+        int256 netAssetCash,
+        int256 netfCash,
+        int256 netLiquidityTokens
+    );
+
+    /// @notice Emitted when reserve fees are accrued
+    event ReserveFeeAccrued(uint16 indexed currencyId, int256 fee);
+    /// @notice Emitted whenever an account context has updated
+    event AccountContextUpdate(address indexed account);
+    /// @notice Emitted when an account has assets that are settled
+    event AccountSettled(address indexed account);
+    /// @notice Emitted when an asset rate is settled
+    event SetSettlementRate(uint256 indexed currencyId, uint256 indexed maturity, uint128 rate);
+
+    /* Liquidation Events */
+    event LiquidateLocalCurrency(
+        address indexed liquidated,
+        address indexed liquidator,
+        uint16 localCurrencyId,
+        int256 netLocalFromLiquidator
+    );
+
+    event LiquidateCollateralCurrency(
+        address indexed liquidated,
+        address indexed liquidator,
+        uint16 localCurrencyId,
+        uint16 collateralCurrencyId,
+        int256 netLocalFromLiquidator,
+        int256 netCollateralTransfer,
+        int256 netNTokenTransfer
+    );
+
+    event LiquidatefCashEvent(
+        address indexed liquidated,
+        address indexed liquidator,
+        uint16 localCurrencyId,
+        uint16 fCashCurrency,
+        int256 netLocalFromLiquidator,
+        uint256[] fCashMaturities,
+        int256[] fCashNotionalTransfer
+    );
+
+    /** UUPS Upgradeable contract calls */
+    function upgradeTo(address newImplementation) external;
+    function upgradeToAndCall(address newImplementation, bytes memory data) external payable;
+    function getImplementation() external view returns (address);
+    function owner() external view returns (address);
+    function pauseRouter() external view returns (address);
+    function pauseGuardian() external view returns (address);
+
+    /** Initialize Markets Action */
+    function initializeMarkets(uint16 currencyId, bool isFirstInit) external;
+
+    function sweepCashIntoMarkets(uint16 currencyId) external;
+
+    /** Redeem nToken Action */
+    function nTokenRedeem(
+        address redeemer,
+        uint16 currencyId,
+        uint96 tokensToRedeem_,
+        bool sellTokenAssets
+    ) external returns (int256);
+
+    /** Account Action */
+    function enableBitmapCurrency(uint16 currencyId) external;
+
+    function settleAccount(address account) external;
+
+    function depositUnderlyingToken(
+        address account,
+        uint16 currencyId,
+        uint256 amountExternalPrecision
+    ) external payable returns (uint256);
+
+    function depositAssetToken(
+        address account,
+        uint16 currencyId,
+        uint256 amountExternalPrecision
+    ) external returns (uint256);
+
+    function withdraw(
+        uint16 currencyId,
+        uint88 amountInternalPrecision,
+        bool redeemToUnderlying
+    ) external returns (uint256);
+
+    /** Batch Action */
+    function batchBalanceAction(address account, BalanceAction[] calldata actions) external payable;
+
+    function batchBalanceAndTradeAction(address account, BalanceActionWithTrades[] calldata actions)
+        external
+        payable;
+
+    function batchBalanceAndTradeActionWithCallback(
+        address account,
+        BalanceActionWithTrades[] calldata actions,
+        bytes calldata callbackData
+    ) external payable;
+
+    /** Liquidation Action */
+    function calculateLocalCurrencyLiquidation(
+        address liquidateAccount,
+        uint16 localCurrency,
+        uint96 maxNTokenLiquidation
+    ) external returns (int256, int256);
+
+    function liquidateLocalCurrency(
+        address liquidateAccount,
+        uint16 localCurrency,
+        uint96 maxNTokenLiquidation
+    ) external returns (int256, int256);
+
+    function calculateCollateralCurrencyLiquidation(
+        address liquidateAccount,
+        uint16 localCurrency,
+        uint16 collateralCurrency,
+        uint128 maxCollateralLiquidation,
+        uint96 maxNTokenLiquidation
+    )
+        external
+        returns (
+            int256,
+            int256,
+            int256
+        );
+
+    function liquidateCollateralCurrency(
+        address liquidateAccount,
+        uint16 localCurrency,
+        uint16 collateralCurrency,
+        uint128 maxCollateralLiquidation,
+        uint96 maxNTokenLiquidation,
+        bool withdrawCollateral,
+        bool redeemToUnderlying
+    )
+        external
+        returns (
+            int256,
+            int256,
+            int256
+        );
+
+    function calculatefCashLocalLiquidation(
+        address liquidateAccount,
+        uint16 localCurrency,
+        uint256[] calldata fCashMaturities,
+        uint256[] calldata maxfCashLiquidateAmounts
+    ) external returns (int256[] memory, int256);
+
+    function liquidatefCashLocal(
+        address liquidateAccount,
+        uint16 localCurrency,
+        uint256[] calldata fCashMaturities,
+        uint256[] calldata maxfCashLiquidateAmounts
+    ) external returns (int256[] memory, int256);
+
+    function calculatefCashCrossCurrencyLiquidation(
+        address liquidateAccount,
+        uint16 localCurrency,
+        uint16 fCashCurrency,
+        uint256[] calldata fCashMaturities,
+        uint256[] calldata maxfCashLiquidateAmounts
+    ) external returns (int256[] memory, int256);
+
+    function liquidatefCashCrossCurrency(
+        address liquidateAccount,
+        uint16 localCurrency,
+        uint16 fCashCurrency,
+        uint256[] calldata fCashMaturities,
+        uint256[] calldata maxfCashLiquidateAmounts
+    ) external returns (int256[] memory, int256);
+}

--- a/src/bridges/notional/interfaces/notional/NotionalViews.sol
+++ b/src/bridges/notional/interfaces/notional/NotionalViews.sol
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.0;
+pragma experimental ABIEncoderV2;
+
+import "../NotionalTypes.sol";
+
+interface NotionalViews {
+    function getMaxCurrencyId() external view returns (uint16);
+
+    function getCurrencyId(address tokenAddress) external view returns (uint16 currencyId);
+
+    function getCurrency(uint16 currencyId)
+        external
+        view
+        returns (Token memory assetToken, Token memory underlyingToken);
+
+    function getRateStorage(uint16 currencyId)
+        external
+        view
+        returns (ETHRateStorage memory ethRate, AssetRateStorage memory assetRate);
+
+    function getCurrencyAndRates(uint16 currencyId)
+        external
+        view
+        returns (
+            Token memory assetToken,
+            Token memory underlyingToken,
+            ETHRate memory ethRate,
+            AssetRateParameters memory assetRate
+        );
+
+    function getCashGroup(uint16 currencyId) external view returns (CashGroupSettings memory);
+
+    function getCashGroupAndAssetRate(uint16 currencyId)
+        external
+        view
+        returns (CashGroupSettings memory cashGroup, AssetRateParameters memory assetRate);
+
+    function getInitializationParameters(uint16 currencyId)
+        external
+        view
+        returns (int256[] memory annualizedAnchorRates, int256[] memory proportions);
+
+    function getDepositParameters(uint16 currencyId)
+        external
+        view
+        returns (int256[] memory depositShares, int256[] memory leverageThresholds);
+
+    function nTokenAddress(uint16 currencyId) external view returns (address);
+
+    function getNoteToken() external view returns (address);
+
+    function getSettlementRate(uint16 currencyId, uint40 maturity)
+        external
+        view
+        returns (AssetRateParameters memory);
+
+    function getMarket(uint16 currencyId, uint256 maturity, uint256 settlementDate)
+        external view returns (MarketParameters memory);
+
+    function getActiveMarkets(uint16 currencyId) external view returns (MarketParameters[] memory);
+
+    function getActiveMarketsAtBlockTime(uint16 currencyId, uint32 blockTime)
+        external
+        view
+        returns (MarketParameters[] memory);
+
+    function getReserveBalance(uint16 currencyId) external view returns (int256 reserveBalance);
+
+    function getNTokenPortfolio(address tokenAddress)
+        external
+        view
+        returns (PortfolioAsset[] memory liquidityTokens, PortfolioAsset[] memory netfCashAssets);
+
+    function getNTokenAccount(address tokenAddress)
+        external
+        view
+        returns (
+            uint16 currencyId,
+            uint256 totalSupply,
+            uint256 incentiveAnnualEmissionRate,
+            uint256 lastInitializedTime,
+            bytes5 nTokenParameters,
+            int256 cashBalance,
+            uint256 integralTotalSupply,
+            uint256 lastSupplyChangeTime
+        );
+
+    function getAccount(address account)
+        external
+        view
+        returns (
+            AccountContext memory accountContext,
+            AccountBalance[] memory accountBalances,
+            PortfolioAsset[] memory portfolio
+        );
+
+    function getAccountContext(address account) external view returns (AccountContext memory);
+
+    function getAccountBalance(uint16 currencyId, address account)
+        external
+        view
+        returns (
+            int256 cashBalance,
+            int256 nTokenBalance,
+            uint256 lastClaimTime
+        );
+
+    function getAccountPortfolio(address account) external view returns (PortfolioAsset[] memory);
+
+    function getfCashNotional(
+        address account,
+        uint16 currencyId,
+        uint256 maturity
+    ) external view returns (int256);
+
+    function getAssetsBitmap(address account, uint16 currencyId) external view returns (bytes32);
+
+    function getFreeCollateral(address account) external view returns (int256, int256[] memory);
+
+    function calculateNTokensToMint(uint16 currencyId, uint88 amountToDepositExternalPrecision)
+        external
+        view
+        returns (uint256);
+
+    function getfCashAmountGivenCashAmount(
+        uint16 currencyId,
+        int88 netCashToAccount,
+        uint256 marketIndex,
+        uint256 blockTime
+    ) external view returns (int256);
+
+    function getCashAmountGivenfCashAmount(
+        uint16 currencyId,
+        int88 fCashAmount,
+        uint256 marketIndex,
+        uint256 blockTime
+    ) external view returns (int256, int256);
+
+    function nTokenGetClaimableIncentives(address account, uint256 blockTime)
+        external
+        view
+        returns (uint256);
+
+}

--- a/src/bridges/notional/interfaces/notional/nERC1155Interface.sol
+++ b/src/bridges/notional/interfaces/notional/nERC1155Interface.sol
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.0;
+pragma experimental ABIEncoderV2;
+import "../NotionalTypes.sol";
+
+interface nERC1155Interface {
+    event TransferSingle(
+        address indexed operator,
+        address indexed from,
+        address indexed to,
+        uint256 id,
+        uint256 value
+    );
+    event TransferBatch(
+        address indexed operator,
+        address indexed from,
+        address indexed to,
+        uint256[] ids,
+        uint256[] values
+    );
+    event ApprovalForAll(address indexed account, address indexed operator, bool approved);
+    event URI(string value, uint256 indexed id);
+
+    function supportsInterface(bytes4 interfaceId) external pure returns (bool);
+
+    function balanceOf(address account, uint256 id) external view returns (uint256);
+
+    function balanceOfBatch(address[] calldata accounts, uint256[] calldata ids)
+        external
+        view
+        returns (uint256[] memory);
+
+    function signedBalanceOf(address account, uint256 id) external view returns (int256);
+
+    function signedBalanceOfBatch(address[] calldata accounts, uint256[] calldata ids)
+        external
+        view
+        returns (int256[] memory);
+
+    function setApprovalForAll(address operator, bool approved) external;
+
+    function isApprovedForAll(address account, address operator) external view returns (bool);
+
+    function safeTransferFrom(
+        address from,
+        address to,
+        uint256 id,
+        uint256 amount,
+        bytes calldata data
+    ) external payable;
+
+    function safeBatchTransferFrom(
+        address from,
+        address to,
+        uint256[] calldata ids,
+        uint256[] calldata amounts,
+        bytes calldata data
+    ) external payable;
+
+    function decodeToAssets(uint256[] calldata ids, uint256[] calldata amounts)
+        external
+        view
+        returns (PortfolioAsset[] memory);
+
+    function encodeToId(
+        uint16 currencyId,
+        uint40 maturity,
+        uint8 assetType
+    ) external pure returns (uint256 id);
+}

--- a/src/bridges/notional/interfaces/notional/nTokenERC20.sol
+++ b/src/bridges/notional/interfaces/notional/nTokenERC20.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.0;
+pragma experimental ABIEncoderV2;
+
+interface nTokenERC20 {
+    event Transfer(address indexed from, address indexed to, uint256 amount);
+
+    event Approval(address indexed owner, address indexed spender, uint256 amount);
+
+    function nTokenTotalSupply(address nTokenAddress) external view returns (uint256);
+
+    function nTokenTransferAllowance(
+        uint16 currencyId,
+        address owner,
+        address spender
+    ) external view returns (uint256);
+
+    function nTokenBalanceOf(uint16 currencyId, address account) external view returns (uint256);
+
+    function nTokenTransferApprove(
+        uint16 currencyId,
+        address owner,
+        address spender,
+        uint256 amount
+    ) external returns (bool);
+
+    function nTokenTransfer(
+        uint16 currencyId,
+        address from,
+        address to,
+        uint256 amount
+    ) external returns (bool);
+
+    function nTokenTransferFrom(
+        uint16 currencyId,
+        address spender,
+        address from,
+        address to,
+        uint256 amount
+    ) external returns (bool);
+
+    function nTokenTransferApproveAll(address spender, uint256 amount) external returns (bool);
+
+    function nTokenClaimIncentives() external returns (uint256);
+
+    function nTokenPresentValueAssetDenominated(uint16 currencyId) external view returns (int256);
+
+    function nTokenPresentValueUnderlyingDenominated(uint16 currencyId)
+        external
+        view
+        returns (int256);
+}

--- a/src/client/notional/notional-bridge-data.ts
+++ b/src/client/notional/notional-bridge-data.ts
@@ -1,0 +1,169 @@
+import {
+    AssetValue,
+    AuxDataConfig,
+    AztecAsset,
+    SolidityType,
+    AztecAssetType,
+    YieldBridgeData,
+  } from '../bridge-data';
+  
+import {
+      NotionalLendingBridge, NotionalViews, IERC20Detailed, CTokenInterface, FCashToken, FCashToken__factory, CTokenInterface__factory
+} from "../../../typechain-types"
+import { BigNumber } from 'ethers';
+import { AssetRateParametersStructOutput } from '../../../typechain-types/NotionalProxy';
+
+export class NotionalBridgeData implements YieldBridgeData {
+    currencyID = new Map<string, number>();
+    NotionalBridge : NotionalLendingBridge
+    NotionalView: NotionalViews
+    ZERO_ADDRESS: string = "0x00000000000000000000000000000000000000"
+    
+
+    constructor(NotionalBridge: NotionalLendingBridge, NotionalView: NotionalViews) {
+      this.NotionalBridge = NotionalBridge;
+      this.NotionalView = NotionalView;
+      const ETH = this.ZERO_ADDRESS;
+      const CETH = "0x4Ddc2D193948926D02f9B1fE9e1daa0718270ED5";
+      const DAI = "0x6B175474E89094C44Da98b954EedeAC495271d0F";
+      const CDAI = "0x5d3a536E4D6DbD6114cc1Ead35777bAB948E3643";
+      const USDC = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
+      const CUSDC = "0x39AA39c021dfbaE8faC545936693aC917d5E7563";
+      const WBTC = "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599";
+      const CWBTC = "0xC11b1268C1A384e55C48c2391d8d480264A3A7F4";
+      this.currencyID.set(ETH, 1);
+      this.currencyID.set(CETH,1);
+      this.currencyID.set(DAI, 2);
+      this.currencyID.set(CDAI, 2);
+      this.currencyID.set(USDC,3);
+      this.currencyID.set(CUSDC, 3);
+      this.currencyID.set(WBTC,4);
+      this.currencyID.set(CWBTC,4);
+     }
+    
+    public auxDataConfig: AuxDataConfig[] = [
+      {
+        start: 0,
+        length: 64,
+        solidityType: SolidityType.uint64,
+        description: 'the most significant 16 bits represent the currencyId, and the follwing 8 bits represent marketId',
+      },
+    ];
+  
+    // Lido bridge contract is stateless
+    async getInteractionPresentValue(interactionNonce: bigint): Promise<AssetValue[]> {
+      return [];
+    }
+  
+    async getAuxData(
+      inputAssetA: AztecAsset,
+      inputAssetB: AztecAsset,
+      outputAssetA: AztecAsset,
+      outputAssetB: AztecAsset,
+    ): Promise<bigint[]> {
+        let auxData: bigint
+        const marketId = 1;
+        if (inputAssetA.assetType != AztecAssetType.NOT_USED){
+            const currency = this.currencyID.get(inputAssetA.erc20Address);
+            auxData = (BigInt(currency) << 48n) +(BigInt(marketId) << 40n);
+        } else {
+            const cashToken = await this.NotionalBridge.fcashTokenCashToken(inputAssetA.erc20Address);
+            if (cashToken != this.ZERO_ADDRESS) {
+              const currency = this.currencyID.get(cashToken)
+              auxData = (BigInt(currency) << 48n) +(BigInt(marketId) << 40n);
+            }
+        }
+      return [auxData]
+    }
+    
+    async computeUnderlyingAmount(underlyingAddr: IERC20Detailed, cToken:CTokenInterface, inputAmt: bigint, isCToken: boolean): 
+    Promise<bigint> {
+      const underlyingDecimal = underlyingAddr.address == this.ZERO_ADDRESS ? 18n : BigInt((await underlyingAddr.decimals()).toString());
+      let cashAmt: bigint
+      if (isCToken) {
+          const exchangeRateCurrent =BigInt((await cToken.exchangeRateStored()).toString());
+          const mantissa = 10n + underlyingDecimal;
+          cashAmt = inputAmt * exchangeRateCurrent/(10n ** mantissa);
+      }  else{
+          cashAmt = inputAmt / (10n ** (underlyingDecimal-8n));
+      }
+      return cashAmt
+    }
+
+
+    convertFromUnderlying(ar: AssetRateParametersStructOutput, underlyingBalance: bigint) {
+      const ASSET_RATE_DECIMAL_DIFFERENCE = 1e10;
+      const assetBalance = ((BigNumber.from(underlyingBalance).mul(ASSET_RATE_DECIMAL_DIFFERENCE)).mul(ar.underlyingDecimals)).div(ar.rate);
+      return assetBalance;
+    }
+
+    async getExpectedOutput(
+      inputAssetA: AztecAsset,
+      inputAssetB: AztecAsset,
+      outputAssetA: AztecAsset,
+      outputAssetB: AztecAsset,
+      auxData: bigint,
+      inputValue: bigint,
+    ): Promise<bigint[]> {
+      // CashToken/UnderlyingToken -> FCashToken
+      let [index,isCToken] = await(this.NotionalBridge.findToken(inputAssetA.erc20Address))
+      let ret_val : bigint
+      if (index.toNumber() != -1){
+        const blockTime = (await this.NotionalBridge.provider.getBlock("latest")).timestamp
+        const currency = this.currencyID.get(inputAssetA.erc20Address);
+        const cashAmt = await this.computeUnderlyingAmount(await this.NotionalBridge.underlyingTokens[Number(index)], await this.NotionalBridge.cTokens[Number(index)], inputValue, isCToken);
+        const fCashAmt = await (this.NotionalView).getfCashAmountGivenCashAmount(currency, -cashAmt, 1, blockTime)
+        ret_val = BigInt(fCashAmt.toString())
+      } else {
+        // FCashToken -> CashToken/UnderlyingToken
+        const fcashContract: FCashToken = FCashToken__factory.connect(inputAssetA.erc20Address, this.NotionalBridge.provider)
+        const maturity =  await fcashContract.maturity()
+        const blockTime = (await this.NotionalBridge.provider.getBlock("latest")).timestamp
+        const cashToken = await this.NotionalBridge.fcashTokenCashToken(inputAssetA.erc20Address)
+        const currency = this.currencyID.get(cashToken)
+        if (blockTime < maturity.toNumber()) {
+          const [cashAmt, underlyingAmt] = await this.NotionalView.getCashAmountGivenfCashAmount(currency, inputValue, inputValue, blockTime)
+          isCToken = await this.NotionalBridge.findToken(cashToken)[1]
+          ret_val = isCToken ?  cashAmt.toBigInt() : underlyingAmt.toBigInt()
+        } else {
+          const ar = await this.NotionalView.getSettlementRate(currency, maturity)
+          const cOutputAmount =  this.convertFromUnderlying(ar, inputValue);
+          index = await this.NotionalBridge.findToken(cashToken)[0]
+          const cashTokenContract = CTokenInterface__factory.connect(cashToken, this.NotionalBridge.provider)
+          const underlyingAmt = await this.computeUnderlyingAmount(await this.NotionalBridge.underlyingTokens[index.toNumber()], cashTokenContract,cOutputAmount.toBigInt(), true)
+          ret_val = isCToken ? cOutputAmount.toBigInt() : underlyingAmt
+        }
+      }
+      return [ret_val];
+    }
+
+    // not applicable
+    async getExpectedYearlyOuput(
+      inputAssetA: AztecAsset,
+      inputAssetB: AztecAsset,
+      outputAssetA: AztecAsset,
+      outputAssetB: AztecAsset,
+      auxData: bigint,
+      precision: bigint,
+    ): Promise<bigint[]> {
+      return [0n]
+    }
+  
+    async getMarketSize(
+      inputAssetA: AztecAsset,
+      inputAssetB: AztecAsset,
+      outputAssetA: AztecAsset,
+      outputAssetB: AztecAsset,
+      auxData: bigint,
+    ): Promise<AssetValue[]> {
+      const currencyId = this.currencyID.get(inputAssetA.erc20Address);
+      const market = (await this.NotionalView.getActiveMarkets(currencyId))[0]
+      const assetValue = market.totalAssetCash
+      return [
+        {
+          assetId: inputAssetA.id,
+          amount: assetValue.toBigInt(),
+        }]
+    }
+  }
+  

--- a/src/test/notional/Notional.t.sol
+++ b/src/test/notional/Notional.t.sol
@@ -1,0 +1,497 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+import "../../../lib/ds-test/src/test.sol";
+import "../../bridges/notional/AztecNotionalLending.sol";
+import {CTokenInterface} from "../../bridges/notional/interfaces/compound/CTokenInterface.sol";
+import {IUniswapV2Router02} from "../../bridges/notional/interfaces/IUniswapV2Router02.sol";
+import {NotionalViews} from "../../bridges/notional//interfaces/notional/NotionalViews.sol";
+import {RollupProcessor} from "./../../aztec/RollupProcessor.sol";
+import {DefiBridgeProxy} from "./../../aztec/DefiBridgeProxy.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+interface Vm {
+    function deal(address who, uint256 amount) external;
+    function warp(uint x) external;
+}
+
+struct Info {
+    uint64 currencyId;
+    uint64 marketId;
+    uint maturity;
+    bool underlying;
+    uint interactionNonce;
+}
+
+contract NotionalTest is DSTest {
+    Vm vm = Vm(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
+    address public constant ETH = address(0);
+    address public constant CETH = address(0x4Ddc2D193948926D02f9B1fE9e1daa0718270ED5);
+    address public constant DAI = address(0x6B175474E89094C44Da98b954EedeAC495271d0F);
+    address public constant CDAI = address(0x5d3a536E4D6DbD6114cc1Ead35777bAB948E3643);
+    address public constant WETH = address(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
+    address public constant USDC = address(0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48);
+    address public constant CUSDC = address(0x39AA39c021dfbaE8faC545936693aC917d5E7563);
+    address public constant WBTC = address(0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599);
+    address public constant CWBTC = address(0xC11b1268C1A384e55C48c2391d8d480264A3A7F4);
+    IUniswapV2Router02 public constant ROUTER = IUniswapV2Router02(0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D);
+    NotionalViews public constant notional = NotionalViews(0x1344A36A1B56144C3Bc62E7757377D288fDE0369);
+    uint16 public constant ETH_CURRENCYID = 1;
+    uint16 public constant DAI_CURRENCYID = 2;
+    uint16 public constant USDC_CURRENCYID = 3;
+    uint16 public constant WBTC_CURRENCYID = 4;
+
+    AztecTypes.AztecAsset private empty;
+
+
+    NotionalLendingBridge public bridge;
+    RollupProcessor public rollup;
+    function setUp() public {
+        DefiBridgeProxy proxy = new DefiBridgeProxy();
+        rollup = new RollupProcessor(address(proxy));
+        bridge =  new NotionalLendingBridge(address(rollup));
+        bridge.insertToken(ERC20(ETH),CTokenInterface(CETH));
+        bridge.insertToken(ERC20(DAI),CTokenInterface(CDAI));
+        bridge.insertToken(ERC20(USDC),CTokenInterface(CUSDC));
+        bridge.insertToken(ERC20(WBTC),CTokenInterface(CWBTC));
+
+    }
+
+    receive() external payable {}
+
+    function swap(uint inputAmount, address[] memory path) internal {
+        vm.deal(address(this), inputAmount);
+        ROUTER.swapExactETHForTokens{value: inputAmount}(0, path, address(rollup), block.timestamp);
+    }
+
+    function lend(uint inputAmount, address[] memory path, address lendToken, Info memory info) internal returns(uint balance, uint maturity) {
+        AztecTypes.AztecAsset memory inputAsset;
+        bool isLendETH = lendToken == address(0);
+        if (isLendETH) {
+            vm.deal(address(rollup), inputAmount);
+        } else {
+            swap(inputAmount, path);
+        }
+        balance = isLendETH ? inputAmount: ERC20(lendToken).balanceOf(address(rollup));
+        inputAsset.assetType = isLendETH ? AztecTypes.AztecAssetType.ETH : AztecTypes.AztecAssetType.ERC20;
+        inputAsset.erc20Address = lendToken;
+        uint64 auxData = (uint64(info.currencyId) << 48) + (info.marketId << 40);
+        maturity = notional.getActiveMarkets(uint16(info.currencyId))[info.marketId - 1].maturity;
+        if (isLendETH) {
+            rollup.convert(address(bridge), inputAsset,empty,empty, empty, balance, info.interactionNonce, auxData);
+        } else {
+            rollup.convert(address(bridge), inputAsset,empty,empty, empty, balance, info.interactionNonce, auxData);
+        }
+    }
+
+    function withdraw(uint withdrawAmount, address underlyingAddr ,address ctoken, Info memory info) internal {
+        AztecTypes.AztecAsset memory inputAsset;
+        AztecTypes.AztecAsset memory outputAsset;
+        address fcashToken = bridge.cashTokenFcashToken(ctoken, info.maturity);
+        inputAsset.assetType = AztecTypes.AztecAssetType.ERC20;
+        inputAsset.erc20Address = fcashToken;
+        outputAsset.assetType = AztecTypes.AztecAssetType.ERC20;
+        if (info.underlying) {
+            outputAsset.erc20Address = underlyingAddr;
+            if (underlyingAddr == address(0)) {
+                outputAsset.assetType = AztecTypes.AztecAssetType.ETH;
+            }
+        } else {
+            outputAsset.erc20Address = ctoken;
+        }
+        uint64 auxData = (info.currencyId << 48) + (info.marketId << 40);
+        rollup.convert(address(bridge),inputAsset,empty,outputAsset,empty, withdrawAmount, info.interactionNonce, auxData);
+    }
+
+    function convertInput(uint x) internal pure returns (uint) {
+        x = 1e16 > x ? 1e16 : x;
+        x = 1e20 < x ? 1e20 : x;
+        return x;
+    }
+
+    // test whether when we lend eth, we receive wrapper fcash token back
+    function testETHLend(uint x) public{
+        x = convertInput(x);
+        Info memory info;
+        info.currencyId = ETH_CURRENCYID;
+        info.marketId = 1;
+        info.interactionNonce = 1;
+        address[] memory path = new address[](0);
+        (, uint maturity) = lend(x, path, ETH, info);
+        address fcashToken = bridge.cashTokenFcashToken(CETH, maturity);
+        uint balance = FCashToken(fcashToken).balanceOf(address(rollup));
+        require(balance > 0, "receive fcash for lending");
+    }
+
+    function testETHWithdrawUnderMaturity(uint x) public {
+        x = convertInput(x);
+        Info memory info;
+        info.currencyId = ETH_CURRENCYID;
+        info.marketId = 1;
+        info.interactionNonce = 1;
+        address[] memory path = new address[](0);
+        (, uint maturity) = lend(x, path, ETH, info);
+        uint prevBalance = address(rollup).balance;
+        uint withdrawAmount = ERC20(bridge.cashTokenFcashToken(CETH, maturity)).balanceOf(address(rollup));
+        info.maturity = maturity;
+        info.underlying = true;
+        info.interactionNonce = 2;
+        withdraw(withdrawAmount, ETH, CETH , info);
+        uint totalRedeemedETH = address(rollup).balance - prevBalance;
+        address fcashToken = bridge.cashTokenFcashToken(CETH, maturity);
+        require(totalRedeemedETH * 10000 /x > 9900, "should take most of the money back");
+        require(FCashToken(fcashToken).balanceOf(address(rollup)) == 0, "fcash should be burned");
+    }
+
+
+    function testETHLendAtAnyTimeWithdraw(uint x, uint time) public {
+        time = time > 60 days ? 60 days : time;
+        vm.warp(block.timestamp + time);
+        x = convertInput(x);
+        Info memory info;
+        info.currencyId = ETH_CURRENCYID;
+        info.marketId = 1;
+        info.interactionNonce = 1;
+        address[] memory path = new address[](0);
+        (,uint maturity) = lend(x, path, ETH, info);
+        uint prevBalance = address(rollup).balance;
+        uint withdrawAmount = ERC20(bridge.cashTokenFcashToken(CETH, maturity)).balanceOf(address(rollup));
+        info.maturity = maturity;
+        info.underlying = true;
+        info.interactionNonce = 2;
+        withdraw(withdrawAmount, ETH, CETH, info);
+        uint totalRedeemedETH = address(rollup).balance - prevBalance;
+        address fcashToken = bridge.cashTokenFcashToken(CETH, maturity);
+        require(totalRedeemedETH * 10000 /x > 9900, "should take most of the money back");
+        require(FCashToken(fcashToken).balanceOf(address(rollup)) == 0, "fcash should be burned");
+    }
+
+
+    function testETHLendTwiceAndWithdraw(uint x) public {
+        x = convertInput(x);
+        // first lend
+        address[] memory path = new address[](0);
+        Info memory info;
+        info.currencyId = ETH_CURRENCYID;
+        info.marketId = 1;
+        info.interactionNonce = 1;
+        (,uint firstMaturity) = lend(x, path, ETH, info);
+        address firstFcashToken = bridge.cashTokenFcashToken(CETH, firstMaturity);
+        uint firstLendFcashTokenAmt = FCashToken(firstFcashToken).balanceOf(address(rollup));        
+        vm.warp(block.timestamp + 30 days);
+        // second lend after a month
+        info.interactionNonce = 2;
+        (, uint secondMaturity) = lend(x, path, ETH, info);
+        address secondFcashToken = bridge.cashTokenFcashToken(CETH,secondMaturity);
+        uint balance = address(rollup).balance;
+        info.maturity = firstMaturity;
+        info.underlying = true;
+        info.interactionNonce = 3;
+        withdraw(firstLendFcashTokenAmt, ETH, CETH, info);
+        uint secondLendFCashTokenAmt = FCashToken(secondFcashToken).balanceOf(address(rollup));
+        uint firstWithdrawETH = address(rollup).balance - balance;
+        info.maturity = secondMaturity;
+        info.interactionNonce = 4;
+        withdraw(secondLendFCashTokenAmt, ETH, CETH, info);
+        uint secondWithdrawETH = address(rollup).balance - firstWithdrawETH - balance;
+        require(firstWithdrawETH > x, "should earn interest");
+        require(firstWithdrawETH > secondWithdrawETH, "should incur more eth interest");
+        require(secondWithdrawETH * 10000 /x  > 9900, "should take most of the money back");
+    }
+
+    function testETHLendTwiceDiffMarketsAndWithdraw(uint x) public {
+        x = convertInput(x);
+        address[] memory path = new address[](0);
+        // first lend
+        Info memory info;
+        info.currencyId = ETH_CURRENCYID;
+        info.marketId = 1;
+        Info memory info2;
+        info2.currencyId = ETH_CURRENCYID;
+        info2.marketId = 2;
+        info.interactionNonce = 1;
+        info2.interactionNonce = 2;
+        (,uint firstMaturity) = lend(x, path,ETH, info);
+        address firstFcashToken = bridge.cashTokenFcashToken(CETH, firstMaturity);
+        uint firstLendFcashTokenAmt = FCashToken(firstFcashToken).balanceOf(address(rollup));
+        (,uint secondMaturity) = lend(x, path,ETH, info2);
+        address secondFcashToken = bridge.cashTokenFcashToken(CETH,secondMaturity);
+        uint balance = address(rollup).balance;
+        info.maturity = firstMaturity;
+        info.underlying = true;
+        info.interactionNonce = 3;
+        withdraw(firstLendFcashTokenAmt, ETH, CETH, info);
+        uint secondLendFCashTokenAmt = FCashToken(secondFcashToken).balanceOf(address(rollup));
+        uint firstWithdrawETH = address(rollup).balance - balance;
+        info2.maturity = secondMaturity;
+        info2.underlying = true;
+        info2.interactionNonce = 4;
+        withdraw(secondLendFCashTokenAmt, ETH, CETH, info2);
+        uint secondWithdrawETH = address(rollup).balance - firstWithdrawETH - balance;
+        require(firstWithdrawETH * 10000/x > 9900, "should take most of the money back");
+        require(secondWithdrawETH * 10000 /x  > 9900, "should take most of the money back");
+    }
+
+
+    function testETHWithdrawOverMaturity(uint x) public {
+        x = convertInput(x);
+        address[] memory path = new address[](0);
+        Info memory info;
+        info.currencyId = ETH_CURRENCYID;
+        info.marketId = 1;
+        info.interactionNonce  = 1;
+        (,uint maturity) = lend(x, path, ETH, info);
+        uint withdrawAmount = ERC20(bridge.cashTokenFcashToken(CETH, maturity)).balanceOf(address(rollup));
+        uint prevBalance = address(rollup).balance;
+        vm.warp(block.timestamp + 90 days);
+        info.maturity = maturity;
+        info.underlying = true;
+        info.interactionNonce = 2;
+        withdraw(withdrawAmount, ETH, CETH, info);
+        uint totalRedeemedETH = address(rollup).balance - prevBalance;
+        address fcashToken = bridge.cashTokenFcashToken(CETH, maturity);
+        require(totalRedeemedETH > x, "should incur interest");
+        require(FCashToken(fcashToken).balanceOf(address(rollup)) == 0, "fcash should be burned");
+    }
+
+    function testETHPartialWithdrawUnderMaturity(uint x) public {
+        x = convertInput(x);
+        Info memory info;
+        info.currencyId = ETH_CURRENCYID;
+        info.marketId = 1;
+        address[] memory path = new address[](0);
+        info.interactionNonce = 1;
+        (,uint maturity) = lend(x, path, ETH, info);
+        uint prevBalance = address(rollup).balance;
+        uint withdrawAmount = ERC20(bridge.cashTokenFcashToken(CETH, maturity)).balanceOf(address(rollup));
+        info.maturity = maturity;
+        info.underlying = true;
+        info.interactionNonce = 2;
+        withdraw(withdrawAmount/2, ETH, CETH, info);
+        uint totalRedeemedETH = address(rollup).balance - prevBalance;
+        address fcashToken = bridge.cashTokenFcashToken(CETH, maturity);
+        require(totalRedeemedETH * 10000 / (x/2) > 9900, "should take roughly 1/2 of the money back");
+        require(totalRedeemedETH * 10000 / x < 5000, "should not take all of the money back");
+        require(FCashToken(fcashToken).balanceOf(address(rollup)) == withdrawAmount - withdrawAmount/2, "half of the fcash should remain");
+    }
+
+    function testETHPartialWithdrawOverMaturity(uint x) public {
+        x = convertInput(x);
+        Info memory info;
+        info.currencyId = ETH_CURRENCYID;
+        info.marketId = 1;
+        info.interactionNonce = 1;
+        address[] memory path = new address[](0);
+        (,uint maturity) = lend(x, path, ETH, info);
+        uint withdrawAmount = ERC20(bridge.cashTokenFcashToken(CETH, maturity)).balanceOf(address(rollup));
+        uint prevBalance = address(rollup).balance;
+        vm.warp(block.timestamp + 90 days);
+        info.maturity = maturity;
+        info.underlying = true;
+        info.interactionNonce = 2;
+        withdraw(withdrawAmount/2, ETH, CETH, info);
+        uint totalRedeemedETH = address(rollup).balance - prevBalance;
+        address fcashToken = bridge.cashTokenFcashToken(CETH, maturity);
+        require(totalRedeemedETH > x/2, "should incur interest on the half of the withdraw amount");
+        require(totalRedeemedETH * 10000 / x < 6000, "should not take all of the money back");
+        require(FCashToken(fcashToken).balanceOf(address(rollup)) == withdrawAmount - withdrawAmount/2, "half of the fcash should remain");
+    }
+
+    function testETHWithdrawOverMaturityWithdrawCETH(uint x) public {
+        x = convertInput(x);
+        Info memory info;
+        info.currencyId = ETH_CURRENCYID;
+        info.marketId = 1;
+        address[] memory path = new address[](0);
+        info.interactionNonce = 1;
+        (,uint maturity) = lend(x, path, ETH, info);
+        uint withdrawAmount = ERC20(bridge.cashTokenFcashToken(CETH, maturity)).balanceOf(address(rollup));
+        vm.warp(block.timestamp + 90 days);
+        info.maturity = maturity;
+        info.underlying = false;
+        info.interactionNonce = 2;
+        withdraw(withdrawAmount,ETH, CETH, info);
+        address fcashToken = bridge.cashTokenFcashToken(CETH, maturity);
+        require(CTokenInterface(CETH).balanceOf(address(rollup)) > 0, "should receive CETH");
+        require(FCashToken(fcashToken).balanceOf(address(rollup)) == 0, "fcash should be burned");
+    }
+
+    function testCDAILend(uint x) public{
+        x = convertInput(x);
+        address[] memory path = new address[](3);
+        path[0] = WETH;
+        path[1] = DAI;
+        path[2] = CDAI;
+        Info memory info;
+        info.currencyId = DAI_CURRENCYID;
+        info.marketId = 1;
+        info.interactionNonce = 1;
+        (,uint maturity) = lend(x, path, CDAI, info);
+        address fcashToken = bridge.cashTokenFcashToken(CDAI, maturity);
+        uint balance = FCashToken(fcashToken).balanceOf(address(rollup));
+        require(balance > 0, "receive fcash for lending");
+    }
+
+    function testCDAIWithdrawUnderMaturity(uint x) public {
+        x = convertInput(x);
+        address[] memory path = new address[](3);
+        path[0] = WETH;
+        path[1] = DAI;
+        path[2] = CDAI;
+        Info memory info;
+        info.currencyId = DAI_CURRENCYID;
+        info.marketId = 1;
+        info.interactionNonce = 1;
+        ( uint inputAmount, uint maturity) = lend(x, path, CDAI, info);
+        uint prevBalance = CTokenInterface(CDAI).balanceOf(address(rollup));
+        uint withdrawAmount = ERC20(bridge.cashTokenFcashToken(CDAI, maturity)).balanceOf(address(rollup));
+        info.maturity = maturity;
+        info.underlying = false;
+        info.interactionNonce = 2;
+        withdraw(withdrawAmount, DAI, CDAI, info);
+        uint redeemedBalance = CTokenInterface(CDAI).balanceOf(address(rollup)) - prevBalance;
+        require(redeemedBalance * 10000 / inputAmount > 9900, "should take most of money back");
+        require(ERC20(bridge.cashTokenFcashToken(CDAI, maturity)).balanceOf(address(rollup)) == 0,"fcash should be burned");
+    }
+
+    function testCDAIWithdrawOverMaturity(uint x) public {
+        x = convertInput(x);
+        address[] memory path = new address[](3);
+        path[0] = WETH;
+        path[1] = DAI;
+        path[2] = CDAI;
+        Info memory info;
+        info.currencyId = DAI_CURRENCYID;
+        info.marketId = 1;
+        info.interactionNonce = 1;
+        ( uint inputAmount, uint maturity) = lend(x, path, CDAI, info);
+        uint prevBalance = CTokenInterface(CDAI).balanceOf(address(rollup));
+        uint withdrawAmount = ERC20(bridge.cashTokenFcashToken(CDAI, maturity)).balanceOf(address(rollup));
+        vm.warp(block.timestamp + 90 days);
+        info.maturity = maturity;
+        info.underlying = false;
+        info.interactionNonce = 2;
+        withdraw(withdrawAmount, DAI, CDAI, info);
+        uint redeemedBalance = CTokenInterface(CDAI).balanceOf(address(rollup)) - prevBalance;
+        require(redeemedBalance  > inputAmount, "should incur interest");
+        require(ERC20(bridge.cashTokenFcashToken(CDAI, maturity)).balanceOf(address(rollup)) == 0,"fcash should be burned");
+    }
+
+
+    function testUSDCLend(uint x) public{
+        x = convertInput(x);
+        address[] memory path = new address[](2);
+        path[0] = WETH;
+        path[1] = USDC;
+        Info memory info;
+        info.currencyId = USDC_CURRENCYID;
+        info.marketId = 1;
+        info.interactionNonce = 1;
+        ( , uint maturity) = lend(x, path, USDC,info);
+        address fcashToken = bridge.cashTokenFcashToken(CUSDC, maturity);
+        uint balance = FCashToken(fcashToken).balanceOf(address(rollup));
+        require(balance > 0, "receive fcash for lending");
+    }
+
+    function testUSDCWithdrawUnderMaturity(uint x) public {
+        x = convertInput(x);
+        address[] memory path = new address[](2);
+        path[0] = WETH;
+        path[1] = USDC;
+        Info memory info;
+        info.currencyId = USDC_CURRENCYID;
+        info.marketId = 1;
+        info.interactionNonce = 1;
+        (uint inputAmount, uint maturity) = lend(x, path, USDC,info);
+        uint prevBalance = ERC20(USDC).balanceOf(address(rollup));
+        uint withdrawAmount = ERC20(bridge.cashTokenFcashToken(CUSDC, maturity)).balanceOf(address(rollup));
+        info.maturity = maturity;
+        info.underlying = true;
+        info.interactionNonce = 2;
+        withdraw(withdrawAmount, USDC, CUSDC, info);
+        uint redeemedBalance = ERC20(USDC).balanceOf(address(rollup)) - prevBalance;
+        require(redeemedBalance * 10000 / inputAmount > 9900, "should take most of money back");
+        require(ERC20(bridge.cashTokenFcashToken(CUSDC, maturity)).balanceOf(address(rollup)) == 0,"fcash should be burned");
+    }
+
+    function testUSDCWithdrawOverMaturity(uint x) public {
+        x = convertInput(x);
+        address[] memory path = new address[](2);
+        path[0] = WETH;
+        path[1] = USDC;
+        Info memory info;
+        info.currencyId = USDC_CURRENCYID;
+        info.marketId = 1;
+        info.interactionNonce = 1;
+        (uint inputAmount, uint maturity) = lend(x, path, USDC, info);
+        uint prevBalance = ERC20(USDC).balanceOf(address(rollup));
+        uint withdrawAmount = ERC20(bridge.cashTokenFcashToken(CUSDC, maturity)).balanceOf(address(rollup));
+        vm.warp(block.timestamp + 90 days);
+        info.maturity = maturity;
+        info.underlying = true;
+        info.interactionNonce = 2;
+        withdraw(withdrawAmount, USDC, CUSDC, info);
+        uint redeemedBalance = ERC20(USDC).balanceOf(address(rollup)) - prevBalance;
+        require(redeemedBalance  > inputAmount, "should incur interest");
+        require(ERC20(bridge.cashTokenFcashToken(CUSDC, maturity)).balanceOf(address(rollup)) == 0,"fcash should be burned");
+    }
+
+
+    function testWBTCLend(uint x) public{
+        x = convertInput(x);
+        address[] memory path = new address[](2);
+        path[0] = WETH;
+        path[1] = WBTC;
+        Info memory info;
+        info.currencyId = WBTC_CURRENCYID;
+        info.marketId = 1;
+        info.interactionNonce = 1;
+        ( , uint maturity) = lend(x, path, WBTC,info);
+        address fcashToken = bridge.cashTokenFcashToken(CWBTC, maturity);
+        uint balance = FCashToken(fcashToken).balanceOf(address(rollup));
+        require(balance > 0, "receive fcash for lending");
+    }
+
+    function testWBTCWithdrawUnderMaturity(uint x) public {
+        x = convertInput(x);
+        address[] memory path = new address[](2);
+        path[0] = WETH;
+        path[1] = WBTC;
+        Info memory info;
+        info.currencyId = WBTC_CURRENCYID;
+        info.marketId = 1;
+        info.interactionNonce = 1;
+        (uint inputAmount, uint maturity) = lend(x, path, WBTC,info);
+        uint prevBalance = ERC20(WBTC).balanceOf(address(rollup));
+        uint withdrawAmount = ERC20(bridge.cashTokenFcashToken(CWBTC, maturity)).balanceOf(address(rollup));
+        info.maturity = maturity;
+        info.underlying = true;
+        info.interactionNonce = 2;
+        withdraw(withdrawAmount, WBTC, CWBTC, info);
+        uint redeemedBalance = ERC20(WBTC).balanceOf(address(rollup)) - prevBalance;
+        require(redeemedBalance * 10000 / inputAmount > 9900, "should take most of money back");
+        require(ERC20(bridge.cashTokenFcashToken(CWBTC, maturity)).balanceOf(address(rollup)) == 0,"fcash should be burned");
+    }
+
+    function testWBTCWithdrawOverMaturity(uint x) public {
+        x = convertInput(x);
+        address[] memory path = new address[](2);
+        path[0] = WETH;
+        path[1] = WBTC;
+        Info memory info;
+        info.currencyId = WBTC_CURRENCYID;
+        info.marketId = 1;
+        info.interactionNonce = 1;
+        (uint inputAmount, uint maturity) = lend(x, path, WBTC,info);
+        uint prevBalance = ERC20(WBTC).balanceOf(address(rollup));
+        uint withdrawAmount = ERC20(bridge.cashTokenFcashToken(CWBTC, maturity)).balanceOf(address(rollup));
+        vm.warp(block.timestamp + 90 days);
+        info.maturity = maturity;
+        info.underlying = true;
+        info.interactionNonce = 2;
+        withdraw(withdrawAmount, WBTC, CWBTC, info);
+        uint redeemedBalance = ERC20(WBTC).balanceOf(address(rollup)) - prevBalance;
+        require(redeemedBalance * 10000 / inputAmount > 9900, "should take most of money back");
+        require(ERC20(bridge.cashTokenFcashToken(CWBTC, maturity)).balanceOf(address(rollup)) == 0,"fcash should be burned");
+    }
+}


### PR DESCRIPTION
In this PR, I implemented a lending bridge for Notional.Finance. 

### Lend

For lending, the rollup processor will receive the fcash tokens from the bridge for the corresponding maturity. Since we need to distinguish fcash tokens between different markets, we need to have a separate contract for each market we interact with. Notional.Finance does not represent fcash tokens as ERC20 tokens for now, so we would need to create a wrapper by ourselves. 

### Withdraw

The bridge contract will burn the wrapped fcash token and redeem the corresponding tokens. The rollup processor will be able to transfer that tokens from the bridge back to itself. 
