### PR TITLE
test: pinned TroveBridge tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,10 +10,12 @@
     "clean": "rm -rf ./cache ./dest ./out ./artifacts ./typechain-types ./client-dest",
     "test": "yarn test:contracts && yarn test:client",
     "test:client": "yarn compile:typechain && jest test",
-    "test:pinned": "forge test --fork-block-number 14000000 --match-contract 'Element|Set' -vvv --fork-url https://mainnet.infura.io/v3/9928b52099854248b3a096be07a6b23c",
+    "test:pinned:elementset": "forge test --fork-block-number 14000000 --match-contract 'Element|Set' -vvv --fork-url https://mainnet.infura.io/v3/9928b52099854248b3a096be07a6b23c",
+    "test:pinned:trovebridge": "forge test --fork-block-number 14400000 --match-contract 'TroveBridge' -vvv --fork-url https://mainnet.infura.io/v3/9928b52099854248b3a096be07a6b23c",
+    "test:pinned": "yarn test:pinned:elementset && yarn test:pinned:trovebridge",
     "test:contracts:block": "forge test --fork-block-number",
     "cast": "cast",
-    "test:contracts": "forge test --no-match-contract 'Element|Set' --no-match-test 'testRedeemFlow|testAsyncLimitOrder|testTwoPartMint' -vvv && yarn test:pinned",
+    "test:contracts": "forge test --no-match-contract 'Element|Set|TroveBridge' --no-match-test 'testAsyncLimitOrder|testTwoPartMint' -vvv && yarn test:pinned",
     "build": "yarn clean && yarn compile:typechain && yarn compile:client-dest"
   },
   "dependencies": {


### PR DESCRIPTION
testRedeemFlow test was currently disabled since it was not passing at the current block height. I pinned it to an older block and now it runs fine.