### PR TITLE
fix: hardhat configuration

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -1,5 +1,14 @@
-import { HardhatUserConfig } from 'hardhat/config';
+import { HardhatUserConfig, subtask } from 'hardhat/config';
 import '@typechain/hardhat';
+
+const {TASK_COMPILE_SOLIDITY_GET_SOURCE_PATHS} = require("hardhat/builtin-tasks/task-names")
+
+subtask(TASK_COMPILE_SOLIDITY_GET_SOURCE_PATHS)
+  .setAction(async (_, __, runSuper) => {
+    const paths = await runSuper();
+
+    return paths.filter((p: any) => !p.includes("src/test/"));
+  });
 
 const config: HardhatUserConfig = {
   solidity: {

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -1,22 +1,23 @@
 import { HardhatUserConfig, subtask } from 'hardhat/config';
 import '@typechain/hardhat';
 
-const {TASK_COMPILE_SOLIDITY_GET_SOURCE_PATHS} = require("hardhat/builtin-tasks/task-names")
+const { TASK_COMPILE_SOLIDITY_GET_SOURCE_PATHS } = require('hardhat/builtin-tasks/task-names');
 
-subtask(TASK_COMPILE_SOLIDITY_GET_SOURCE_PATHS)
-  .setAction(async (_, __, runSuper) => {
-    const paths = await runSuper();
+subtask(TASK_COMPILE_SOLIDITY_GET_SOURCE_PATHS).setAction(async (_, __, runSuper) => {
+  const paths = await runSuper();
 
-    return paths.filter((p: any) => !p.includes("src/test/"));
-  });
+  // Do not generate types for files in the src/test folder unless they are in interface subfolder.
+  // (Types of all the interfaces are needed in end to end tests.)
+  return paths.filter((p: any) => !p.includes('src/test/') || p.includes('interface'));
+});
 
 const config: HardhatUserConfig = {
   solidity: {
-    version: "0.8.10",
+    version: '0.8.10',
     settings: {
-    optimizer: { enabled: true, runs: 200 },
+      optimizer: { enabled: true, runs: 200 },
     },
-    },
+  },
   typechain: {
     target: 'ethers-v5',
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "setup": "yarn install:foundry && yarn setup:foundry",
     "setup:foundry": "foundryup && git submodule update --init",
     "install:foundry": "curl -L https://foundry.paradigm.xyz | bash",
-    "compile:contracts": "yarn clean forge build",
+    "compile:contracts": "yarn clean && forge build",
     "compile:typechain": "yarn compile:contracts && hardhat compile ",
     "compile:client-dest:watch": "yarn compile:typechain && tsc --project tsconfig.client-dest.json --watch",
     "compile:client-dest": "yarn compile:typechain && tsc --project tsconfig.client-dest.json",

--- a/src/aztec/DefiBridgeProxy.sol
+++ b/src/aztec/DefiBridgeProxy.sol
@@ -8,11 +8,7 @@ import {AztecTypes} from "./AztecTypes.sol";
 
 import {TokenTransfers} from "../libraries/TokenTransfers.sol";
 
-import "../../lib/ds-test/src/test.sol";
-
-import { console } from 'forge-std/console.sol';
-
-contract DefiBridgeProxy is DSTest {
+contract DefiBridgeProxy {
     bytes4 private constant BALANCE_OF_SELECTOR = 0x70a08231; // bytes4(keccak256('balanceOf(address)'));
     bytes4 private constant TRANSFER_SELECTOR = 0xa9059cbb; // bytes4(keccak256('transfer(address,uint256)'));
     bytes4 private constant DEPOSIT_SELECTOR = 0xb6b55f25; // bytes4(keccak256('deposit(uint256)'));

--- a/src/aztec/RollupProcessor.sol
+++ b/src/aztec/RollupProcessor.sol
@@ -8,11 +8,7 @@ import {IERC20} from "../interfaces/IERC20Permit.sol";
 import {DefiBridgeProxy} from "./DefiBridgeProxy.sol";
 import {AztecTypes} from "./AztecTypes.sol";
 
-import "../../lib/ds-test/src/test.sol";
-
-import { console } from 'forge-std/console.sol';
-
-contract RollupProcessor is DSTest {
+contract RollupProcessor {
     DefiBridgeProxy private bridgeProxy;
 
     struct DefiInteraction {

--- a/src/bridges/uniswapv3/SyncUniswapV3Bridge.sol
+++ b/src/bridges/uniswapv3/SyncUniswapV3Bridge.sol
@@ -171,7 +171,7 @@ contract SyncUniswapV3Bridge is IDefiBridge, UniswapV3Bridge {
             //outputAssetA.id = interactionNonce;
             //outputAssetA.erc20Address = input_address;
             outputValueA = inputValue;
-            console.log("finished");
+//            console.log("finished");
         }
         //INTERACTION TYPE 2 
         //1 real 1 virtual
@@ -372,8 +372,8 @@ contract SyncUniswapV3Bridge is IDefiBridge, UniswapV3Bridge {
 
             amounts[0] =  input < output ? inputValue/2 : amountOut;
             amounts[1] =  input < output ? amountOut : inputValue/2;
-            console.log(amounts[0], "amount0");
-            console.log(amounts[1], "amount1");
+//            console.log(amounts[0], "amount0");
+//            console.log(amounts[1], "amount1");
 
         }
 

--- a/src/bridges/uniswapv3/UniswapV3Bridge.sol
+++ b/src/bridges/uniswapv3/UniswapV3Bridge.sol
@@ -6,7 +6,6 @@ import {TransferHelper} from './libraries/TransferHelper.sol';
 import {ISwapRouter} from './interfaces/ISwapRouter.sol';
 import {IERC20} from './interfaces/IERC20.sol';
 import {IERC721Receiver} from '@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol';
-import { console } from 'forge-std/console.sol';
 import '../../interfaces/IRollupProcessor.sol';
 import './interfaces/IUniswapV3Factory.sol';
 import './base/LiquidityManagement.sol';

--- a/src/bridges/uniswapv3/base/LiquidityManagement.sol
+++ b/src/bridges/uniswapv3/base/LiquidityManagement.sol
@@ -12,7 +12,6 @@ import '../libraries/LiquidityAmounts.sol';
 
 import './PeripheryPayments.sol';
 import './PeripheryImmutableState.sol';
-import { console } from 'forge-std/console.sol';
 
 
 /// @title Liquidity management functions


### PR DESCRIPTION
I introduced a bug in PR https://github.com/AztecProtocol/aztec-connect-bridges/pull/71 which broke hardhat compilation. This PR fixes it.

The issue with hardhat was that hardhat doesn't have support for remappings. I fixed the compilation issues by forcing Hardhat to ignore test contracts during compilation. From my knowledge we don't need types for tests as tests are not accessed by frontend. If I am mistaken please let me know.

I have removed the console.sol dependency from non-test files. I think it's better to have the console.sol dependency imported only when debugging and during debugging we don't need hardhat compatibility.