### PR TITLE
Implemented changes based on Set audit

### DIFF
--- a/src/bridges/set/IssuanceBridge.sol
+++ b/src/bridges/set/IssuanceBridge.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-only
 // Copyright 2020 Spilsbury Holdings Ltd
-pragma solidity >=0.8.0 <=0.8.10;
+pragma solidity >=0.8.4 <=0.8.10;
 
 import {IERC20} from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 import {SafeERC20} from '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';

--- a/src/bridges/set/IssuanceBridge.sol
+++ b/src/bridges/set/IssuanceBridge.sol
@@ -22,7 +22,7 @@ contract IssuanceBridge is IDefiBridge {
     error ApproveFailed(address token);
     error InvalidCaller();
     error ZeroInputValue();
-    error IncompatibleAssetPair();
+    error IncorrectInput();
     error AsyncModeDisabled();
 
     constructor(
@@ -82,7 +82,7 @@ contract IssuanceBridge is IDefiBridge {
         returns (
             uint256 outputValueA,
             uint256,
-            bool isAsync
+            bool
         )
     {
         // Only Rollup Processor can call this function
@@ -93,17 +93,11 @@ contract IssuanceBridge is IDefiBridge {
         // Check if the user wants to ISSUE or REDEEM SetToken based on the input/output asset types
         // -----------------------------------------------------------------------------------------
 
-        bool inputIsSet = setController.isSet(address(inputAssetA.erc20Address));
-        bool outputIsSet = setController.isSet(address(outputAssetA.erc20Address));
-
         // REDEEM SET: User wants to redeem SetToken and receive ETH or ERC20
         // inputAssetA: SetToken
         // outputAssetA ERC20 or ETH
-        if (
-            inputIsSet &&
-            (outputAssetA.assetType == AztecTypes.AztecAssetType.ETH ||
-                outputAssetA.assetType == AztecTypes.AztecAssetType.ERC20)
-        ) {
+
+        if (setController.isSet(address(inputAssetA.erc20Address))) {
             if (outputAssetA.assetType == AztecTypes.AztecAssetType.ETH) {
                 // user wants to receive ETH
                 outputValueA = exchangeIssuance.redeemExactSetForETH(
@@ -121,30 +115,32 @@ contract IssuanceBridge is IDefiBridge {
                     inputValue, //  _amountSetToken,
                     auxData //  _minOutputReceive
                 );
+            } else {
+                revert IncorrectInput();
             }
-        }
-        // ISSUE SET: User wants to issue SetToken in for ERC20
-        // inputAssetA: ERC20 (but not SetToken)
-        // outputAssetA: SetToken
-        else if (inputAssetA.assetType == AztecTypes.AztecAssetType.ERC20 && !inputIsSet && outputIsSet) {
-            outputValueA = exchangeIssuance.issueSetForExactToken(
-                ISetToken(address(outputAssetA.erc20Address)),
-                IERC20(address(inputAssetA.erc20Address)),
-                inputValue, //  _amountInput
-                auxData // _minSetReceive
-            );
-        }
-        // ISSUE: User wants to issue SetToken for ETH
-        // inputAssetA: ETH
-        // outputAssetA: SetToken
-        else if (inputAssetA.assetType == AztecTypes.AztecAssetType.ETH && outputIsSet) {
-            // issue SetTokens for a given amount of ETH (=inputValue)
-            outputValueA = exchangeIssuance.issueSetForExactETH{value: inputValue}(
-                ISetToken(address(outputAssetA.erc20Address)),
-                auxData // _minSetReceive
-            );
+        } else if (setController.isSet(address(outputAssetA.erc20Address))) {
+            if (inputAssetA.assetType == AztecTypes.AztecAssetType.ERC20) {
+                outputValueA = exchangeIssuance.issueSetForExactToken(
+                    ISetToken(address(outputAssetA.erc20Address)),
+                    IERC20(address(inputAssetA.erc20Address)),
+                    inputValue, //  _amountInput
+                    auxData // _minSetReceive
+                );
+            }
+            // ISSUE: User wants to issue SetToken for ETH
+            // inputAssetA: ETH
+            // outputAssetA: SetToken
+            else if (inputAssetA.assetType == AztecTypes.AztecAssetType.ETH) {
+                // issue SetTokens for a given amount of ETH (=inputValue)
+                outputValueA = exchangeIssuance.issueSetForExactETH{value: inputValue}(
+                    ISetToken(address(outputAssetA.erc20Address)),
+                    auxData // _minSetReceive
+                );
+            } else {
+                revert IncorrectInput();
+            }
         } else {
-            revert IncompatibleAssetPair();
+            revert IncorrectInput();
         }
     }
 

--- a/src/bridges/set/IssuanceBridge.sol
+++ b/src/bridges/set/IssuanceBridge.sol
@@ -3,15 +3,15 @@
 pragma solidity >=0.6.10 <=0.8.10;
 pragma experimental ABIEncoderV2;
 
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC20} from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 
-import { AztecTypes } from "../../aztec/AztecTypes.sol";
+import {AztecTypes} from '../../aztec/AztecTypes.sol';
 
-import { IDefiBridge } from "../../interfaces/IDefiBridge.sol";
-import { ISetToken } from "./interfaces/ISetToken.sol";
-import { IController } from "./interfaces/IController.sol";
-import { IExchangeIssuance } from "./interfaces/IExchangeIssuance.sol";
-import { IRollupProcessor } from "../../interfaces/IRollupProcessor.sol";
+import {IDefiBridge} from '../../interfaces/IDefiBridge.sol';
+import {ISetToken} from './interfaces/ISetToken.sol';
+import {IController} from './interfaces/IController.sol';
+import {IExchangeIssuance} from './interfaces/IExchangeIssuance.sol';
+import {IRollupProcessor} from '../../interfaces/IRollupProcessor.sol';
 
 contract IssuanceBridge is IDefiBridge {
     address public immutable rollupProcessor;
@@ -35,6 +35,9 @@ contract IssuanceBridge is IDefiBridge {
         setController = IController(_setController);
     }
 
+    // Empty fallback function in order to receive ETH
+    receive() external payable {}
+
     /**
      * @notice Sets all the important approvals.
      * @dev This bridge never holds any ERC20s after or before an invocation of any of its functions.
@@ -44,7 +47,8 @@ contract IssuanceBridge is IDefiBridge {
         uint256 tokensLength = tokens.length;
         for (uint256 i; i < tokensLength; ) {
             if (!IERC20(tokens[i]).approve(rollupProcessor, type(uint256).max)) revert ApproveFailed(tokens[i]);
-            if (!IERC20(tokens[i]).approve(address(exchangeIssuance), type(uint256).max)) revert ApproveFailed(tokens[i]);
+            if (!IERC20(tokens[i]).approve(address(exchangeIssuance), type(uint256).max))
+                revert ApproveFailed(tokens[i]);
             unchecked {
                 ++i;
             }
@@ -70,7 +74,7 @@ contract IssuanceBridge is IDefiBridge {
         uint256 inputValue,
         uint256 interactionNonce,
         uint64 auxData,
-        address 
+        address
     )
         external
         payable
@@ -139,9 +143,7 @@ contract IssuanceBridge is IDefiBridge {
             setController.isSet(address(outputAssetA.erc20Address))
         ) {
             // issue SetTokens for a given amount of ETH (=inputValue)
-            outputValueA = exchangeIssuance.issueSetForExactETH{
-                value: inputValue
-            }(
+            outputValueA = exchangeIssuance.issueSetForExactETH{value: inputValue}(
                 ISetToken(address(outputAssetA.erc20Address)),
                 auxData // _minSetReceive
             );
@@ -150,9 +152,6 @@ contract IssuanceBridge is IDefiBridge {
         }
     }
 
-    // Empty fallback function in order to receive ETH 
-    receive() external payable {}
-    
     function finalise(
         AztecTypes.AztecAsset calldata,
         AztecTypes.AztecAsset calldata,
@@ -160,7 +159,16 @@ contract IssuanceBridge is IDefiBridge {
         AztecTypes.AztecAsset calldata,
         uint256,
         uint64
-    ) external payable override returns (uint256, uint256, bool) {
+    )
+        external
+        payable
+        override
+        returns (
+            uint256,
+            uint256,
+            bool
+        )
+    {
         revert AsyncModeDisabled();
     }
 }

--- a/src/bridges/set/IssuanceBridge.sol
+++ b/src/bridges/set/IssuanceBridge.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0-only
 // Copyright 2020 Spilsbury Holdings Ltd
-pragma solidity >=0.6.10 <=0.8.10;
-pragma experimental ABIEncoderV2;
+pragma solidity >=0.8.0 <=0.8.10;
 
 import {IERC20} from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
+import {SafeERC20} from '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
 
 import {AztecTypes} from '../../aztec/AztecTypes.sol';
 
@@ -14,6 +14,8 @@ import {IExchangeIssuance} from './interfaces/IExchangeIssuance.sol';
 import {IRollupProcessor} from '../../interfaces/IRollupProcessor.sol';
 
 contract IssuanceBridge is IDefiBridge {
+    using SafeERC20 for IERC20;
+
     IExchangeIssuance public constant EXCHANGE_ISSUANCE = IExchangeIssuance(0xc8C85A3b4d03FB3451e7248Ff94F780c92F884fD);
     IController public constant SET_CONTROLLER = IController(0xa4c8d221d8BB851f83aadd0223a8900A6921A349);
 
@@ -44,9 +46,8 @@ contract IssuanceBridge is IDefiBridge {
     function approveTokens(address[] calldata tokens) external {
         uint256 tokensLength = tokens.length;
         for (uint256 i; i < tokensLength; ) {
-            if (!IERC20(tokens[i]).approve(rollupProcessor, type(uint256).max)) revert ApproveFailed(tokens[i]);
-            if (!IERC20(tokens[i]).approve(address(EXCHANGE_ISSUANCE), type(uint256).max))
-                revert ApproveFailed(tokens[i]);
+            IERC20(tokens[i]).safeIncreaseAllowance(rollupProcessor, type(uint256).max);
+            IERC20(tokens[i]).safeIncreaseAllowance(address(EXCHANGE_ISSUANCE), type(uint256).max);
             unchecked {
                 ++i;
             }
@@ -58,7 +59,7 @@ contract IssuanceBridge is IDefiBridge {
      * @param inputAssetA    - If ISSUE SET: ETH or ERC20        | If REDEEM SET: SetToken
      * @param outputAssetA   - If ISSUE SET: setToken            | If REDEEM SET: ETH or ERC20
      * @param inputValue     - If ISSUE SET: ETH or ERC20 amount | If REDEEM SET: SetToken amount
-     * @param auxData -
+     * @param auxData        - minimum token amount received during redemption or minting
      * @return outputValueA  - If ISSUE SET: SetToken amount     | If REDEEM SET: ETH or ERC20 amount
      * @return isAsync a flag to toggle if this bridge interaction will return assets at a later
             date after some third party contract has interacted with it via finalise()
@@ -109,18 +110,18 @@ contract IssuanceBridge is IDefiBridge {
             }
         } else if (SET_CONTROLLER.isSet(address(outputAssetA.erc20Address))) {
             // User wants to issue SetToken
-            if (inputAssetA.assetType == AztecTypes.AztecAssetType.ERC20) {
+            if (inputAssetA.assetType == AztecTypes.AztecAssetType.ETH) {
+                // User supplies ETH
+                outputValueA = EXCHANGE_ISSUANCE.issueSetForExactETH{value: inputValue}(
+                    ISetToken(address(outputAssetA.erc20Address)),
+                    auxData // _minSetReceive
+                );
+            } else if (inputAssetA.assetType == AztecTypes.AztecAssetType.ERC20) {
                 // User supplies ERC20
                 outputValueA = EXCHANGE_ISSUANCE.issueSetForExactToken(
                     ISetToken(address(outputAssetA.erc20Address)),
                     IERC20(address(inputAssetA.erc20Address)),
-                    inputValue, //  _amountInput
-                    auxData // _minSetReceive
-                );
-            } else if (inputAssetA.assetType == AztecTypes.AztecAssetType.ETH) {
-                // User supplies ETH
-                outputValueA = EXCHANGE_ISSUANCE.issueSetForExactETH{value: inputValue}(
-                    ISetToken(address(outputAssetA.erc20Address)),
+                    inputValue, // _amountInput
                     auxData // _minSetReceive
                 );
             } else {

--- a/src/bridges/set/IssuanceBridge.sol
+++ b/src/bridges/set/IssuanceBridge.sol
@@ -93,11 +93,14 @@ contract IssuanceBridge is IDefiBridge {
         // Check if the user wants to ISSUE or REDEEM SetToken based on the input/output asset types
         // -----------------------------------------------------------------------------------------
 
+        bool inputIsSet = setController.isSet(address(inputAssetA.erc20Address));
+        bool outputIsSet = setController.isSet(address(outputAssetA.erc20Address));
+
         // REDEEM SET: User wants to redeem SetToken and receive ETH or ERC20
         // inputAssetA: SetToken
         // outputAssetA ERC20 or ETH
         if (
-            setController.isSet(address(inputAssetA.erc20Address)) &&
+            inputIsSet &&
             (outputAssetA.assetType == AztecTypes.AztecAssetType.ETH ||
                 outputAssetA.assetType == AztecTypes.AztecAssetType.ERC20)
         ) {
@@ -123,11 +126,7 @@ contract IssuanceBridge is IDefiBridge {
         // ISSUE SET: User wants to issue SetToken in for ERC20
         // inputAssetA: ERC20 (but not SetToken)
         // outputAssetA: SetToken
-        else if (
-            inputAssetA.assetType == AztecTypes.AztecAssetType.ERC20 &&
-            !setController.isSet(address(inputAssetA.erc20Address)) &&
-            setController.isSet(address(outputAssetA.erc20Address))
-        ) {
+        else if (inputAssetA.assetType == AztecTypes.AztecAssetType.ERC20 && !inputIsSet && outputIsSet) {
             outputValueA = exchangeIssuance.issueSetForExactToken(
                 ISetToken(address(outputAssetA.erc20Address)),
                 IERC20(address(inputAssetA.erc20Address)),
@@ -138,10 +137,7 @@ contract IssuanceBridge is IDefiBridge {
         // ISSUE: User wants to issue SetToken for ETH
         // inputAssetA: ETH
         // outputAssetA: SetToken
-        else if (
-            inputAssetA.assetType == AztecTypes.AztecAssetType.ETH &&
-            setController.isSet(address(outputAssetA.erc20Address))
-        ) {
+        else if (inputAssetA.assetType == AztecTypes.AztecAssetType.ETH && outputIsSet) {
             // issue SetTokens for a given amount of ETH (=inputValue)
             outputValueA = exchangeIssuance.issueSetForExactETH{value: inputValue}(
                 ISetToken(address(outputAssetA.erc20Address)),

--- a/src/bridges/set/interfaces/IController.sol
+++ b/src/bridges/set/interfaces/IController.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-only
-pragma solidity >=0.8.0 <=0.8.10;
+pragma solidity >=0.8.4 <=0.8.10;
 
 interface IController {
     function addSet(address _setToken) external;

--- a/src/bridges/set/interfaces/IController.sol
+++ b/src/bridges/set/interfaces/IController.sol
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-only
-pragma solidity >=0.6.10 <=0.8.10;
-pragma experimental ABIEncoderV2;
+pragma solidity >=0.8.0 <=0.8.10;
 
 interface IController {
     function addSet(address _setToken) external;

--- a/src/bridges/set/interfaces/IExchangeIssuance.sol
+++ b/src/bridges/set/interfaces/IExchangeIssuance.sol
@@ -2,8 +2,8 @@
 pragma solidity >=0.6.10 <=0.8.10;
 pragma experimental ABIEncoderV2;
 
-import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import {ISetToken} from "./ISetToken.sol";
+import {IERC20} from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
+import {ISetToken} from './ISetToken.sol';
 
 interface IExchangeIssuance {
     // Issues an exact amount of SetTokens using a given amount of ether.

--- a/src/bridges/set/interfaces/IExchangeIssuance.sol
+++ b/src/bridges/set/interfaces/IExchangeIssuance.sol
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-only
-pragma solidity >=0.6.10 <=0.8.10;
-pragma experimental ABIEncoderV2;
+pragma solidity >=0.8.0 <=0.8.10;
 
 import {IERC20} from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 import {ISetToken} from './ISetToken.sol';

--- a/src/bridges/set/interfaces/IExchangeIssuance.sol
+++ b/src/bridges/set/interfaces/IExchangeIssuance.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-only
-pragma solidity >=0.8.0 <=0.8.10;
+pragma solidity >=0.8.4 <=0.8.10;
 
 import {IERC20} from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 import {ISetToken} from './ISetToken.sol';

--- a/src/bridges/set/interfaces/ISetToken.sol
+++ b/src/bridges/set/interfaces/ISetToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-only
-pragma solidity >=0.8.0 <=0.8.10;
+pragma solidity >=0.8.4 <=0.8.10;
 
 import {IERC20} from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 

--- a/src/bridges/set/interfaces/ISetToken.sol
+++ b/src/bridges/set/interfaces/ISetToken.sol
@@ -2,7 +2,7 @@
 pragma solidity >=0.6.10 <=0.8.10;
 pragma experimental ABIEncoderV2;
 
-import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC20} from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 
 interface ISetToken is IERC20 {
     /* ============ Enums ============ */

--- a/src/bridges/set/interfaces/ISetToken.sol
+++ b/src/bridges/set/interfaces/ISetToken.sol
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-only
-pragma solidity >=0.6.10 <=0.8.10;
-pragma experimental ABIEncoderV2;
+pragma solidity >=0.8.0 <=0.8.10;
 
 import {IERC20} from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 

--- a/src/test/set/Set.t.sol
+++ b/src/test/set/Set.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-only
 // Copyright 2022 Spilsbury Holdings Ltd
-pragma solidity >=0.8.0 <=0.8.10;
+pragma solidity >=0.8.4 <=0.8.10;
 
 import {DefiBridgeProxy} from './../../aztec/DefiBridgeProxy.sol';
 import {RollupProcessor} from './../../aztec/RollupProcessor.sol';

--- a/src/test/set/Set.t.sol
+++ b/src/test/set/Set.t.sol
@@ -1,9 +1,6 @@
-// SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.10;
-
-import '../../../lib/ds-test/src/test.sol';
-
-import {Vm} from '../../../lib/forge-std/src/Vm.sol';
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright 2022 Spilsbury Holdings Ltd
+pragma solidity >=0.8.0 <=0.8.10;
 
 import {DefiBridgeProxy} from './../../aztec/DefiBridgeProxy.sol';
 import {RollupProcessor} from './../../aztec/RollupProcessor.sol';
@@ -15,9 +12,9 @@ import {IController} from './../../bridges/set/interfaces/IController.sol';
 import {ISetToken} from './../../bridges/set/interfaces/ISetToken.sol';
 import {AztecTypes} from './../../aztec/AztecTypes.sol';
 
-contract SetTest is DSTest {
-    Vm vm = Vm(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
+import 'forge-std/Test.sol';
 
+contract SetTest is Test {
     // Aztec
     DefiBridgeProxy defiBridgeProxy;
     RollupProcessor rollupProcessor;
@@ -69,9 +66,9 @@ contract SetTest is DSTest {
 
     function testSetBridge() public {
         // test if we can prefund rollup with tokens and ETH
-        uint256 depositAmountDai = 1000000000;
-        uint256 depositAmountDpi = 2000000000;
-        uint256 depositAmountEth = 1000000000000000000; // 1 ETH
+        uint256 depositAmountDai = 1e9;
+        uint256 depositAmountDpi = 2e9;
+        uint256 depositAmountEth = 1 ether;
 
         _setTokenBalance(address(dai), address(rollupProcessor), depositAmountDai, 2);
         _setTokenBalance(address(dpi), address(rollupProcessor), depositAmountDpi, 0);
@@ -90,7 +87,7 @@ contract SetTest is DSTest {
 
     function testIssueSetForExactToken() public {
         // Pre-fund contract with DAI
-        uint256 depositAmountDai = 1000000000000000000000; // $1000
+        uint256 depositAmountDai = 1e21; // 1000 DAI
         _setTokenBalance(address(dai), address(rollupProcessor), depositAmountDai, 2);
 
         // Used for unused input/output assets
@@ -141,7 +138,7 @@ contract SetTest is DSTest {
 
     function testIssueSetForExactEth() public {
         // Pre-fund contract with ETH
-        uint256 depositAmountEth = 100000000000000000; // 0.1 ETH
+        uint256 depositAmountEth = 1e17; // 0.1 ETH
         _setEthBalance(address(rollupProcessor), depositAmountEth);
 
         // Used for unused input/output assets
@@ -191,7 +188,7 @@ contract SetTest is DSTest {
 
     function testRedeemExactSetForToken() public {
         // Pre-fund rollup contract DPI
-        uint256 depositAmountDpi = 100000000000000000000; // 100
+        uint256 depositAmountDpi = 1e20; // 100 DPI
         _setTokenBalance(address(dpi), address(rollupProcessor), depositAmountDpi, 0);
 
         // Used for unused input/output assets
@@ -244,7 +241,7 @@ contract SetTest is DSTest {
 
     function testRedeemExactSetForEth() public {
         // prefund rollup with tokens
-        uint256 depositAmountDpi = 100000000000000000000; // 100
+        uint256 depositAmountDpi = 1e20; // 100 DPI
         _setTokenBalance(address(dpi), address(rollupProcessor), depositAmountDpi, 0);
 
         // Used for unused input/output assets

--- a/src/test/set/Set.t.sol
+++ b/src/test/set/Set.t.sol
@@ -1,19 +1,19 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.10;
 
-import "../../../lib/ds-test/src/test.sol";
+import '../../../lib/ds-test/src/test.sol';
 
-import { Vm } from "../../../lib/forge-std/src/Vm.sol";
+import {Vm} from '../../../lib/forge-std/src/Vm.sol';
 
-import { DefiBridgeProxy } from "./../../aztec/DefiBridgeProxy.sol";
-import { RollupProcessor } from "./../../aztec/RollupProcessor.sol";
+import {DefiBridgeProxy} from './../../aztec/DefiBridgeProxy.sol';
+import {RollupProcessor} from './../../aztec/RollupProcessor.sol';
 
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC20} from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 
-import { IssuanceBridge } from "./../../bridges/set/IssuanceBridge.sol";
-import { IController } from "./../../bridges/set/interfaces/IController.sol";
-import { ISetToken } from "./../../bridges/set/interfaces/ISetToken.sol";
-import { AztecTypes } from "./../../aztec/AztecTypes.sol";
+import {IssuanceBridge} from './../../bridges/set/IssuanceBridge.sol';
+import {IController} from './../../bridges/set/interfaces/IController.sol';
+import {ISetToken} from './../../bridges/set/interfaces/ISetToken.sol';
+import {AztecTypes} from './../../aztec/AztecTypes.sol';
 
 contract SetTest is DSTest {
     Vm vm = Vm(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
@@ -24,7 +24,7 @@ contract SetTest is DSTest {
 
     // Bridges
     IssuanceBridge issuanceBridge;
-    
+
     // Set-Protocol related contracts
     address exchangeIssuanceAddress = 0xc8C85A3b4d03FB3451e7248Ff94F780c92F884fD;
     address setControllerAddress = 0xa4c8d221d8BB851f83aadd0223a8900A6921A349;
@@ -32,7 +32,7 @@ contract SetTest is DSTest {
     // ERC20 tokens
     IERC20 constant dai = IERC20(0x6B175474E89094C44Da98b954EedeAC495271d0F);
     IERC20 constant dpi = IERC20(0x1494CA1F11D487c2bBe4543E90080AeBa4BA3C2b);
-    
+
     function _aztecPreSetup() internal {
         defiBridgeProxy = new DefiBridgeProxy();
         rollupProcessor = new RollupProcessor(address(defiBridgeProxy));
@@ -41,11 +41,7 @@ contract SetTest is DSTest {
     function setUp() public {
         _aztecPreSetup();
 
-        issuanceBridge = new IssuanceBridge(
-            address(rollupProcessor),
-            exchangeIssuanceAddress,
-            setControllerAddress
-        );
+        issuanceBridge = new IssuanceBridge(address(rollupProcessor), exchangeIssuanceAddress, setControllerAddress);
 
         address[] memory tokens = new address[](2);
         tokens[0] = address(dai);
@@ -57,9 +53,8 @@ contract SetTest is DSTest {
         AztecTypes.AztecAsset memory empty;
 
         vm.prank(address(124));
-        try issuanceBridge.convert(empty, empty, empty, empty, 0, 0, 0, address(0))
-        {
-            revert("convert(...) has to revert when msg.sender != rollupProcessor.");
+        try issuanceBridge.convert(empty, empty, empty, empty, 0, 0, 0, address(0)) {
+            revert('convert(...) has to revert when msg.sender != rollupProcessor.');
         } catch (bytes memory reason) {
             assertEq(IssuanceBridge.InvalidCaller.selector, bytes4(reason));
         }
@@ -69,9 +64,8 @@ contract SetTest is DSTest {
         AztecTypes.AztecAsset memory empty;
 
         vm.prank(address(rollupProcessor));
-        try issuanceBridge.convert(empty, empty, empty, empty, 0, 0, 0, address(0))
-        {
-            revert("convert(...) has to revert inputValue == 0.");
+        try issuanceBridge.convert(empty, empty, empty, empty, 0, 0, 0, address(0)) {
+            revert('convert(...) has to revert inputValue == 0.');
         } catch (bytes memory reason) {
             assertEq(IssuanceBridge.ZeroInputValue.selector, bytes4(reason));
         }
@@ -91,30 +85,18 @@ contract SetTest is DSTest {
         uint256 rollupBalanceDpi = dpi.balanceOf(address(rollupProcessor));
         uint256 rollupBalanceEth = address(rollupProcessor).balance;
 
-        assertEq(
-            depositAmountDai,
-            rollupBalanceDai,
-            "DAI balance must match"
-        );
-        
-        assertEq(
-            depositAmountDpi,
-            rollupBalanceDpi,
-            "DPI balance must match"
-        );
-        
-        assertEq(
-            depositAmountEth,
-            rollupBalanceEth,
-            "ETH balance must match"
-        );
+        assertEq(depositAmountDai, rollupBalanceDai, 'DAI balance must match');
+
+        assertEq(depositAmountDpi, rollupBalanceDpi, 'DPI balance must match');
+
+        assertEq(depositAmountEth, rollupBalanceEth, 'ETH balance must match');
     }
 
     function testIssueSetForExactToken() public {
         // Pre-fund contract with DAI
         uint256 depositAmountDai = 1000000000000000000000; // $1000
         _setTokenBalance(address(dai), address(rollupProcessor), depositAmountDai, 2);
- 
+
         // Used for unused input/output assets
         AztecTypes.AztecAsset memory empty;
 
@@ -136,60 +118,36 @@ contract SetTest is DSTest {
         uint256 rollupBalanceBeforeDpi = dpi.balanceOf(address(rollupProcessor));
 
         // Call rollup's convert function
-        (
-            uint256 outputValueA,
-            uint256 outputValueB,
-            bool isAsync
-        ) = rollupProcessor.convert(
-                address(issuanceBridge),
-                inputAsset,
-                empty,
-                outputAsset,
-                empty,
-                depositAmountDai,
-                0,
-                0
-            );
+        (uint256 outputValueA, uint256 outputValueB, bool isAsync) = rollupProcessor.convert(
+            address(issuanceBridge),
+            inputAsset,
+            empty,
+            outputAsset,
+            empty,
+            depositAmountDai,
+            0,
+            0
+        );
 
         uint256 rollupBalanceAfterDai = dai.balanceOf(address(rollupProcessor));
         uint256 rollupBalanceAfterDpi = dpi.balanceOf(address(rollupProcessor));
 
-        assertEq(
-            depositAmountDai,
-            rollupBalanceBeforeDai,
-            "DAI balance before convert must match"
-        );
+        assertEq(depositAmountDai, rollupBalanceBeforeDai, 'DAI balance before convert must match');
 
-        assertEq(
-            0,
-            rollupBalanceBeforeDpi,
-            "DPI balance before convert must match"
-        );
+        assertEq(0, rollupBalanceBeforeDpi, 'DPI balance before convert must match');
 
-        assertEq(
-            0,
-            rollupBalanceAfterDai,
-            "DAI balance after convert must match"
-        );
+        assertEq(0, rollupBalanceAfterDai, 'DAI balance after convert must match');
 
-        assertEq(
-            outputValueA,
-            rollupBalanceAfterDpi,
-            "DPI balance after convert must match"
-        );
+        assertEq(outputValueA, rollupBalanceAfterDpi, 'DPI balance after convert must match');
 
-        assertGt(
-            rollupBalanceAfterDpi,
-            0,
-            "DPI balance after must be > 0"
-        );
+        assertGt(rollupBalanceAfterDpi, 0, 'DPI balance after must be > 0');
     }
 
     function testIssueSetForExactEth() public {
         // Pre-fund contract with ETH
         uint256 depositAmountEth = 100000000000000000; // 0.1 ETH
         _setEthBalance(address(rollupProcessor), depositAmountEth);
- 
+
         // Used for unused input/output assets
         AztecTypes.AztecAsset memory empty;
 
@@ -210,60 +168,36 @@ contract SetTest is DSTest {
         uint256 rollupBalanceBeforeEth = address(rollupProcessor).balance;
         uint256 rollupBalanceBeforeDpi = dpi.balanceOf(address(rollupProcessor));
 
-        (
-            uint256 outputValueA,
-            uint256 outputValueB,
-            bool isAsync
-        ) = rollupProcessor.convert(
-                address(issuanceBridge),
-                inputAsset,
-                empty,
-                outputAsset,
-                empty,
-                depositAmountEth,
-                0,
-                0
-            );
+        (uint256 outputValueA, uint256 outputValueB, bool isAsync) = rollupProcessor.convert(
+            address(issuanceBridge),
+            inputAsset,
+            empty,
+            outputAsset,
+            empty,
+            depositAmountEth,
+            0,
+            0
+        );
 
         uint256 rollupBalanceAfterEth = address(rollupProcessor).balance;
         uint256 rollupBalanceAfterDpi = dpi.balanceOf(address(rollupProcessor));
 
-        assertEq(
-            depositAmountEth,
-            rollupBalanceBeforeEth,
-            "ETH balance before convert must match"
-        );
+        assertEq(depositAmountEth, rollupBalanceBeforeEth, 'ETH balance before convert must match');
 
-        assertEq(
-            0,
-            rollupBalanceBeforeDpi,
-            "DPI balance before convert must match"
-        );
+        assertEq(0, rollupBalanceBeforeDpi, 'DPI balance before convert must match');
 
-        assertEq(
-            0,
-            rollupBalanceAfterEth,
-            "ETH balance after convert must match"
-        );
+        assertEq(0, rollupBalanceAfterEth, 'ETH balance after convert must match');
 
-        assertEq(
-            outputValueA,
-            rollupBalanceAfterDpi,
-            "DPI balance after convert must match"
-        );
+        assertEq(outputValueA, rollupBalanceAfterDpi, 'DPI balance after convert must match');
 
-        assertGt(
-            rollupBalanceAfterDpi,
-            0,
-            "DPI balance after must be > 0"
-        );
+        assertGt(rollupBalanceAfterDpi, 0, 'DPI balance after must be > 0');
     }
 
     function testRedeemExactSetForToken() public {
-        // Pre-fund rollup contract DPI 
+        // Pre-fund rollup contract DPI
         uint256 depositAmountDpi = 100000000000000000000; // 100
         _setTokenBalance(address(dpi), address(rollupProcessor), depositAmountDpi, 0);
- 
+
         // Used for unused input/output assets
         AztecTypes.AztecAsset memory empty;
 
@@ -284,64 +218,39 @@ contract SetTest is DSTest {
         uint256 rollupBalanceBeforeDai = dai.balanceOf(address(rollupProcessor));
         uint256 rollupBalanceBeforeDpi = dpi.balanceOf(address(rollupProcessor));
 
-
         // Call rollup's convert function
-        (
-            uint256 outputValueA,
-            uint256 outputValueB,
-            bool isAsync
-        ) = rollupProcessor.convert(
-                address(issuanceBridge),
-                inputAsset,
-                empty,
-                outputAsset,
-                empty,
-                depositAmountDpi,
-                0,
-                0
-            );
+        (uint256 outputValueA, uint256 outputValueB, bool isAsync) = rollupProcessor.convert(
+            address(issuanceBridge),
+            inputAsset,
+            empty,
+            outputAsset,
+            empty,
+            depositAmountDpi,
+            0,
+            0
+        );
 
         uint256 rollupBalanceAfterDai = dai.balanceOf(address(rollupProcessor));
         uint256 rollupBalanceAfterDpi = dpi.balanceOf(address(rollupProcessor));
 
         // Checks before
-        assertEq(
-            0,
-            rollupBalanceBeforeDai,
-            "DAI balance before convert must match"
-        );
+        assertEq(0, rollupBalanceBeforeDai, 'DAI balance before convert must match');
 
-        assertEq(
-            depositAmountDpi,
-            rollupBalanceBeforeDpi,
-            "DPI balance before convert must match"
-        );
+        assertEq(depositAmountDpi, rollupBalanceBeforeDpi, 'DPI balance before convert must match');
 
         // Checks after
-        assertEq(
-            outputValueA,
-            rollupBalanceAfterDai,
-            "DAI balance after convert must match"
-        );
+        assertEq(outputValueA, rollupBalanceAfterDai, 'DAI balance after convert must match');
 
-        assertEq(
-            0,
-            rollupBalanceAfterDpi,
-            "DPI balance after convert must match"
-        );
+        assertEq(0, rollupBalanceAfterDpi, 'DPI balance after convert must match');
 
-        assertGt(
-            rollupBalanceAfterDai,
-            0,
-            "DAI balance after must be > 0"
-        );
+        assertGt(rollupBalanceAfterDai, 0, 'DAI balance after must be > 0');
     }
 
     function testRedeemExactSetForEth() public {
         // prefund rollup with tokens
         uint256 depositAmountDpi = 100000000000000000000; // 100
         _setTokenBalance(address(dpi), address(rollupProcessor), depositAmountDpi, 0);
- 
+
         // Used for unused input/output assets
         AztecTypes.AztecAsset memory empty;
 
@@ -362,80 +271,47 @@ contract SetTest is DSTest {
         uint256 rollupBalanceBeforeDpi = dpi.balanceOf(address(rollupProcessor));
         uint256 rollupBalanceBeforeEth = address(rollupProcessor).balance;
 
-        (
-            uint256 outputValueA,
-            uint256 outputValueB,
-            bool isAsync
-        ) = rollupProcessor.convert(
-                address(issuanceBridge),
-                inputAsset,
-                empty,
-                outputAsset,
-                empty,
-                depositAmountDpi,
-                0,
-                0
-            );
+        (uint256 outputValueA, uint256 outputValueB, bool isAsync) = rollupProcessor.convert(
+            address(issuanceBridge),
+            inputAsset,
+            empty,
+            outputAsset,
+            empty,
+            depositAmountDpi,
+            0,
+            0
+        );
 
         uint256 rollupBalanceAfterDpi = dpi.balanceOf(address(rollupProcessor));
         uint256 rollupBalanceAfterEth = address(rollupProcessor).balance;
 
         // Checks before
-        assertEq(
-            0,
-            rollupBalanceBeforeEth,
-            "ETH balance before convert must match"
-        );
+        assertEq(0, rollupBalanceBeforeEth, 'ETH balance before convert must match');
 
-        assertEq(
-            depositAmountDpi,
-            rollupBalanceBeforeDpi,
-            "DPI balance before convert must match"
-        );
+        assertEq(depositAmountDpi, rollupBalanceBeforeDpi, 'DPI balance before convert must match');
 
         // Checks after
-        assertEq(
-            outputValueA,
-            rollupBalanceAfterEth,
-            "ETH balance after convert must match"
-        );
+        assertEq(outputValueA, rollupBalanceAfterEth, 'ETH balance after convert must match');
 
-        assertEq(
-            0,
-            rollupBalanceAfterDpi,
-            "DPI balance after convert must match"
-        );
+        assertEq(0, rollupBalanceAfterDpi, 'DPI balance after convert must match');
 
-        assertGt(
-            rollupBalanceAfterEth,
-            0,
-            "ETH balance after must be > 0"
-        );
+        assertGt(rollupBalanceAfterEth, 0, 'ETH balance after must be > 0');
     }
-    
+
     function _setTokenBalance(
         address token,
         address user,
         uint256 balance,
         uint256 slot // May vary depending on token
     ) internal {
+        vm.store(token, keccak256(abi.encode(user, slot)), bytes32(uint256(balance)));
 
-        vm.store(
-            token,
-            keccak256(abi.encode(user, slot)),
-            bytes32(uint256(balance))
-        );
-
-        assertEq(IERC20(token).balanceOf(user), balance, "wrong token balance");
+        assertEq(IERC20(token).balanceOf(user), balance, 'wrong token balance');
     }
 
-    function _setEthBalance(
-        address user,
-        uint256 balance
-    ) internal {
-
+    function _setEthBalance(address user, uint256 balance) internal {
         vm.deal(user, balance);
 
-        assertEq(user.balance, balance, "wrong ETH balance");
+        assertEq(user.balance, balance, 'wrong ETH balance');
     }
 }

--- a/src/test/set/Set.t.sol
+++ b/src/test/set/Set.t.sol
@@ -25,10 +25,6 @@ contract SetTest is DSTest {
     // Bridges
     IssuanceBridge issuanceBridge;
 
-    // Set-Protocol related contracts
-    address exchangeIssuanceAddress = 0xc8C85A3b4d03FB3451e7248Ff94F780c92F884fD;
-    address setControllerAddress = 0xa4c8d221d8BB851f83aadd0223a8900A6921A349;
-
     // ERC20 tokens
     IERC20 constant dai = IERC20(0x6B175474E89094C44Da98b954EedeAC495271d0F);
     IERC20 constant dpi = IERC20(0x1494CA1F11D487c2bBe4543E90080AeBa4BA3C2b);
@@ -41,7 +37,7 @@ contract SetTest is DSTest {
     function setUp() public {
         _aztecPreSetup();
 
-        issuanceBridge = new IssuanceBridge(address(rollupProcessor), exchangeIssuanceAddress, setControllerAddress);
+        issuanceBridge = new IssuanceBridge(address(rollupProcessor));
 
         address[] memory tokens = new address[](2);
         tokens[0] = address(dai);

--- a/src/test/set/Set.t.sol
+++ b/src/test/set/Set.t.sol
@@ -46,6 +46,26 @@ contract SetTest is DSTest {
             exchangeIssuanceAddress,
             setControllerAddress
         );
+
+        address[] memory exchangeTokens = new address[](1);
+        address[] memory processorTokens = new address[](2);
+        exchangeTokens[0] = address(dpi);
+        processorTokens[0] = address(dai);
+        processorTokens[1] = address(dpi);
+        issuanceBridge.approveTokens(exchangeTokens, processorTokens);
+    }
+
+    function testApproveNonSetAsSet() public {
+        address[] memory exchangeTokens = new address[](1);
+        address[] memory processorTokens = new address[](0);
+        exchangeTokens[0] = address(dai);
+
+        try issuanceBridge.approveTokens(exchangeTokens, processorTokens)
+        {
+            assertTrue(false, "approveTokens(...) has when approving non-set token as set.");
+        } catch (bytes memory reason) {
+            assertEq(IssuanceBridge.NotSetToken.selector, bytes4(reason));
+        }
     }
 
     function testSetBridge() public {


### PR DESCRIPTION
The biggest changes are:
1) Approving tokens once instead of every call --> this is not a vulnerability because the spenders are trusted (issuanceExchange and rollupProcessor) + the bridge never holds any tokens after the interaction is finished;
2) cleaned up logic;
3) improved tests and docs.