### PR TITLE
Janb/linting errors in Set and Liquity bridges

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -3,6 +3,7 @@
   "rules": {
     "compiler-version": ["error", ">=0.8.4"],
     "func-visibility": ["warn", { "ignoreConstructors": true }],
-    "no-empty-blocks": "off"
+    "no-empty-blocks": "off",
+    "not-rely-on-time": "off"
   }
 }

--- a/src/bridges/liquity/StabilityPoolBridge.sol
+++ b/src/bridges/liquity/StabilityPoolBridge.sol
@@ -2,11 +2,14 @@
 // Copyright 2022 Spilsbury Holdings Ltd
 pragma solidity >=0.8.4;
 
-import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import "../../interfaces/IDefiBridge.sol";
-import "../../interfaces/IWETH.sol";
-import "./interfaces/IStabilityPool.sol";
-import "./interfaces/ISwapRouter.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {IDefiBridge} from "../../interfaces/IDefiBridge.sol";
+import {AztecTypes} from "../../aztec/AztecTypes.sol";
+import {IWETH} from "../../interfaces/IWETH.sol";
+
+import {IStabilityPool} from "./interfaces/IStabilityPool.sol";
+import {ISwapRouter} from "./interfaces/ISwapRouter.sol";
 
 /**
  * @title Aztec Connect Bridge for Liquity's StabilityPool.sol

--- a/src/bridges/liquity/StakingBridge.sol
+++ b/src/bridges/liquity/StakingBridge.sol
@@ -2,11 +2,14 @@
 // Copyright 2022 Spilsbury Holdings Ltd
 pragma solidity >=0.8.4;
 
-import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import "../../interfaces/IDefiBridge.sol";
-import "../../interfaces/IWETH.sol";
-import "./interfaces/ILQTYStaking.sol";
-import "./interfaces/ISwapRouter.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {IDefiBridge} from "../../interfaces/IDefiBridge.sol";
+import {AztecTypes} from "../../aztec/AztecTypes.sol";
+import {IWETH} from "../../interfaces/IWETH.sol";
+
+import {ILQTYStaking} from "./interfaces/ILQTYStaking.sol";
+import {ISwapRouter} from "./interfaces/ISwapRouter.sol";
 
 /**
  * @title Aztec Connect Bridge for Liquity's LQTYStaking.sol

--- a/src/bridges/liquity/TroveBridge.sol
+++ b/src/bridges/liquity/TroveBridge.sol
@@ -2,14 +2,17 @@
 // Copyright 2022 Spilsbury Holdings Ltd
 pragma solidity >=0.8.4;
 
-import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import "@openzeppelin/contracts/access/Ownable.sol";
-import "@openzeppelin/contracts/utils/Strings.sol";
-import "../../interfaces/IDefiBridge.sol";
-import "../../interfaces/IRollupProcessor.sol";
-import "./interfaces/IBorrowerOperations.sol";
-import "./interfaces/ITroveManager.sol";
-import "./interfaces/ISortedTroves.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
+import {IDefiBridge} from "../../interfaces/IDefiBridge.sol";
+import {AztecTypes} from "../../aztec/AztecTypes.sol";
+import {IRollupProcessor} from "../../interfaces/IRollupProcessor.sol";
+
+import {IBorrowerOperations} from "./interfaces/IBorrowerOperations.sol";
+import {ITroveManager} from "./interfaces/ITroveManager.sol";
+import {ISortedTroves} from "./interfaces/ISortedTroves.sol";
 
 /**
  * @title Aztec Connect Bridge for opening and closing Liquity's troves

--- a/src/bridges/liquity/interfaces/IBorrowerOperations.sol
+++ b/src/bridges/liquity/interfaces/IBorrowerOperations.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.0;
+pragma solidity >=0.8.4;
 
 interface IBorrowerOperations {
     function openTrove(

--- a/src/bridges/liquity/interfaces/ILQTYStaking.sol
+++ b/src/bridges/liquity/interfaces/ILQTYStaking.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.0;
+pragma solidity >=0.8.4;
 
 interface ILQTYStaking {
     function stakes(address _user) external view returns (uint256);

--- a/src/bridges/liquity/interfaces/ILiquityBase.sol
+++ b/src/bridges/liquity/interfaces/ILiquityBase.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.0;
+pragma solidity >=0.8.4;
 
 import "./IPriceFeed.sol";
 

--- a/src/bridges/liquity/interfaces/ILiquityBase.sol
+++ b/src/bridges/liquity/interfaces/ILiquityBase.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.4;
 
-import "./IPriceFeed.sol";
+import {IPriceFeed} from "./IPriceFeed.sol";
 
 interface ILiquityBase {
     function priceFeed() external view returns (IPriceFeed);

--- a/src/bridges/liquity/interfaces/IPriceFeed.sol
+++ b/src/bridges/liquity/interfaces/IPriceFeed.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.0;
+pragma solidity >=0.8.4;
 
 interface IPriceFeed {
     function fetchPrice() external returns (uint256);

--- a/src/bridges/liquity/interfaces/ISortedTroves.sol
+++ b/src/bridges/liquity/interfaces/ISortedTroves.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.0;
+pragma solidity >=0.8.4;
 
 interface ISortedTroves {
     function getNext(address _id) external view returns (address);

--- a/src/bridges/liquity/interfaces/IStabilityPool.sol
+++ b/src/bridges/liquity/interfaces/IStabilityPool.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.0;
+pragma solidity >=0.8.4;
 
 interface IStabilityPool {
     function provideToSP(uint256 _amount, address _frontEndTag) external;

--- a/src/bridges/liquity/interfaces/ISwapRouter.sol
+++ b/src/bridges/liquity/interfaces/ISwapRouter.sol
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity >=0.7.5;
-pragma abicoder v2;
+pragma solidity >=0.8.4;
 
 /// @title Router token swapping functionality
 /// @notice Functions for swapping tokens via Uniswap V3

--- a/src/bridges/liquity/interfaces/ITroveManager.sol
+++ b/src/bridges/liquity/interfaces/ITroveManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.0;
+pragma solidity >=0.8.4;
 
 import "./ILiquityBase.sol";
 import "./IStabilityPool.sol";

--- a/src/bridges/liquity/interfaces/ITroveManager.sol
+++ b/src/bridges/liquity/interfaces/ITroveManager.sol
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.4;
 
-import "./ILiquityBase.sol";
-import "./IStabilityPool.sol";
-import "./ILQTYStaking.sol";
+import {ILiquityBase} from "./ILiquityBase.sol";
 
 // Common interface for the Trove Manager.
 interface ITroveManager is ILiquityBase {

--- a/src/bridges/set/IssuanceBridge.sol
+++ b/src/bridges/set/IssuanceBridge.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-only
 // Copyright 2020 Spilsbury Holdings Ltd
-pragma solidity >=0.8.4 <=0.8.10;
+pragma solidity >=0.8.4;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";

--- a/src/bridges/set/interfaces/IController.sol
+++ b/src/bridges/set/interfaces/IController.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-only
-pragma solidity >=0.8.4 <=0.8.10;
+pragma solidity >=0.8.4;
 
 interface IController {
     function addSet(address _setToken) external;

--- a/src/bridges/set/interfaces/IExchangeIssuance.sol
+++ b/src/bridges/set/interfaces/IExchangeIssuance.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-only
-pragma solidity >=0.8.4 <=0.8.10;
+pragma solidity >=0.8.4;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {ISetToken} from "./ISetToken.sol";

--- a/src/bridges/set/interfaces/ISetToken.sol
+++ b/src/bridges/set/interfaces/ISetToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-only
-pragma solidity >=0.8.4 <=0.8.10;
+pragma solidity >=0.8.4;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 

--- a/src/interfaces/IDefiBridge.sol
+++ b/src/interfaces/IDefiBridge.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-only
-// Copyright 2020 Spilsbury Holdings Ltd
-pragma solidity >=0.6.6 <0.8.11;
-pragma experimental ABIEncoderV2;
+// Copyright 2022 Spilsbury Holdings Ltd
+pragma solidity >=0.8.4;
 
 import {AztecTypes} from "../aztec/AztecTypes.sol";
 

--- a/src/interfaces/IERC20Permit.sol
+++ b/src/interfaces/IERC20Permit.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-only
-// Copyright 2020 Spilsbury Holdings Ltd
-pragma solidity >=0.6.10 <=0.8.10;
+// Copyright 2022 Spilsbury Holdings Ltd
+pragma solidity >=0.8.4;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 

--- a/src/interfaces/IRollupProcessor.sol
+++ b/src/interfaces/IRollupProcessor.sol
@@ -1,6 +1,6 @@
-// SPDX-License-Identifier: Apache-2.0
-// Copyright 2022 Aztec
-pragma solidity >=0.8.4 <0.8.11;
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright 2022 Spilsbury Holdings Ltd
+pragma solidity >=0.8.4;
 
 interface IRollupProcessor {
     function defiBridgeProxy() external view returns (address);

--- a/src/interfaces/IWETH.sol
+++ b/src/interfaces/IWETH.sol
@@ -1,6 +1,6 @@
-// SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity >=0.7.5;
-pragma abicoder v2;
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright 2022 Spilsbury Holdings Ltd
+pragma solidity >=0.8.4;
 
 interface IWETH {
     function deposit() external payable;

--- a/src/test/example/Example.t.sol
+++ b/src/test/example/Example.t.sol
@@ -37,10 +37,9 @@ contract ExampleTest is Test {
 
         address callerAddress = address(bytes20(uint160(uint256(keccak256("non-rollup-processor-address")))));
 
-        vm.startPrank(callerAddress);
+        vm.prank(callerAddress);
         vm.expectRevert(ExampleBridgeContract.InvalidCaller.selector);
         exampleBridge.convert(empty, empty, empty, empty, 0, 0, 0, address(0));
-        vm.stopPrank();
     }
 
     function testExampleBridge() public {

--- a/src/test/liquity/StabilityPoolBridge.t.sol
+++ b/src/test/liquity/StabilityPoolBridge.t.sol
@@ -2,8 +2,10 @@
 // Copyright 2022 Spilsbury Holdings Ltd
 pragma solidity >=0.8.4;
 
-import "./utils/TestUtil.sol";
-import "../../bridges/liquity/StabilityPoolBridge.sol";
+import {AztecTypes} from "../../aztec/AztecTypes.sol";
+
+import {TestUtil} from "./utils/TestUtil.sol";
+import {StabilityPoolBridge} from "../../bridges/liquity/StabilityPoolBridge.sol";
 
 contract StabilityPoolBridgeTest is TestUtil {
     StabilityPoolBridge private bridge;

--- a/src/test/liquity/StabilityPoolBridge.t.sol
+++ b/src/test/liquity/StabilityPoolBridge.t.sol
@@ -27,22 +27,17 @@ contract StabilityPoolBridgeTest is TestUtil {
     function testIncorrectInput() public {
         // Call convert with incorrect input
         vm.prank(address(rollupProcessor));
-        try
-            bridge.convert(
-                AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
-                AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
-                AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
-                AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
-                0,
-                0,
-                0,
-                address(0)
-            )
-        {
-            assertTrue(false, "convert(...) has to revert on incorrect input.");
-        } catch (bytes memory reason) {
-            assertEq(StabilityPoolBridge.IncorrectInput.selector, bytes4(reason));
-        }
+        vm.expectRevert(StabilityPoolBridge.IncorrectInput.selector);
+        bridge.convert(
+            AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
+            AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
+            AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
+            AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
+            0,
+            0,
+            0,
+            address(0)
+        );
     }
 
     function testFullDepositWithdrawalFlow() public {

--- a/src/test/liquity/StabilityPoolBridgeInternal.t.sol
+++ b/src/test/liquity/StabilityPoolBridgeInternal.t.sol
@@ -10,18 +10,9 @@ abstract contract StabilityPoolBridgeTestInternal is TestUtil, StabilityPoolBrid
         _aztecPreSetup();
         setUpTokens();
 
-        require(
-            IERC20(WETH).approve(address(UNI_ROUTER), type(uint256).max),
-            "StabilityPoolBridge: WETH_APPROVE_FAILED"
-        );
-        require(
-            IERC20(LQTY).approve(address(UNI_ROUTER), type(uint256).max),
-            "StabilityPoolBridge: LQTY_APPROVE_FAILED"
-        );
-        require(
-            IERC20(USDC).approve(address(UNI_ROUTER), type(uint256).max),
-            "StabilityPoolBridge: USDC_APPROVE_FAILED"
-        );
+        require(IERC20(WETH).approve(address(UNI_ROUTER), type(uint256).max), "WETH_APPROVE_FAILED");
+        require(IERC20(LQTY).approve(address(UNI_ROUTER), type(uint256).max), "LQTY_APPROVE_FAILED");
+        require(IERC20(USDC).approve(address(UNI_ROUTER), type(uint256).max), "USDC_APPROVE_FAILED");
     }
 
     function testSwapRewardsOnUni() public {

--- a/src/test/liquity/StabilityPoolBridgeInternal.t.sol
+++ b/src/test/liquity/StabilityPoolBridgeInternal.t.sol
@@ -2,8 +2,10 @@
 // Copyright 2022 Spilsbury Holdings Ltd
 pragma solidity >=0.8.4;
 
-import "./utils/TestUtil.sol";
-import "../../bridges/liquity/StabilityPoolBridge.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import {TestUtil} from "./utils/TestUtil.sol";
+import {StabilityPoolBridge} from "../../bridges/liquity/StabilityPoolBridge.sol";
 
 abstract contract StabilityPoolBridgeTestInternal is TestUtil, StabilityPoolBridge(address(0), address(0)) {
     function setUp() public {

--- a/src/test/liquity/StabilityPoolBridgeInternal.t.sol
+++ b/src/test/liquity/StabilityPoolBridgeInternal.t.sol
@@ -25,7 +25,7 @@ abstract contract StabilityPoolBridgeTestInternal is TestUtil, StabilityPoolBrid
         payable(address(0)).transfer(address(this).balance - 1 ether);
 
         uint256 depositedLUSDBeforeSwap = STABILITY_POOL.getCompoundedLUSDDeposit(address(this));
-        _swapRewardsToLUSDAndDeposit();
+        swapRewardsToLUSDAndDeposit();
         uint256 depositedLUSDAfterSwap = STABILITY_POOL.getCompoundedLUSDDeposit(address(this));
 
         // Verify that rewards were swapped for non-zero amount and correctly staked

--- a/src/test/liquity/StakingBridge.t.sol
+++ b/src/test/liquity/StakingBridge.t.sol
@@ -26,22 +26,17 @@ contract StakingBridgeTest is TestUtil {
     function testIncorrectInput() public {
         // Call convert with incorrect input
         vm.prank(address(rollupProcessor));
-        try
-            bridge.convert(
-                AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
-                AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
-                AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
-                AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
-                0,
-                0,
-                0,
-                address(0)
-            )
-        {
-            assertTrue(false, "convert(...) has to revert on incorrect input.");
-        } catch (bytes memory reason) {
-            assertEq(StakingBridge.IncorrectInput.selector, bytes4(reason));
-        }
+        vm.expectRevert(StakingBridge.IncorrectInput.selector);
+        bridge.convert(
+            AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
+            AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
+            AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
+            AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
+            0,
+            0,
+            0,
+            address(0)
+        );
     }
 
     function testFullDepositWithdrawalFlow() public {

--- a/src/test/liquity/StakingBridge.t.sol
+++ b/src/test/liquity/StakingBridge.t.sol
@@ -2,8 +2,10 @@
 // Copyright 2022 Spilsbury Holdings Ltd
 pragma solidity >=0.8.4;
 
-import "./utils/TestUtil.sol";
-import "../../bridges/liquity/StakingBridge.sol";
+import {AztecTypes} from "../../aztec/AztecTypes.sol";
+
+import {TestUtil} from "./utils/TestUtil.sol";
+import {StakingBridge} from "../../bridges/liquity/StakingBridge.sol";
 
 contract StakingBridgeTest is TestUtil {
     StakingBridge private bridge;

--- a/src/test/liquity/StakingBridge.t.sol
+++ b/src/test/liquity/StakingBridge.t.sol
@@ -80,7 +80,7 @@ contract StakingBridgeTest is TestUtil {
             AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
             AztecTypes.AztecAsset(1, tokens["LQTY"].addr, AztecTypes.AztecAssetType.ERC20),
             AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
-            depositAmount,
+            withdrawAmount,
             1,
             0
         );

--- a/src/test/liquity/StakingBridgeInternal.t.sol
+++ b/src/test/liquity/StakingBridgeInternal.t.sol
@@ -2,8 +2,10 @@
 // Copyright 2022 Spilsbury Holdings Ltd
 pragma solidity >=0.8.4;
 
-import "./utils/TestUtil.sol";
-import "../../bridges/liquity/StakingBridge.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import {TestUtil} from "./utils/TestUtil.sol";
+import {StakingBridge} from "../../bridges/liquity/StakingBridge.sol";
 
 abstract contract StakingBridgeTestInternal is TestUtil, StakingBridge(address(0)) {
     function setUp() public {

--- a/src/test/liquity/StakingBridgeInternal.t.sol
+++ b/src/test/liquity/StakingBridgeInternal.t.sol
@@ -9,9 +9,9 @@ abstract contract StakingBridgeTestInternal is TestUtil, StakingBridge(address(0
     function setUp() public {
         _aztecPreSetup();
         setUpTokens();
-        require(IERC20(WETH).approve(address(UNI_ROUTER), type(uint256).max), "StakingBridge: WETH_APPROVE_FAILED");
-        require(IERC20(LUSD).approve(address(UNI_ROUTER), type(uint256).max), "StakingBridge: LUSD_APPROVE_FAILED");
-        require(IERC20(USDC).approve(address(UNI_ROUTER), type(uint256).max), "StakingBridge: USDC_APPROVE_FAILED");
+        require(IERC20(WETH).approve(address(UNI_ROUTER), type(uint256).max), "WETH_APPROVE_FAILED");
+        require(IERC20(LUSD).approve(address(UNI_ROUTER), type(uint256).max), "LUSD_APPROVE_FAILED");
+        require(IERC20(USDC).approve(address(UNI_ROUTER), type(uint256).max), "USDC_APPROVE_FAILED");
     }
 
     function testSwapRewardsToLQTY() public {

--- a/src/test/liquity/StakingBridgeInternal.t.sol
+++ b/src/test/liquity/StakingBridgeInternal.t.sol
@@ -24,7 +24,7 @@ abstract contract StakingBridgeTestInternal is TestUtil, StakingBridge(address(0
         payable(address(0)).transfer(address(this).balance - 1 ether);
 
         uint256 stakedLQTYBeforeSwap = STAKING_CONTRACT.stakes(address(this));
-        _swapRewardsToLQTYAndStake();
+        swapRewardsToLQTYAndStake();
         uint256 stakedLQTYAfterSwap = STAKING_CONTRACT.stakes(address(this));
 
         // Verify that rewards were swapped for non-zero amount and correctly staked

--- a/src/test/liquity/TroveBridge.t.sol
+++ b/src/test/liquity/TroveBridge.t.sol
@@ -9,8 +9,8 @@ import "../../bridges/liquity/TroveBridge.sol";
 contract TroveBridgeTest is TestUtil {
     TroveBridge private bridge;
 
-    IHintHelpers private constant hintHelpers = IHintHelpers(0xE84251b93D9524E0d2e621Ba7dc7cb3579F997C0);
-    ISortedTroves private constant sortedTroves = ISortedTroves(0x8FdD3fbFEb32b28fb73555518f8b361bCeA741A6);
+    IHintHelpers private constant HINT_HELPERS = IHintHelpers(0xE84251b93D9524E0d2e621Ba7dc7cb3579F997C0);
+    ISortedTroves private constant SORTED_TROVES = ISortedTroves(0x8FdD3fbFEb32b28fb73555518f8b361bCeA741A6);
 
     address private constant OWNER = address(24);
 
@@ -108,8 +108,8 @@ contract TroveBridgeTest is TestUtil {
 
         // Drop price and liquidate the trove
         dropLiquityPriceByHalf();
-        bridge.troveManager().liquidate(address(bridge));
-        Status troveStatus = Status(bridge.troveManager().getTroveStatus(address(bridge)));
+        bridge.TROVE_MANAGER().liquidate(address(bridge));
+        Status troveStatus = Status(bridge.TROVE_MANAGER().getTroveStatus(address(bridge)));
         assertTrue(troveStatus == Status.closedByLiquidation);
 
         // Set msg.sender to OWNER
@@ -139,8 +139,8 @@ contract TroveBridgeTest is TestUtil {
         uint256 amountToRedeem = 2e25;
         do {
             deal(tokens["LUSD"].addr, address(this), amountToRedeem);
-            bridge.troveManager().redeemCollateral(amountToRedeem, address(0), address(0), address(0), 0, 0, 1e18);
-        } while (Status(bridge.troveManager().getTroveStatus(address(bridge))) != Status.closedByRedemption);
+            bridge.TROVE_MANAGER().redeemCollateral(amountToRedeem, address(0), address(0), address(0), 0, 0, 1e18);
+        } while (Status(bridge.TROVE_MANAGER().getTroveStatus(address(bridge))) != Status.closedByRedemption);
 
         _redeem();
     }
@@ -155,18 +155,18 @@ contract TroveBridgeTest is TestUtil {
         // The following is Solidity implementation of https://github.com/liquity/dev#opening-a-trove
         uint256 numTrials = 15;
         uint256 randomSeed = 42;
-        (address approxHint, , ) = hintHelpers.getApproxHint(nicr, numTrials, randomSeed);
-        (address upperHint, address lowerHint) = sortedTroves.findInsertPosition(nicr, approxHint, approxHint);
+        (address approxHint, , ) = HINT_HELPERS.getApproxHint(nicr, numTrials, randomSeed);
+        (address upperHint, address lowerHint) = SORTED_TROVES.findInsertPosition(nicr, approxHint, approxHint);
 
         // Open the trove
         bridge.openTrove{value: OWNER_WEI_BALANCE}(upperHint, lowerHint, MAX_FEE);
 
-        uint256 price = bridge.troveManager().priceFeed().fetchPrice();
-        uint256 icr = bridge.troveManager().getCurrentICR(address(bridge), price);
+        uint256 price = bridge.TROVE_MANAGER().priceFeed().fetchPrice();
+        uint256 icr = bridge.TROVE_MANAGER().getCurrentICR(address(bridge), price);
         // Verify the ICR equals the one specified in the bridge constructor
         assertEq(icr, 160e16);
 
-        (uint256 debtAfterBorrowing, uint256 collAfterBorrowing, , ) = bridge.troveManager().getEntireDebtAndColl(
+        (uint256 debtAfterBorrowing, uint256 collAfterBorrowing, , ) = bridge.TROVE_MANAGER().getEntireDebtAndColl(
             address(bridge)
         );
         // Check the TB total supply equals totalDebt
@@ -185,10 +185,10 @@ contract TroveBridgeTest is TestUtil {
     }
 
     function _borrow() private {
-        uint256 price = bridge.troveManager().priceFeed().fetchPrice();
-        uint256 icrBeforeBorrowing = bridge.troveManager().getCurrentICR(address(bridge), price);
+        uint256 price = bridge.TROVE_MANAGER().priceFeed().fetchPrice();
+        uint256 icrBeforeBorrowing = bridge.TROVE_MANAGER().getCurrentICR(address(bridge), price);
 
-        (, uint256 collBeforeBorrowing, , ) = bridge.troveManager().getEntireDebtAndColl(address(bridge));
+        (, uint256 collBeforeBorrowing, , ) = bridge.TROVE_MANAGER().getEntireDebtAndColl(address(bridge));
 
         // Borrow against ROLLUP_PROCESSOR_WEI_BALANCE
         rollupProcessor.convert(
@@ -202,13 +202,13 @@ contract TroveBridgeTest is TestUtil {
             MAX_FEE
         );
 
-        (uint256 debtAfterBorrowing, uint256 collAfterBorrowing, , ) = bridge.troveManager().getEntireDebtAndColl(
+        (uint256 debtAfterBorrowing, uint256 collAfterBorrowing, , ) = bridge.TROVE_MANAGER().getEntireDebtAndColl(
             address(bridge)
         );
         // Check the collateral increase equals ROLLUP_PROCESSOR_WEI_BALANCE
         assertEq(collAfterBorrowing - collBeforeBorrowing, ROLLUP_PROCESSOR_WEI_BALANCE);
 
-        uint256 icrAfterBorrowing = bridge.troveManager().getCurrentICR(address(bridge), price);
+        uint256 icrAfterBorrowing = bridge.TROVE_MANAGER().getCurrentICR(address(bridge), price);
         // Check the the ICR didn't change
         assertEq(icrBeforeBorrowing, icrAfterBorrowing);
 
@@ -270,7 +270,7 @@ contract TroveBridgeTest is TestUtil {
 
         bridge.closeTrove();
 
-        Status troveStatus = Status(bridge.troveManager().getTroveStatus(address(bridge)));
+        Status troveStatus = Status(bridge.TROVE_MANAGER().getTroveStatus(address(bridge)));
         assertTrue(troveStatus == Status.closedByOwner);
 
         // Check the bridge doesn't hold any ETH or LUSD

--- a/src/test/liquity/TroveBridge.t.sol
+++ b/src/test/liquity/TroveBridge.t.sol
@@ -56,7 +56,7 @@ contract TroveBridgeTest is TestUtil {
     function testIncorrectTroveState() public {
         // Attempt borrowing when trove was not opened - state 0
         vm.prank(address(rollupProcessor));
-        vm.expectRevert(TroveBridge.IncorrectStatus.selector);
+        vm.expectRevert(abi.encodeWithSignature("IncorrectStatus(uint8,uint8)", 1, 0));
         bridge.convert(
             AztecTypes.AztecAsset(3, address(0), AztecTypes.AztecAssetType.ETH),
             AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),

--- a/src/test/liquity/TroveBridge.t.sol
+++ b/src/test/liquity/TroveBridge.t.sol
@@ -2,9 +2,12 @@
 // Copyright 2022 Spilsbury Holdings Ltd
 pragma solidity >=0.8.4;
 
-import "./utils/TestUtil.sol";
-import "./interfaces/IHintHelpers.sol";
-import "../../bridges/liquity/TroveBridge.sol";
+import {AztecTypes} from "../../aztec/AztecTypes.sol";
+
+import {TestUtil} from "./utils/TestUtil.sol";
+import {IHintHelpers} from "./interfaces/IHintHelpers.sol";
+import {TroveBridge} from "../../bridges/liquity/TroveBridge.sol";
+import {ISortedTroves} from "../../bridges/liquity/interfaces/ISortedTroves.sol";
 
 contract TroveBridgeTest is TestUtil {
     TroveBridge private bridge;

--- a/src/test/liquity/TroveBridge.t.sol
+++ b/src/test/liquity/TroveBridge.t.sol
@@ -56,43 +56,33 @@ contract TroveBridgeTest is TestUtil {
     function testIncorrectTroveState() public {
         // Attempt borrowing when trove was not opened - state 0
         vm.prank(address(rollupProcessor));
-        try
-            bridge.convert(
-                AztecTypes.AztecAsset(3, address(0), AztecTypes.AztecAssetType.ETH),
-                AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
-                AztecTypes.AztecAsset(2, address(bridge), AztecTypes.AztecAssetType.ERC20),
-                AztecTypes.AztecAsset(1, tokens["LUSD"].addr, AztecTypes.AztecAssetType.ERC20),
-                ROLLUP_PROCESSOR_WEI_BALANCE,
-                0,
-                MAX_FEE,
-                address(0)
-            )
-        {
-            assertTrue(false, "convert(...) has to revert when trove is in an incorrect state.");
-        } catch (bytes memory reason) {
-            assertEq(TroveBridge.IncorrectStatus.selector, bytes4(reason));
-        }
+        vm.expectRevert(TroveBridge.IncorrectStatus.selector);
+        bridge.convert(
+            AztecTypes.AztecAsset(3, address(0), AztecTypes.AztecAssetType.ETH),
+            AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
+            AztecTypes.AztecAsset(2, address(bridge), AztecTypes.AztecAssetType.ERC20),
+            AztecTypes.AztecAsset(1, tokens["LUSD"].addr, AztecTypes.AztecAssetType.ERC20),
+            ROLLUP_PROCESSOR_WEI_BALANCE,
+            0,
+            MAX_FEE,
+            address(0)
+        );
     }
 
     function testIncorrectInput() public {
         // Call convert with incorrect input
         vm.prank(address(rollupProcessor));
-        try
-            bridge.convert(
-                AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
-                AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
-                AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
-                AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
-                0,
-                0,
-                0,
-                address(0)
-            )
-        {
-            assertTrue(false, "convert(...) has to revert on incorrect input.");
-        } catch (bytes memory reason) {
-            assertEq(TroveBridge.IncorrectInput.selector, bytes4(reason));
-        }
+        vm.expectRevert(TroveBridge.IncorrectInput.selector);
+        bridge.convert(
+            AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
+            AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
+            AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
+            AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
+            0,
+            0,
+            0,
+            address(0)
+        );
     }
 
     function testFullFlow() public {
@@ -119,17 +109,11 @@ contract TroveBridgeTest is TestUtil {
         vm.startPrank(OWNER);
 
         // Bridge is now defunct so check that closing and reopening fails with appropriate errors
-        try bridge.closeTrove() {
-            assertTrue(false, "closeTrove() has to revert in case owner's balance != TB total supply.");
-        } catch (bytes memory reason) {
-            assertEq(TroveBridge.OwnerNotLast.selector, bytes4(reason));
-        }
+        vm.expectRevert(TroveBridge.OwnerNotLast.selector);
+        bridge.closeTrove();
 
-        try bridge.openTrove(address(0), address(0), MAX_FEE) {
-            assertTrue(false, "openTrove() has to revert in case TB total supply != 0.");
-        } catch (bytes memory reason) {
-            assertEq(TroveBridge.NonZeroTotalSupply.selector, bytes4(reason));
-        }
+        vm.expectRevert(TroveBridge.NonZeroTotalSupply.selector);
+        bridge.openTrove(address(0), address(0), MAX_FEE);
 
         vm.stopPrank();
     }

--- a/src/test/liquity/interfaces/IHintHelpers.sol
+++ b/src/test/liquity/interfaces/IHintHelpers.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.0;
+pragma solidity >=0.8.4;
 
 interface IHintHelpers {
     function getApproxHint(

--- a/src/test/liquity/utils/MockPriceFeed.sol
+++ b/src/test/liquity/utils/MockPriceFeed.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-only
 pragma solidity >=0.8.4;
 
-import "../../../bridges/liquity/interfaces/IPriceFeed.sol";
+import {IPriceFeed} from "../../../bridges/liquity/interfaces/IPriceFeed.sol";
 
 contract MockPriceFeed is IPriceFeed {
     uint256 public immutable lastGoodPrice;

--- a/src/test/liquity/utils/MockPriceFeed.sol
+++ b/src/test/liquity/utils/MockPriceFeed.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-only
-pragma solidity >=0.8.0 <=0.8.10;
+pragma solidity >=0.8.4;
 
 import "../../../bridges/liquity/interfaces/IPriceFeed.sol";
 

--- a/src/test/liquity/utils/TestUtil.sol
+++ b/src/test/liquity/utils/TestUtil.sol
@@ -2,10 +2,12 @@
 // Copyright 2022 Spilsbury Holdings Ltd
 pragma solidity >=0.8.4;
 
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {Test} from "forge-std/Test.sol";
-import {MockPriceFeed} from "./MockPriceFeed.sol";
 import {DefiBridgeProxy} from "../../../aztec/DefiBridgeProxy.sol";
 import {RollupProcessor} from "../../../aztec/RollupProcessor.sol";
+
+import {MockPriceFeed} from "./MockPriceFeed.sol";
 import {IPriceFeed} from "../../../bridges/liquity/interfaces/IPriceFeed.sol";
 
 contract TestUtil is Test {

--- a/src/test/liquity/utils/TestUtil.sol
+++ b/src/test/liquity/utils/TestUtil.sol
@@ -2,11 +2,11 @@
 // Copyright 2022 Spilsbury Holdings Ltd
 pragma solidity >=0.8.4;
 
-import "forge-std/Test.sol";
-import "./MockPriceFeed.sol";
-import "../../../aztec/DefiBridgeProxy.sol";
-import "../../../aztec/RollupProcessor.sol";
-import "../../../bridges/liquity/interfaces/IPriceFeed.sol";
+import {Test} from "forge-std/Test.sol";
+import {MockPriceFeed} from "./MockPriceFeed.sol";
+import {DefiBridgeProxy} from "../../../aztec/DefiBridgeProxy.sol";
+import {RollupProcessor} from "../../../aztec/RollupProcessor.sol";
+import {IPriceFeed} from "../../../bridges/liquity/interfaces/IPriceFeed.sol";
 
 contract TestUtil is Test {
     DefiBridgeProxy internal defiBridgeProxy;

--- a/src/test/liquity/utils/TestUtil.sol
+++ b/src/test/liquity/utils/TestUtil.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-only
 // Copyright 2022 Spilsbury Holdings Ltd
-pragma solidity >=0.8.0 <=0.8.10;
-pragma abicoder v2;
+pragma solidity >=0.8.4;
 
 import "forge-std/Test.sol";
 import "./MockPriceFeed.sol";

--- a/src/test/set/Set.t.sol
+++ b/src/test/set/Set.t.sol
@@ -64,9 +64,9 @@ contract SetTest is Test {
         uint256 depositAmountDpi = 2e9;
         uint256 depositAmountEth = 1 ether;
 
-        _setTokenBalance(address(DAI), address(rollupProcessor), depositAmountDai, 2);
-        _setTokenBalance(address(DPI), address(rollupProcessor), depositAmountDpi, 0);
-        _setEthBalance(address(rollupProcessor), depositAmountEth);
+        deal(address(DAI), address(rollupProcessor), depositAmountDai);
+        deal(address(DPI), address(rollupProcessor), depositAmountDpi);
+        deal(address(rollupProcessor), depositAmountEth);
 
         uint256 rollupBalanceDai = DAI.balanceOf(address(rollupProcessor));
         uint256 rollupBalanceDpi = DPI.balanceOf(address(rollupProcessor));
@@ -82,7 +82,7 @@ contract SetTest is Test {
     function testIssueSetForExactToken() public {
         // Pre-fund contract with DAI
         uint256 depositAmountDai = 1e21; // 1000 DAI
-        _setTokenBalance(address(DAI), address(rollupProcessor), depositAmountDai, 2);
+        deal(address(DAI), address(rollupProcessor), depositAmountDai);
 
         // Used for unused input/output assets
         AztecTypes.AztecAsset memory empty;
@@ -133,7 +133,7 @@ contract SetTest is Test {
     function testIssueSetForExactEth() public {
         // Pre-fund contract with ETH
         uint256 depositAmountEth = 1e17; // 0.1 ETH
-        _setEthBalance(address(rollupProcessor), depositAmountEth);
+        deal(address(rollupProcessor), depositAmountEth);
 
         // Used for unused input/output assets
         AztecTypes.AztecAsset memory empty;
@@ -183,7 +183,7 @@ contract SetTest is Test {
     function testRedeemExactSetForToken() public {
         // Pre-fund rollup contract DPI
         uint256 depositAmountDpi = 1e20; // 100 DPI
-        _setTokenBalance(address(DPI), address(rollupProcessor), depositAmountDpi, 0);
+        deal(address(DPI), address(rollupProcessor), depositAmountDpi);
 
         // Used for unused input/output assets
         AztecTypes.AztecAsset memory empty;
@@ -236,7 +236,7 @@ contract SetTest is Test {
     function testRedeemExactSetForEth() public {
         // prefund rollup with tokens
         uint256 depositAmountDpi = 1e20; // 100 DPI
-        _setTokenBalance(address(DPI), address(rollupProcessor), depositAmountDpi, 0);
+        deal(address(DPI), address(rollupProcessor), depositAmountDpi);
 
         // Used for unused input/output assets
         AztecTypes.AztecAsset memory empty;
@@ -283,22 +283,5 @@ contract SetTest is Test {
         assertEq(0, rollupBalanceAfterDpi, "DPI balance after convert must match");
 
         assertGt(rollupBalanceAfterEth, 0, "ETH balance after must be > 0");
-    }
-
-    function _setTokenBalance(
-        address token,
-        address user,
-        uint256 balance,
-        uint256 slot // May vary depending on token
-    ) internal {
-        vm.store(token, keccak256(abi.encode(user, slot)), bytes32(uint256(balance)));
-
-        assertEq(IERC20(token).balanceOf(user), balance, "wrong token balance");
-    }
-
-    function _setEthBalance(address user, uint256 balance) internal {
-        vm.deal(user, balance);
-
-        assertEq(user.balance, balance, "wrong ETH balance");
     }
 }

--- a/src/test/set/Set.t.sol
+++ b/src/test/set/Set.t.sol
@@ -12,7 +12,7 @@ import {IController} from "./../../bridges/set/interfaces/IController.sol";
 import {ISetToken} from "./../../bridges/set/interfaces/ISetToken.sol";
 import {AztecTypes} from "./../../aztec/AztecTypes.sol";
 
-import "forge-std/Test.sol";
+import {Test} from "forge-std/Test.sol";
 
 contract SetTest is Test {
     // Aztec


### PR DESCRIPTION
1. Fixed linting errors in Set tests (the bridge itself didn't contain any issues),
2. fixed linting errors in Liquity bridges and tests,
3. updated solhint config to not warn about using block.timestamp,
4. updated solidity versions in src/interfaces/*,
5. using vm.expectRevert(...) instead of try.. catch,
6. ordered functions in Liquity bridges according to solidity style guide,
7. more concise example test.