### PR TITLE
fix: Update solhint to use forked repo with extra rules

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -4,6 +4,13 @@
     "compiler-version": ["error", ">=0.8.4"],
     "func-visibility": ["warn", { "ignoreConstructors": true }],
     "no-empty-blocks": "off",
-    "not-rely-on-time": "off"
+    "not-rely-on-time": "off",
+    "const-name-snakecase": ["warn", { "treatImmutableVarAsConstant": true}],
+    "var-name-mixedcase": ["warn", { "treatImmutableVarAsConstant": true}],
+    "error-name-mixedcase": ["warn"],
+    "private-func-leading-underscore": ["warn"],
+    "private-vars-no-leading-underscore": ["warn"],
+    "func-param-name-leading-underscore": ["warn"],
+    "custom-error-over-require": ["warn"]
   }
 }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "node-fetch": "2.6.7",
     "prettier": "^2.6.2",
     "prettier-plugin-solidity": "^1.0.0-beta.19",
-    "solhint": "^3.3.7",
+    "solhint": "https://github.com/LHerskind/solhint",
     "solhint-plugin-prettier": "^0.0.5",
     "ts-jest": "^27.1.3",
     "ts-node": "^10.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1064,6 +1064,13 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
+"@solidity-parser/parser@^0.13.2":
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.13.2.tgz#b6c71d8ca0b382d90a7bbed241f9bc110af65cbe"
+  integrity sha512-RwHnpRnfrnD2MSPveYoPh8nhofEvX7fgjHk1Oq+NNvCcLx4r1js91CO9o+F/F3fBzOCyvm8kKRTriFICX/odWw==
+  dependencies:
+    antlr4ts "^0.5.0-alpha.4"
+
 "@solidity-parser/parser@^0.14.0", "@solidity-parser/parser@^0.14.1":
   version "0.14.1"
   resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.14.1.tgz#179afb29f4e295a77cc141151f26b3848abc3c46"
@@ -4904,12 +4911,11 @@ solhint-plugin-prettier@^0.0.5:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
-solhint@^3.3.7:
-  version "3.3.7"
-  resolved "https://registry.yarnpkg.com/solhint/-/solhint-3.3.7.tgz#b5da4fedf7a0fee954cb613b6c55a5a2b0063aa7"
-  integrity sha512-NjjjVmXI3ehKkb3aNtRJWw55SUVJ8HMKKodwe0HnejA+k0d2kmhw7jvpa+MCTbcEgt8IWSwx0Hu6aCo/iYOZzQ==
+"solhint@https://github.com/LHerskind/solhint":
+  version "3.3.6"
+  resolved "https://github.com/LHerskind/solhint#f7039525ec319963e2694eef1fbef0344cc7df4a"
   dependencies:
-    "@solidity-parser/parser" "^0.14.1"
+    "@solidity-parser/parser" "^0.13.2"
     ajv "^6.6.1"
     antlr4 "4.7.1"
     ast-parents "0.0.1"


### PR DESCRIPTION
Extends solhint with custom rules that:
- Treat `immutable` as `constant` with regard to naming
- Give a warning if not using CamelCase for custom errors
- Give a warning if using require, or empty revert
- Prefer internal/private functions to have a single leading `_`
- Prefer internal/private variables to NOT have a single leading `_`
- Prefer function argument names to have a single leading `_`