### PR TITLE
feat: Add func-param-name-mixedcase rule

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -11,6 +11,7 @@
     "private-func-leading-underscore": ["warn"],
     "private-vars-no-leading-underscore": ["warn"],
     "func-param-name-leading-underscore": ["warn"],
+    "func-param-name-mixedcase": ["warn"],
     "custom-error-over-require": ["warn"]
   }
 }


### PR DESCRIPTION
Adds an extra rule to the solhint file to ensure that function params are mixed case.