### PR TITLE
fix: Add strict override and import rules + ordering

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -12,6 +12,9 @@
     "private-vars-no-leading-underscore": ["warn"],
     "func-param-name-leading-underscore": ["warn"],
     "func-param-name-mixedcase": ["warn"],
-    "custom-error-over-require": ["warn"]
+    "custom-error-over-require": ["warn"],
+    "strict-override": ["warn"],
+    "strict-import": ["warn"],
+    "ordering": ["warn"]
   }
 }


### PR DESCRIPTION
Extending the solhint rules with rules to ensure that `override` and `import` are specific are specific and that ordering with respect to the soliditylang guidelines is satisfied.