### PR TITLE
fix: Use wstEth in `getExpectedOutput`

### DIFF
--- a/src/client/lido/lido-bridge-data.test.ts
+++ b/src/client/lido/lido-bridge-data.test.ts
@@ -1,4 +1,4 @@
-import { LidoBridgeData } from './lido-bridge-data';
+import { LidoBridgeData } from "./lido-bridge-data";
 import {
   IWstETH,
   ICurvePool,
@@ -6,12 +6,12 @@ import {
   IWstETH__factory,
   ICurvePool__factory,
   ILidoOracle__factory,
-} from '../../../typechain-types';
-import { AztecAsset, AztecAssetType } from '../bridge-data';
-import { BigNumber } from 'ethers';
-import { EthAddress } from '@aztec/barretenberg/address';
+} from "../../../typechain-types";
+import { AztecAsset, AztecAssetType } from "../bridge-data";
+import { BigNumber } from "ethers";
+import { EthAddress } from "@aztec/barretenberg/address";
 
-jest.mock('../aztec/provider', () => ({
+jest.mock("../aztec/provider", () => ({
   createWeb3Provider: jest.fn(),
 }));
 
@@ -19,7 +19,7 @@ type Mockify<T> = {
   [P in keyof T]: jest.Mock | any;
 };
 
-describe('lido bridge data', () => {
+describe("lido bridge data", () => {
   let lidoBridgeData: LidoBridgeData;
   let wstethContract: Mockify<IWstETH>;
   let curvePoolContract: Mockify<ICurvePool>;
@@ -44,27 +44,28 @@ describe('lido bridge data', () => {
     ethAsset = {
       id: 1n,
       assetType: AztecAssetType.ETH,
-      erc20Address: '0x0',
+      erc20Address: "0x0",
     };
     wstETHAsset = {
       id: 2n,
       assetType: AztecAssetType.ERC20,
-      erc20Address: '0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0',
+      erc20Address: "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
     };
     emptyAsset = {
       id: 0n,
       assetType: AztecAssetType.NOT_USED,
-      erc20Address: '0x0',
+      erc20Address: "0x0",
     };
   });
 
-  it('should get wstETH when deposit small amount of ETH - curve route', async () => {
+  it("should get wstETH when deposit small amount of ETH", async () => {
     const depositAmount = BigInt(10e18);
-    const expectedOutput = depositAmount + 1n;
+    const wstEthAmount = BigInt(9.5e18);
+    const expectedOutput = wstEthAmount;
 
-    curvePoolContract = {
-      ...curvePoolContract,
-      get_dy: jest.fn().mockResolvedValue(BigNumber.from(expectedOutput)),
+    wstethContract = {
+      ...wstethContract,
+      getWstETHByStETH: jest.fn().mockResolvedValue(BigNumber.from(wstEthAmount)),
     };
 
     lidoBridgeData = createLidoBridgeData(wstethContract as any, curvePoolContract as any, lidoOracleContract as any);
@@ -79,13 +80,14 @@ describe('lido bridge data', () => {
     );
     expect(expectedOutput == output[0]).toBeTruthy();
   });
-  it('should get wstETH when deposit a large amount of ETH - lido route', async () => {
-    const depositAmount = BigInt(10000000e18);
-    const expectedOutput = depositAmount;
+  it("should get wstETH when deposit a large amount of ETH", async () => {
+    const depositAmount = BigInt(10000e18);
+    const wstEthAmount = BigInt(9500e18);
+    const expectedOutput = wstEthAmount;
 
-    curvePoolContract = {
-      ...curvePoolContract,
-      get_dy: jest.fn().mockResolvedValue(BigNumber.from(depositAmount - 1n)),
+    wstethContract = {
+      ...wstethContract,
+      getWstETHByStETH: jest.fn().mockResolvedValue(BigNumber.from(wstEthAmount)),
     };
 
     lidoBridgeData = createLidoBridgeData(wstethContract as any, curvePoolContract as any, lidoOracleContract as any);
@@ -100,9 +102,9 @@ describe('lido bridge data', () => {
     );
     expect(expectedOutput == output[0]).toBeTruthy();
   });
-  it('should exit to ETH when deposit WstETH', async () => {
+  it("should exit to ETH when deposit WstETH", async () => {
     const depositAmount = BigInt(100e18);
-    const stethOutputAmount = BigInt(101e18);
+    const stethOutputAmount = BigInt(110e18);
     const expectedOutput = BigInt(105e18);
 
     wstethContract = {
@@ -129,7 +131,7 @@ describe('lido bridge data', () => {
     expect(expectedOutput == output[0]).toBeTruthy();
   });
 
-  it('should correctly return the expectedYearlyOutput', async () => {
+  it("should correctly return the expectedYearlyOutput", async () => {
     const depositAmount = BigInt(1 * 10e18);
     const expectedOutput = 4.32;
 

--- a/src/client/lido/lido-bridge-data.ts
+++ b/src/client/lido/lido-bridge-data.ts
@@ -5,7 +5,7 @@ import {
   SolidityType,
   AztecAssetType,
   BridgeDataFieldGetters,
-} from '../bridge-data';
+} from "../bridge-data";
 
 import {
   IWstETH,
@@ -14,10 +14,10 @@ import {
   IWstETH__factory,
   ILidoOracle__factory,
   ICurvePool__factory,
-} from '../../../typechain-types';
-import { EthereumProvider } from '@aztec/barretenberg/blockchain';
-import { createWeb3Provider } from '../aztec/provider';
-import { EthAddress } from '@aztec/barretenberg/address';
+} from "../../../typechain-types";
+import { EthereumProvider } from "@aztec/barretenberg/blockchain";
+import { createWeb3Provider } from "../aztec/provider";
+import { EthAddress } from "@aztec/barretenberg/address";
 
 export class LidoBridgeData implements BridgeDataFieldGetters {
   public scalingFactor: bigint = 1n * 10n ** 18n;
@@ -47,7 +47,7 @@ export class LidoBridgeData implements BridgeDataFieldGetters {
       start: 0,
       length: 64,
       solidityType: SolidityType.uint64,
-      description: 'Not Used',
+      description: "Not Used",
     },
   ];
 
@@ -76,12 +76,9 @@ export class LidoBridgeData implements BridgeDataFieldGetters {
   ): Promise<bigint[]> {
     // ETH -> wstETH
     if (inputAssetA.assetType == AztecAssetType.ETH) {
-      const curveMinOutput = await this.curvePoolContract.get_dy(0, 1, inputValue);
-      if (curveMinOutput.toBigInt() > inputValue) {
-        return [curveMinOutput.toBigInt()];
-      } else {
-        return [inputValue];
-      }
+      // Assume ETH -> stETh 1:1 (there will be a tiny diff because rounding down)
+      const wstETHBalance = await this.wstETHContract.getWstETHByStETH(inputValue);
+      return [wstETHBalance.toBigInt()];
     }
 
     // wstETH -> ETH


### PR DESCRIPTION
Update the Lido client data class to use `wstEth` instead of `stEth` in the expected, and remove the curve route to match the underlying Lido bridge. 