### PR TITLE
fix: Remove virtual from IDefiBridge interface

### DIFF
--- a/src/interfaces/IDefiBridge.sol
+++ b/src/interfaces/IDefiBridge.sol
@@ -55,7 +55,6 @@ interface IDefiBridge {
     )
         external
         payable
-        virtual
         returns (
             uint256 outputValueA,
             uint256 outputValueB,
@@ -82,7 +81,6 @@ interface IDefiBridge {
     )
         external
         payable
-        virtual
         returns (
             uint256 outputValueA,
             uint256 outputValueB,


### PR DESCRIPTION
# Description

Remove `virtual` from the `IDefiBridge.sol` as they are redundant.

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] There are no unexpected formatting changes, or superfluous debug logs.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewers next convenience.
