### PR TITLE
Lh/base bridge

### DIFF
--- a/src/bridges/aceofzk/AceOfZkBridge.sol
+++ b/src/bridges/aceofzk/AceOfZkBridge.sol
@@ -2,23 +2,15 @@
 pragma solidity >=0.8.4;
 
 import {IERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
-import {IRollupProcessor} from "../../interfaces/IRollupProcessor.sol";
-import {IDefiBridge} from "../../interfaces/IDefiBridge.sol";
 import {AztecTypes} from "../../aztec/AztecTypes.sol";
+import {BridgeBase} from "../base/BridgeBase.sol";
 
-contract AceOfZkBridge is IDefiBridge {
-    error InvalidCaller();
-    error AsyncDisabled();
-
+contract AceOfZkBridge is BridgeBase {
     address public constant ACE_OF_ZK_NFT = 0xE56B526E532804054411A470C49715c531CFd485;
     address public constant NFT_HOLDER = 0xE298a76986336686CC3566469e3520d23D1a8aaD;
     uint256 public constant NFT_ID = 16;
 
-    address public immutable ROLLUP_PROCESSOR;
-
-    constructor(address _rollupProcessor) {
-        ROLLUP_PROCESSOR = _rollupProcessor;
-    }
+    constructor(address _rollupProcessor) BridgeBase(_rollupProcessor) {}
 
     function convert(
         AztecTypes.AztecAsset calldata,
@@ -32,37 +24,15 @@ contract AceOfZkBridge is IDefiBridge {
     )
         external
         payable
+        override(BridgeBase)
+        onlyRollup
         returns (
             uint256,
             uint256,
             bool
         )
     {
-        if (msg.sender != ROLLUP_PROCESSOR) {
-            revert InvalidCaller();
-        }
-
         IERC721(ACE_OF_ZK_NFT).transferFrom(NFT_HOLDER, ROLLUP_PROCESSOR, NFT_ID);
-
         return (0, 0, false);
-    }
-
-    function finalise(
-        AztecTypes.AztecAsset calldata,
-        AztecTypes.AztecAsset calldata,
-        AztecTypes.AztecAsset calldata,
-        AztecTypes.AztecAsset calldata,
-        uint256,
-        uint64
-    )
-        external
-        payable
-        returns (
-            uint256,
-            uint256,
-            bool
-        )
-    {
-        revert AsyncDisabled();
     }
 }

--- a/src/bridges/base/BridgeBase.sol
+++ b/src/bridges/base/BridgeBase.sol
@@ -12,7 +12,7 @@ import {ErrorLib} from "./ErrorLib.sol";
  * @dev Reverts `convert` with missing implementation, and `finalise` with async disabled
  * @author Lasse Herskind
  */
-contract BridgeBase is IDefiBridge {
+abstract contract BridgeBase is IDefiBridge {
     error MissingImplementation();
 
     address public immutable ROLLUP_PROCESSOR;

--- a/src/bridges/base/BridgeBase.sol
+++ b/src/bridges/base/BridgeBase.sol
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright 2022 Spilsbury Holdings Ltd
+pragma solidity >=0.8.4;
+
+import {IDefiBridge} from "../../interfaces/IDefiBridge.sol";
+import {AztecTypes} from "../../aztec/AztecTypes.sol";
+import {ErrorLib} from "./ErrorLib.sol";
+
+/**
+ * @title BridgeBase
+ * @notice A base that bridges can be built upon which imports a limited set of features
+ * @dev Reverts `convert` with missing implementation, and `finalise` with async disabled
+ * @author Lasse Herskind
+ */
+contract BridgeBase is IDefiBridge {
+    error MissingImplementation();
+
+    address public immutable ROLLUP_PROCESSOR;
+
+    constructor(address _rollupProcessor) {
+        ROLLUP_PROCESSOR = _rollupProcessor;
+    }
+
+    modifier onlyRollup() {
+        if (msg.sender != ROLLUP_PROCESSOR) {
+            revert ErrorLib.InvalidCaller();
+        }
+        _;
+    }
+
+    function convert(
+        AztecTypes.AztecAsset calldata,
+        AztecTypes.AztecAsset calldata,
+        AztecTypes.AztecAsset calldata,
+        AztecTypes.AztecAsset calldata,
+        uint256,
+        uint256,
+        uint64,
+        address
+    )
+        external
+        payable
+        virtual
+        override(IDefiBridge)
+        returns (
+            uint256,
+            uint256,
+            bool
+        )
+    {
+        revert MissingImplementation();
+    }
+
+    function finalise(
+        AztecTypes.AztecAsset calldata,
+        AztecTypes.AztecAsset calldata,
+        AztecTypes.AztecAsset calldata,
+        AztecTypes.AztecAsset calldata,
+        uint256,
+        uint64
+    )
+        external
+        payable
+        virtual
+        override(IDefiBridge)
+        returns (
+            uint256,
+            uint256,
+            bool
+        )
+    {
+        revert ErrorLib.AsyncDisabled();
+    }
+}

--- a/src/bridges/base/ErrorLib.sol
+++ b/src/bridges/base/ErrorLib.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright 2022 Spilsbury Holdings Ltd
+pragma solidity >=0.8.4;
+
+library ErrorLib {
+    error InvalidCaller();
+
+    error InvalidInputA();
+    error InvalidInputB();
+    error InvalidOutputA();
+    error InvalidOutputB();
+    error InvalidInputAmount();
+    error InvalidAuxData();
+
+    error InvalidNonce();
+    error AsyncDisabled();
+}

--- a/src/bridges/element/ElementBridge.sol
+++ b/src/bridges/element/ElementBridge.sol
@@ -14,7 +14,8 @@ import {IRollupProcessor} from "../../interfaces/IRollupProcessor.sol";
 import {MinHeap} from "./MinHeap.sol";
 import {FullMath} from "../uniswapv3/libraries/FullMath.sol";
 
-import {IDefiBridge} from "../../interfaces/IDefiBridge.sol";
+import {BridgeBase} from "../base/BridgeBase.sol";
+import {ErrorLib} from "../base/ErrorLib.sol";
 
 import {AztecTypes} from "../../aztec/AztecTypes.sol";
 
@@ -23,7 +24,7 @@ import {AztecTypes} from "../../aztec/AztecTypes.sol";
  * @dev Smart contract responsible for depositing, managing and redeeming Defi interactions with the Element protocol
  */
 
-contract ElementBridge is IDefiBridge {
+contract ElementBridge is BridgeBase {
     using MinHeap for MinHeap.MinHeapData;
 
     /*----------------------------------------
@@ -32,14 +33,12 @@ contract ElementBridge is IDefiBridge {
     error INVALID_TRANCHE();
     error INVALID_WRAPPED_POSITION();
     error INVALID_POOL();
-    error INVALID_CALLER();
     error ASSET_IDS_NOT_EQUAL();
     error ASSET_NOT_ERC20();
     error INPUT_ASSETB_NOT_UNUSED();
     error OUTPUT_ASSETB_NOT_UNUSED();
     error INTERACTION_ALREADY_EXISTS();
     error POOL_NOT_FOUND();
-    error UNKNOWN_NONCE();
     error BRIDGE_NOT_READY();
     error ALREADY_FINALISED();
     error TRANCHE_POSITION_MISMATCH();
@@ -138,9 +137,6 @@ contract ElementBridge is IDefiBridge {
     // mapping containing the block number in which a tranche was configured
     mapping(address => uint256) private trancheDeploymentBlockNumbers;
 
-    // the aztec rollup processor contract
-    address public immutable rollupProcessor;
-
     // the balancer contract
     address private immutable balancerAddress;
 
@@ -184,8 +180,7 @@ contract ElementBridge is IDefiBridge {
         bytes32 _trancheBytecodeHash,
         address _balancerVaultAddress,
         address _elementDeploymentValidatorAddress
-    ) {
-        rollupProcessor = _rollupProcessor;
+    ) BridgeBase(_rollupProcessor) {
         trancheFactory = _trancheFactory;
         trancheBytecodeHash = _trancheBytecodeHash;
         balancerAddress = _balancerVaultAddress;
@@ -376,7 +371,7 @@ contract ElementBridge is IDefiBridge {
     function getTrancheDeploymentBlockNumber(uint256 interactionNonce) public view returns (uint256 blockNumber) {
         Interaction storage interaction = interactions[interactionNonce];
         if (interaction.expiry == 0) {
-            revert UNKNOWN_NONCE();
+            revert ErrorLib.InvalidNonce();
         }
         blockNumber = trancheDeploymentBlockNumbers[interaction.trancheAddress];
     }
@@ -439,7 +434,8 @@ contract ElementBridge is IDefiBridge {
     )
         external
         payable
-        override
+        override(BridgeBase)
+        onlyRollup
         returns (
             uint256 outputValueA,
             uint256 outputValueB,
@@ -448,10 +444,6 @@ contract ElementBridge is IDefiBridge {
     {
         int64 gasAtStart = int64(int256(gasleft()));
         int64 gasUsed = 0;
-        // ### INITIALIZATION AND SANITY CHECKS
-        if (msg.sender != rollupProcessor) {
-            revert INVALID_CALLER();
-        }
         if (inputAssetA.id != outputAssetA.id) {
             revert ASSET_IDS_NOT_EQUAL();
         }
@@ -599,7 +591,7 @@ contract ElementBridge is IDefiBridge {
             }
             uint256 gasForFinalise = gasRemaining - ourGasFloor;
             // make the call to finalise the interaction with the gas limit
-            try IRollupProcessor(rollupProcessor).processAsyncDefiInteraction{gas: gasForFinalise}(nonce) returns (
+            try IRollupProcessor(ROLLUP_PROCESSOR).processAsyncDefiInteraction{gas: gasForFinalise}(nonce) returns (
                 bool interactionCompleted
             ) {
                 // no need to do anything here, we just need to know that the call didn't throw
@@ -624,7 +616,8 @@ contract ElementBridge is IDefiBridge {
     )
         external
         payable
-        override
+        override(BridgeBase)
+        onlyRollup
         returns (
             uint256 outputValueA,
             uint256 outputValueB,
@@ -633,13 +626,10 @@ contract ElementBridge is IDefiBridge {
     {
         int64 gasAtStart = int64(int256(gasleft()));
         int64 gasUsed = 0;
-        if (msg.sender != rollupProcessor) {
-            revert INVALID_CALLER();
-        }
         // retrieve the interaction and verify it's ready for finalising
         Interaction storage interaction = interactions[interactionNonce];
         if (interaction.expiry == 0) {
-            revert UNKNOWN_NONCE();
+            revert ErrorLib.InvalidNonce();
         }
         if (interaction.expiry >= block.timestamp) {
             revert BRIDGE_NOT_READY();
@@ -720,7 +710,7 @@ contract ElementBridge is IDefiBridge {
         }
 
         // approve the transfer of funds back to the rollup contract
-        ERC20(outputAssetA.erc20Address).approve(rollupProcessor, amountToAllocate);
+        ERC20(outputAssetA.erc20Address).approve(ROLLUP_PROCESSOR, amountToAllocate);
         interaction.finalised = true;
         popInteractionFromNonceMapping(interaction, interactionNonce);
         outputValueA = amountToAllocate;

--- a/src/bridges/example/ExampleBridge.sol
+++ b/src/bridges/example/ExampleBridge.sol
@@ -3,61 +3,37 @@
 pragma solidity >=0.8.4;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import {IDefiBridge} from "../../interfaces/IDefiBridge.sol";
 import {AztecTypes} from "../../aztec/AztecTypes.sol";
+import {BridgeBase} from "../base/BridgeBase.sol";
 
-contract ExampleBridgeContract is IDefiBridge {
+contract ExampleBridgeContract is BridgeBase {
     error InvalidCaller();
     error AsyncModeDisabled();
 
-    address public immutable rollupProcessor;
-
-    constructor(address _rollupProcessor) public {
-        rollupProcessor = _rollupProcessor;
-    }
+    constructor(address _rollupProcessor) BridgeBase(_rollupProcessor) {}
 
     function convert(
         AztecTypes.AztecAsset memory inputAssetA,
-        AztecTypes.AztecAsset memory inputAssetB,
-        AztecTypes.AztecAsset memory outputAssetA,
-        AztecTypes.AztecAsset memory outputAssetB,
+        AztecTypes.AztecAsset memory,
+        AztecTypes.AztecAsset memory,
+        AztecTypes.AztecAsset memory,
         uint256 totalInputValue,
-        uint256 interactionNonce,
-        uint64 auxData,
-        address rollupBeneficiary
+        uint256,
+        uint64,
+        address
     )
         external
         payable
-        override
+        override(BridgeBase)
+        onlyRollup
         returns (
             uint256 outputValueA,
-            uint256 outputValueB,
-            bool isAsync
-        )
-    {
-        // ### INITIALIZATION AND SANITY CHECKS
-        if (msg.sender != rollupProcessor) revert InvalidCaller();
-        outputValueA = totalInputValue;
-        IERC20(inputAssetA.erc20Address).approve(rollupProcessor, totalInputValue);
-    }
-
-    function finalise(
-        AztecTypes.AztecAsset calldata inputAssetA,
-        AztecTypes.AztecAsset calldata inputAssetB,
-        AztecTypes.AztecAsset calldata outputAssetA,
-        AztecTypes.AztecAsset calldata outputAssetB,
-        uint256 interactionNonce,
-        uint64 auxData
-    )
-        external
-        payable
-        override
-        returns (
-            uint256,
             uint256,
             bool
         )
     {
-        revert AsyncModeDisabled();
+        // ### INITIALIZATION AND SANITY CHECKS
+        outputValueA = totalInputValue;
+        IERC20(inputAssetA.erc20Address).approve(ROLLUP_PROCESSOR, totalInputValue);
     }
 }

--- a/src/bridges/mStable/MStableBridge.sol
+++ b/src/bridges/mStable/MStableBridge.sol
@@ -9,14 +9,10 @@ import {IMStableAsset} from "./interfaces/IMStableAsset.sol";
 import {IMStableSavingsContract} from "./interfaces/IMStableSavingsContract.sol";
 import {IDefiBridge} from "../../interfaces/IDefiBridge.sol";
 import {AztecTypes} from "../../aztec/AztecTypes.sol";
+import {BridgeBase} from "../base/BridgeBase.sol";
 
-contract MStableBridge is IDefiBridge {
-    // the aztec rollup processor contract
-    address public immutable rollupProcessor;
-
-    constructor(address _rollupProcessor) {
-        rollupProcessor = _rollupProcessor;
-    }
+contract MStableBridge is BridgeBase {
+    constructor(address _rollupProcessor) BridgeBase(_rollupProcessor) {}
 
     // convert the input asset to the output asset
     // serves as the 'on ramp' to the interaction
@@ -26,21 +22,20 @@ contract MStableBridge is IDefiBridge {
         AztecTypes.AztecAsset calldata outputAssetA,
         AztecTypes.AztecAsset calldata,
         uint256 totalInputValue,
-        uint256 interactionNonce,
+        uint256,
         uint64 auxData,
-        address rollupBeneficiary
+        address
     )
         external
         payable
+        override(BridgeBase)
+        onlyRollup
         returns (
             uint256 outputValueA,
-            uint256 outputValueB,
+            uint256,
             bool isAsync
         )
     {
-        // ### INITIALIZATION AND SANITY CHECKS
-        require(msg.sender == rollupProcessor, "MStableBridge: INVALID_CALLER");
-
         require(inputAssetA.id != outputAssetA.id, "MStableBridge: ASSET_IDS_EQUAL");
 
         require(inputAssetA.assetType == AztecTypes.AztecAssetType.ERC20, "MStableBridge: NOT_ERC20");
@@ -61,32 +56,13 @@ contract MStableBridge is IDefiBridge {
 
             outputValueA = IMStableSavingsContract(imUSD).depositSavings(massetsMinted); // Deposit into save
 
-            ERC20(imUSD).approve(rollupProcessor, outputValueA);
+            ERC20(imUSD).approve(ROLLUP_PROCESSOR, outputValueA);
         } else {
             uint256 redeemedMUSD = IMStableSavingsContract(imUSD).redeemCredits(totalInputValue);
             uint256 minimumBAssetToRedeem = (redeemedMUSD * ((uint256(10000) - uint256(auxData)))) / 10000;
             uint256 redeemedValue = IMStableAsset(mUSD).redeem(dai, redeemedMUSD, minimumBAssetToRedeem, address(this));
             outputValueA = redeemedValue;
-            ERC20(dai).approve(rollupProcessor, outputValueA);
+            ERC20(dai).approve(ROLLUP_PROCESSOR, outputValueA);
         }
-    }
-
-    function finalise(
-        AztecTypes.AztecAsset calldata inputAssetA,
-        AztecTypes.AztecAsset calldata inputAssetB,
-        AztecTypes.AztecAsset calldata outputAssetA,
-        AztecTypes.AztecAsset calldata outputAssetB,
-        uint256 interactionNonce,
-        uint64 auxData
-    )
-        external
-        payable
-        returns (
-            uint256,
-            uint256,
-            bool
-        )
-    {
-        require(false);
     }
 }

--- a/src/bridges/rai/RaiBridge.sol
+++ b/src/bridges/rai/RaiBridge.sol
@@ -6,7 +6,6 @@ pragma experimental ABIEncoderV2;
 import {SafeMath} from "@openzeppelin/contracts/utils/math/SafeMath.sol";
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
-import {IDefiBridge} from "../../interfaces/IDefiBridge.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 import {AztecTypes} from "../../aztec/AztecTypes.sol";
@@ -18,15 +17,15 @@ import {ISafeManager} from "./interfaces/ISafeManager.sol";
 import {IWETH} from "../../interfaces/IWETH.sol";
 import {AggregatorV3Interface} from "./interfaces/AggregatorV3Interface.sol";
 import {IRollupProcessor} from "../../interfaces/IRollupProcessor.sol";
+import {BridgeBase} from "../base/BridgeBase.sol";
 
 // NOTE:
 // 1. Theres a minimum amount of RAI to be borrowed in the first call, which is currently 1469 RAI
 // 2. You can find the readme for the contract here: https://gist.github.com/realdiganta/2c73f86820bf7310bd934184fa960e3d
 
-contract RaiBridge is ERC20, IDefiBridge {
+contract RaiBridge is ERC20, BridgeBase {
     using SafeMath for uint256;
 
-    address public immutable rollupProcessor;
     AggregatorV3Interface internal priceFeed = AggregatorV3Interface(0x4ad7B025127e89263242aB68F0f9c4E5C033B489);
     address public constant SAFE_ENGINE = 0xCC88a9d330da1133Df3A7bD823B95e52511A6962;
     address public constant SAFE_MANAGER = 0xEfe0B4cA532769a3AE758fD82E1426a03A94F185;
@@ -43,9 +42,7 @@ contract RaiBridge is ERC20, IDefiBridge {
         address _rollupProcessor,
         string memory _name,
         string memory _symbol
-    ) ERC20(_name, _symbol) {
-        rollupProcessor = _rollupProcessor;
-
+    ) ERC20(_name, _symbol) BridgeBase(_rollupProcessor) {
         // OPEN THE SAFE
         safeId = ISafeManager(SAFE_MANAGER).openSAFE(
             0x4554482d41000000000000000000000000000000000000000000000000000000,
@@ -56,9 +53,9 @@ contract RaiBridge is ERC20, IDefiBridge {
 
         // do all one off approvals
         require(IWETH(WETH).approve(ETH_JOIN, type(uint256).max), "Weth approve failed");
-        require(IWETH(WETH).approve(rollupProcessor, type(uint256).max), "Weth approve failed");
+        require(IWETH(WETH).approve(ROLLUP_PROCESSOR, type(uint256).max), "Weth approve failed");
         require(IERC20(RAI).approve(COIN_JOIN, type(uint256).max), "Rai approve failed");
-        require(IERC20(RAI).approve(rollupProcessor, type(uint256).max), "Rai approve failed");
+        require(IERC20(RAI).approve(ROLLUP_PROCESSOR, type(uint256).max), "Rai approve failed");
         ISafeEngine(SAFE_ENGINE).approveSAFEModification(COIN_JOIN);
     }
 
@@ -100,15 +97,14 @@ contract RaiBridge is ERC20, IDefiBridge {
     )
         external
         payable
+        override(BridgeBase)
+        onlyRollup
         returns (
             uint256 outputValueA,
             uint256 outputValueB,
             bool isAsync
         )
     {
-        // ### INITIALIZATION AND SANITY CHECKS
-        require(msg.sender == rollupProcessor, "RaiBridge: INVALID_CALLER");
-
         if (inputAssetA.assetType == AztecTypes.AztecAssetType.ETH) {
             // transfer to weth
             IWETH(WETH).deposit{value: msg.value}();
@@ -132,7 +128,7 @@ contract RaiBridge is ERC20, IDefiBridge {
                 if (outputAssetA.assetType == AztecTypes.AztecAssetType.ETH) {
                     // change weth to eth
                     IWETH(WETH).withdraw(outputValueA);
-                    IRollupProcessor(rollupProcessor).receiveEthFromBridge{value: outputValueA}(interactionNonce);
+                    IRollupProcessor(ROLLUP_PROCESSOR).receiveEthFromBridge{value: outputValueA}(interactionNonce);
                 }
             }
         } else {
@@ -143,7 +139,7 @@ contract RaiBridge is ERC20, IDefiBridge {
             );
             isInitialized = true;
 
-            require(IERC20(address(this)).approve(rollupProcessor, type(uint256).max), "BridgeTokens approve failed");
+            require(IERC20(address(this)).approve(ROLLUP_PROCESSOR, type(uint256).max), "BridgeTokens approve failed");
 
             (, int256 raiToEth, , , ) = priceFeed.latestRoundData();
 
@@ -153,25 +149,6 @@ contract RaiBridge is ERC20, IDefiBridge {
             outputValueB = outputValueA;
             _mint(address(this), outputValueB);
         }
-    }
-
-    function finalise(
-        AztecTypes.AztecAsset calldata inputAssetA,
-        AztecTypes.AztecAsset calldata inputAssetB,
-        AztecTypes.AztecAsset calldata outputAssetA,
-        AztecTypes.AztecAsset calldata outputAssetB,
-        uint256 interactionNonce,
-        uint64 auxData
-    )
-        external
-        payable
-        returns (
-            uint256,
-            uint256,
-            bool
-        )
-    {
-        require(false);
     }
 
     // ------------------------------- INTERNAL FUNCTIONS -------------------------------------------------

--- a/src/test/compound/Compound.t.sol
+++ b/src/test/compound/Compound.t.sol
@@ -10,6 +10,7 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import {ICERC20} from "./../../bridges/compound/interfaces/ICERC20.sol";
 import {CompoundBridge} from "./../../bridges/compound/CompoundBridge.sol";
+import {ErrorLib} from "./../../bridges/base/ErrorLib.sol";
 
 contract CompoundTest is Test {
     // solhint-disable-next-line
@@ -50,7 +51,7 @@ contract CompoundTest is Test {
             uint8 underlyingDecimals = 18;
             uint256 exchangeRate = ICERC20(cETH).exchangeRateCurrent();
             uint256 oneCTokenInUnderlying = (exchangeRate * 1e18) / (10**(18 + underlyingDecimals - 8));
-            depositAmount = bound(_depositAmount, oneCTokenInUnderlying, 10000 * 10**underlyingDecimals);
+            depositAmount = bound(_depositAmount, 10 * oneCTokenInUnderlying, 10000 * 10**underlyingDecimals);
         }
 
         vm.deal(address(rollupProcessor), depositAmount);
@@ -124,11 +125,11 @@ contract CompoundTest is Test {
     function testInvalidCaller() public {
         AztecTypes.AztecAsset memory empty;
 
-        vm.expectRevert(CompoundBridge.InvalidCaller.selector);
+        vm.expectRevert(ErrorLib.InvalidCaller.selector);
         compoundBridge.convert(empty, empty, empty, empty, 0, 0, 0, address(0));
     }
 
-    function testIncorrectInputAsset() public {
+    function testInvalidInputAsset() public {
         AztecTypes.AztecAsset memory empty;
 
         AztecTypes.AztecAsset memory ethAsset = AztecTypes.AztecAsset({
@@ -138,15 +139,15 @@ contract CompoundTest is Test {
         });
 
         vm.prank(address(rollupProcessor));
-        vm.expectRevert(CompoundBridge.IncorrectInputAsset.selector);
+        vm.expectRevert(ErrorLib.InvalidInputA.selector);
         compoundBridge.convert(ethAsset, empty, empty, empty, 0, 0, 1, address(0));
     }
 
-    function testIncorrectOutputAsset() public {
+    function testInvalidOutputAsset() public {
         AztecTypes.AztecAsset memory empty;
 
         vm.prank(address(rollupProcessor));
-        vm.expectRevert(CompoundBridge.IncorrectOutputAsset.selector);
+        vm.expectRevert(ErrorLib.InvalidOutputA.selector);
         compoundBridge.convert(empty, empty, empty, empty, 0, 0, 0, address(0));
     }
 
@@ -154,8 +155,16 @@ contract CompoundTest is Test {
         AztecTypes.AztecAsset memory empty;
 
         vm.prank(address(rollupProcessor));
-        vm.expectRevert(CompoundBridge.IncorrectAuxData.selector);
+        vm.expectRevert(ErrorLib.InvalidAuxData.selector);
         compoundBridge.convert(empty, empty, empty, empty, 0, 0, 2, address(0));
+    }
+
+    function testFinalise() public {
+        AztecTypes.AztecAsset memory empty;
+
+        vm.prank(address(rollupProcessor));
+        vm.expectRevert(ErrorLib.AsyncDisabled.selector);
+        compoundBridge.finalise(empty, empty, empty, empty, 0, 0);
     }
 
     function _depositAndWithdrawERC20(address _cToken, uint256 _depositAmount) private {
@@ -166,7 +175,7 @@ contract CompoundTest is Test {
             uint8 underlyingDecimals = 18;
             uint256 exchangeRate = ICERC20(_cToken).exchangeRateCurrent();
             uint256 oneCTokenInUnderlying = (exchangeRate * 1e18) / (10**(18 + underlyingDecimals - 8));
-            depositAmount = bound(_depositAmount, oneCTokenInUnderlying, 10000 * 10**underlyingDecimals);
+            depositAmount = bound(_depositAmount, 10 * oneCTokenInUnderlying, 10000 * 10**underlyingDecimals);
         }
 
         deal(underlyingToken, address(rollupProcessor), depositAmount);

--- a/src/test/element/Element.t.sol
+++ b/src/test/element/Element.t.sol
@@ -15,6 +15,7 @@ import {ITranche} from "../../bridges/element/interfaces/ITranche.sol";
 import {IPool} from "../../bridges/element/interfaces/IPool.sol";
 import {IWrappedPosition} from "../../bridges/element/interfaces/IWrappedPosition.sol";
 import {MockDeploymentValidator} from "./MockDeploymentValidator.sol";
+import {ErrorLib} from "../../bridges/base/ErrorLib.sol";
 
 import {AztecTypes} from "./../../aztec/AztecTypes.sol";
 
@@ -46,8 +47,8 @@ contract ElementTest is Test {
     bytes32 private constant BYTE_CODE_HASH = 0xf481a073666136ab1f5e93b296e84df58092065256d0db23b2d22b62c68e978d;
     address private constant TRANCHE_FACTORY_ADDRESS = 0x62F161BF3692E4015BefB05A03a94A40f520d1c0;
 
-    int64 private constant DAI_CONVERT_GAS = 237954;
-    int64 private constant USDC_FINALISE_GAS = 224844;
+    int64 private constant DAI_CONVERT_GAS = 237914;
+    int64 private constant USDC_FINALISE_GAS = 224810;
 
     uint256[] private timestamps = [
         1640995200, //Jan 01 2022
@@ -646,7 +647,7 @@ contract ElementTest is Test {
         uint256 depositAmount = 15000;
         _setTokenBalance("DAI", address(elementBridge), depositAmount);
 
-        vm.expectRevert(abi.encodeWithSelector(ElementBridge.INVALID_CALLER.selector));
+        vm.expectRevert(abi.encodeWithSelector(ErrorLib.InvalidCaller.selector));
         elementBridge.convert(
             inputAsset,
             emptyAsset,
@@ -757,12 +758,12 @@ contract ElementTest is Test {
         assertEq(blockNumber, block.number); // block.number = convergentPoolBlockNumber
     }
 
-    function testRetrieveTrancheDeploymentBlockNumberFailsForUnknownNonce() public {
+    function testRetrieveTrancheDeploymentBlockNumberFailsForInvalidNonce() public {
         TrancheConfig storage config = trancheConfigs["DAI"][0];
         _setupConvergentPool(config);
 
         // unknown nonce should revert
-        vm.expectRevert(abi.encodeWithSelector(ElementBridge.UNKNOWN_NONCE.selector));
+        vm.expectRevert(abi.encodeWithSelector(ErrorLib.InvalidNonce.selector));
         elementBridge.getTrancheDeploymentBlockNumber(12345);
     }
 
@@ -789,17 +790,17 @@ contract ElementTest is Test {
             erc20Address: address(tokens["DAI"]),
             assetType: AztecTypes.AztecAssetType.ERC20
         });
-        vm.expectRevert(abi.encodeWithSelector(ElementBridge.INVALID_CALLER.selector));
+        vm.expectRevert(abi.encodeWithSelector(ErrorLib.InvalidCaller.selector));
         elementBridge.finalise(asset, emptyAsset, asset, emptyAsset, 1, trancheConfigs["DAI"][0].expiry);
     }
 
-    function testRejectFinaliseUnknownNonce() public {
+    function testRejectFinaliseInvalidNonce() public {
         AztecTypes.AztecAsset memory asset = AztecTypes.AztecAsset({
             id: 1,
             erc20Address: address(tokens["DAI"]),
             assetType: AztecTypes.AztecAssetType.ERC20
         });
-        vm.expectRevert(abi.encodeWithSelector(ElementBridge.UNKNOWN_NONCE.selector));
+        vm.expectRevert(abi.encodeWithSelector(ErrorLib.InvalidNonce.selector));
         vm.prank(address(rollupProcessor));
         elementBridge.finalise(asset, emptyAsset, asset, emptyAsset, 6, trancheConfigs["DAI"][0].expiry);
     }

--- a/src/test/example/Example.t.sol
+++ b/src/test/example/Example.t.sol
@@ -10,6 +10,7 @@ import {Test} from "forge-std/Test.sol";
 // Example-specific imports
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {ExampleBridgeContract} from "./../../bridges/example/ExampleBridge.sol";
+import {ErrorLib} from "../../bridges/base/ErrorLib.sol";
 
 contract ExampleTest is Test {
     IERC20 public constant DAI = IERC20(0x6B175474E89094C44Da98b954EedeAC495271d0F);
@@ -34,7 +35,7 @@ contract ExampleTest is Test {
         address callerAddress = address(bytes20(uint160(uint256(keccak256("non-rollup-processor-address")))));
 
         vm.prank(callerAddress);
-        vm.expectRevert(ExampleBridgeContract.InvalidCaller.selector);
+        vm.expectRevert(ErrorLib.InvalidCaller.selector);
         exampleBridge.convert(empty, empty, empty, empty, 0, 0, 0, address(0));
     }
 

--- a/src/test/lido/Lido.t.sol
+++ b/src/test/lido/Lido.t.sol
@@ -10,6 +10,7 @@ import {RollupProcessor} from "./../../aztec/RollupProcessor.sol";
 
 import {LidoBridge} from "./../../bridges/lido/LidoBridge.sol";
 import {AztecTypes} from "./../../aztec/AztecTypes.sol";
+import {ErrorLib} from "./../../bridges/base/ErrorLib.sol";
 
 contract LidoTest is Test {
     // solhint-disable-next-line
@@ -34,21 +35,21 @@ contract LidoTest is Test {
     }
 
     function testErrorCodes() public {
-        vm.expectRevert(LidoBridge.InvalidCaller.selector);
+        vm.expectRevert(ErrorLib.InvalidCaller.selector);
         bridge.convert(empty, empty, empty, empty, 0, 0, 0, address(0));
 
         vm.startPrank(address(rollupProcessor));
 
-        vm.expectRevert(LidoBridge.InvalidInput.selector);
+        vm.expectRevert(ErrorLib.InvalidInputA.selector);
         bridge.convert(empty, empty, empty, empty, 0, 0, 0, address(0));
 
-        vm.expectRevert(LidoBridge.InvalidOutput.selector);
+        vm.expectRevert(ErrorLib.InvalidOutputA.selector);
         bridge.convert(ethAsset, empty, empty, empty, 0, 0, 0, address(0));
 
-        vm.expectRevert(LidoBridge.InvalidOutput.selector);
+        vm.expectRevert(ErrorLib.InvalidOutputA.selector);
         bridge.convert(wstETHAsset, empty, empty, empty, 0, 0, 0, address(0));
 
-        vm.expectRevert(LidoBridge.AsyncDisabled.selector);
+        vm.expectRevert(ErrorLib.AsyncDisabled.selector);
         bridge.finalise(wstETHAsset, empty, empty, empty, 0, 0);
 
         vm.stopPrank();

--- a/src/test/set/Set.t.sol
+++ b/src/test/set/Set.t.sol
@@ -12,6 +12,8 @@ import {IController} from "./../../bridges/set/interfaces/IController.sol";
 import {ISetToken} from "./../../bridges/set/interfaces/ISetToken.sol";
 import {AztecTypes} from "./../../aztec/AztecTypes.sol";
 
+import {ErrorLib} from "../../bridges/base/ErrorLib.sol";
+
 import {Test} from "forge-std/Test.sol";
 
 contract SetTest is Test {
@@ -36,13 +38,16 @@ contract SetTest is Test {
         tokens[0] = address(DAI);
         tokens[1] = address(DPI);
         issuanceBridge.approveTokens(tokens);
+
+        vm.label(tokens[0], "DAI");
+        vm.label(tokens[1], "DPI");
     }
 
     function testInvalidCaller() public {
         AztecTypes.AztecAsset memory empty;
 
         vm.prank(address(124));
-        vm.expectRevert(IssuanceBridge.InvalidCaller.selector);
+        vm.expectRevert(ErrorLib.InvalidCaller.selector);
         issuanceBridge.convert(empty, empty, empty, empty, 0, 0, 0, address(0));
     }
 


### PR DESCRIPTION
# Description

Adds an `ErrorLib` that has a couple of widely used error codes that can be used across bridges. The error codes related to `InvalidUser` and `InvalidInputA` etc. 

Creates an abstract `BridgeBase` contract that stores the rollup processor address, and implements `convert` that reverts with `MissingImplementation` and `finalise` that reverts with `AsyncDisabled`. The intention for `finalise` reverting with the error is that this is the expected behaviour whenever the bridge is Synchronous, so it removes some clutter from the actual bridges. Also, it implements an `onlyRollup()` modifier, which reverts with `InvalidCaller` if the `msg.sender != ROLLUP_PROCESSOR`. 

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] There are no unexpected formatting changes, or superfluous debug logs.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewers next convenience.
