### PR TITLE
emit block number from compound setup

### DIFF
--- a/src/test/bridges/compound/Compound.t.sol
+++ b/src/test/bridges/compound/Compound.t.sol
@@ -40,6 +40,7 @@ contract CompoundTest is Test {
     CompoundBridge internal compoundBridge;
 
     function setUp() public {
+        emit log_named_uint("block number", block.number);
         defiBridgeProxy = new DefiBridgeProxy();
         rollupProcessor = new RollupProcessor(address(defiBridgeProxy));
         compoundBridge = new CompoundBridge(address(rollupProcessor));


### PR DESCRIPTION
# Description

Add a log of `block.number` in the compound, that will make it easier to find the blocks where we run into #119.

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] There are no unexpected formatting changes, or superfluous debug logs.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewers next convenience.
