### PR TITLE
Implementation of changes based on the Compound audit

### DIFF
--- a/src/bridges/compound/CompoundBridge.sol
+++ b/src/bridges/compound/CompoundBridge.sol
@@ -104,7 +104,6 @@ contract CompoundBridge is BridgeBase {
                 cToken.mint{value: msg.value}();
                 outputValueA = cToken.balanceOf(address(this));
             } else if (_inputAssetA.assetType == AztecTypes.AztecAssetType.ERC20) {
-                IERC20 tokenIn = IERC20(_inputAssetA.erc20Address);
                 ICERC20 tokenOut = ICERC20(_outputAssetA.erc20Address);
                 tokenOut.mint(_inputValue);
                 outputValueA = tokenOut.balanceOf(address(this));

--- a/src/bridges/compound/CompoundBridge.sol
+++ b/src/bridges/compound/CompoundBridge.sol
@@ -143,12 +143,16 @@ contract CompoundBridge is BridgeBase {
             IERC20 underlying = IERC20(_cToken.underlying());
             // Using safeIncreaseAllowance(...) instead of approve(...) here because underlying can be Tether;
             allowance = underlying.allowance(address(this), address(_cToken));
-            if (allowance < type(uint256).max) {
-                underlying.safeIncreaseAllowance(address(_cToken), type(uint256).max - allowance);
+            if (allowance != type(uint256).max) {
+                // Resetting allowance to 0 in order to avoid issues with USDT
+                underlying.safeApprove(address(_cToken), 0);
+                underlying.safeApprove(address(_cToken), type(uint256).max);
             }
             allowance = underlying.allowance(address(this), ROLLUP_PROCESSOR);
-            if (allowance < type(uint256).max) {
-                underlying.safeIncreaseAllowance(ROLLUP_PROCESSOR, type(uint256).max - allowance);
+            if (allowance != type(uint256).max) {
+                // Resetting allowance to 0 in order to avoid issues with USDT
+                underlying.safeApprove(ROLLUP_PROCESSOR, 0);
+                underlying.safeApprove(ROLLUP_PROCESSOR, type(uint256).max);
             }
         }
     }

--- a/src/bridges/compound/CompoundBridge.sol
+++ b/src/bridges/compound/CompoundBridge.sol
@@ -38,7 +38,7 @@ contract CompoundBridge is BridgeBase {
     receive() external payable {}
 
     /**
-     * @notice Set all the necessary approvals for a given cToken and its underlying
+     * @notice Set all the necessary approvals for a given cToken and its underlying.
      * @param _cToken - cToken address
      */
     function preApprove(address _cToken) external {
@@ -49,8 +49,6 @@ contract CompoundBridge is BridgeBase {
 
     /**
      * @notice Set all the necessary approvals for all the cTokens registered in Comptroller.
-     * @dev Note: It could happen that this function would revert in case some of the allowances were not 0. If this
-     *      happens call the preApprove(...) function for the given tokens individually.
      */
     function preApproveAll() external {
         address[] memory cTokens = COMPTROLLER.getAllMarkets();
@@ -140,7 +138,7 @@ contract CompoundBridge is BridgeBase {
         }
         if (address(_cToken) != cETH) {
             IERC20 underlying = IERC20(_cToken.underlying());
-            // Using safeIncreaseAllowance(...) instead of approve(...) here because underlying can be Tether;
+            // Using safeApprove(...) instead of approve(...) here because underlying can be Tether;
             allowance = underlying.allowance(address(this), address(_cToken));
             if (allowance != type(uint256).max) {
                 // Resetting allowance to 0 in order to avoid issues with USDT

--- a/src/interfaces/compound/IComptroller.sol
+++ b/src/interfaces/compound/IComptroller.sol
@@ -1,0 +1,17 @@
+pragma solidity >=0.8.4;
+
+interface IComptroller {
+    /// @notice A list of all markets
+    function allMarkets(uint256 i) external view returns (address);
+
+    function getAllMarkets() external view returns (address[] memory);
+
+    function markets(address market)
+        external
+        view
+        returns (
+            bool isListed,
+            uint256 collateralFactorMantissa,
+            bool isComped
+        );
+}

--- a/src/test/bridges/compound/Compound.t.sol
+++ b/src/test/bridges/compound/Compound.t.sol
@@ -91,7 +91,10 @@ contract CompoundTest is BridgeTestBase {
     function testERC20DepositAndWithdrawal(uint88 _depositAmount, uint88 _redeemAmount) public {
         address[] memory cTokens = bridge.COMPTROLLER().getAllMarkets();
         for (uint256 i; i < cTokens.length; ++i) {
-            _depositAndWithdrawERC20(cTokens[i], _depositAmount, _redeemAmount);
+            address cToken = cTokens[i];
+            if (cToken != cETH) {
+                _depositAndWithdrawERC20(cToken, _depositAmount, _redeemAmount);
+            }
         }
     }
 

--- a/src/test/bridges/compound/Compound.t.sol
+++ b/src/test/bridges/compound/Compound.t.sol
@@ -28,6 +28,7 @@ contract CompoundTest is BridgeTestBase {
 
     CompoundBridge internal bridge;
     uint256 internal id;
+    mapping(address => bool) internal isDeprecated;
 
     function setUp() public {
         emit log_named_uint("block number", block.number);
@@ -40,6 +41,10 @@ contract CompoundTest is BridgeTestBase {
         ROLLUP_PROCESSOR.setSupportedBridge(address(bridge), 5000000);
 
         id = ROLLUP_PROCESSOR.getSupportedBridgesLength();
+
+        isDeprecated[0x158079Ee67Fce2f58472A96584A73C7Ab9AC95c1] = true; // cREP - Augur v1
+        isDeprecated[0xC11b1268C1A384e55C48c2391d8d480264A3A7F4] = true; // legacy cWBTC token
+        isDeprecated[0xF5DCe57282A584D2746FaF1593d3121Fcac444dC] = true; // cSAI
     }
 
     function testPreApprove() public {
@@ -92,7 +97,7 @@ contract CompoundTest is BridgeTestBase {
         address[] memory cTokens = bridge.COMPTROLLER().getAllMarkets();
         for (uint256 i; i < cTokens.length; ++i) {
             address cToken = cTokens[i];
-            if (cToken != cETH) {
+            if (!isDeprecated[cToken] && cToken != cETH) {
                 _depositAndWithdrawERC20(cToken, _depositAmount, _redeemAmount);
             }
         }

--- a/src/test/bridges/compound/Compound.t.sol
+++ b/src/test/bridges/compound/Compound.t.sol
@@ -74,7 +74,7 @@ contract CompoundTest is BridgeTestBase {
             }
             if (address(cToken) != cETH) {
                 IERC20 underlying = IERC20(cToken.underlying());
-                // Using safeIncreaseAllowance(...) instead of approve(...) here because underlying can be Tether;
+                // Using safeApprove(...) instead of approve(...) here because underlying can be Tether;
                 allowance = underlying.allowance(address(this), address(cToken));
                 if (allowance != type(uint256).max) {
                     underlying.safeApprove(address(cToken), 0);


### PR DESCRIPTION
# Description

These were the issues mentioned in the audit:

1. The safeIncreaseAllowance() might revert if the current allowance is not 0
>  We've addressed this issue by pre-approving the tokens. There are 2 new methods `preApprove` and `preApproveAll`. `preApproveAll` sets the approvals for all the cTokens from Comptroller and its underlying tokens. `preApprove` sets the approvals for ` cToken and its underlying. By pre-approving the tokens once to the maximum the probability of this issue occurring gets significantly diminished.

2. Only allow valid cToken contracts from Compound
> We've decided that this is not an issue because the bridge doesn't have any state.

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] There are no unexpected formatting changes, or superfluous debug logs.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewers next convenience.
