### PR TITLE
Jcf/interaction present value share

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "rootDir": "./src"
   },
   "name": "@aztec/bridge-clients",
-  "version": "0.1.47",
+  "version": "0.1.48",
   "description": "This repo contains the solidity files and typescript helper class for all of the Aztec Connect Bridge Contracts",
   "repository": "git@github.com:AztecProtocol/aztec-connect-bridges.git",
   "license": "MIT",

--- a/src/client/bridge-data.ts
+++ b/src/client/bridge-data.ts
@@ -36,10 +36,10 @@ export interface AuxDataConfig {
 
 export interface BridgeDataFieldGetters {
   /*
-  @dev This function should be implemented for stateful bridges. It's purpose is to tell the developer using the bridge the value of a given interaction.
-  @dev The value should be returned as an array of AssetValue's
+  @dev This function should be implemented for stateful bridges. It's purpose is to tell the developer using the bridge
+  @dev the value of the user's share of a given interaction. The value should be returned as an array of `AssetValue`s.
   */
-  getInteractionPresentValue?(interactionNonce: bigint): Promise<AssetValue[]>;
+  getInteractionPresentValue?(interactionNonce: bigint, inputValue: bigint): Promise<AssetValue[]>;
 
   /*
   @dev This function should be implemented for all bridges that use auxData that require onchain data. It's purpose is to tell the developer using the bridge

--- a/src/client/element/element-bridge-data.test.ts
+++ b/src/client/element/element-bridge-data.test.ts
@@ -148,14 +148,16 @@ describe('element bridge data', () => {
       finalised: false,
       failed: false,
     } as Interaction;
+    const totalInput = defiEvents.find(x => x.nonce === 56)!.totalInputValue;
+    const userShareDivisor = 2n;
     const defiEvent = getDefiEvent(56)!;
-    const [daiValue] = await elementBridgeData.getInteractionPresentValue(56n);
+    const [daiValue] = await elementBridgeData.getInteractionPresentValue(56n, totalInput / userShareDivisor);
     const delta = outputValue - defiEvent.totalInputValue;
     const scalingFactor = elementBridgeData.scalingFactor;
     const ratio = ((BigInt(now) - startDate) * scalingFactor) / (expiration1 - startDate);
     const out = defiEvent.totalInputValue + (delta * ratio) / scalingFactor;
 
-    expect(daiValue.amount).toStrictEqual(out);
+    expect(daiValue.amount).toStrictEqual(out / userShareDivisor);
     expect(Number(daiValue.assetId)).toStrictEqual(bridge1.inputAssetIdA);
   });
 
@@ -171,14 +173,18 @@ describe('element bridge data', () => {
         finalised: false,
         failed: false,
       } as Interaction;
+      const totalInput = defiEvents.find(x => x.nonce === nonce)!.totalInputValue;
+      const userShareDivisor = 2n;
 
-      const [daiValue] = await elementBridgeData.getInteractionPresentValue(BigInt(nonce));
+      const [daiValue] = await elementBridgeData.getInteractionPresentValue(
+        BigInt(nonce),
+        totalInput / userShareDivisor,
+      );
       const delta = interactions[nonce].quantityPT.toBigInt() - defiEvent.totalInputValue;
       const scalingFactor = elementBridgeData.scalingFactor;
       const ratio = ((BigInt(now) - startDate) * scalingFactor) / (BigInt(bridgeId.auxData) - startDate);
       const out = defiEvent.totalInputValue + (delta * ratio) / scalingFactor;
-
-      expect(daiValue.amount).toStrictEqual(out);
+      expect(daiValue.amount).toStrictEqual(out / userShareDivisor);
       expect(Number(daiValue.assetId)).toStrictEqual(bridgeId.inputAssetIdA);
     };
     await testInteraction(56);
@@ -193,7 +199,7 @@ describe('element bridge data', () => {
 
   it('requesting the present value of an unknown interaction should return empty values', async () => {
     const elementBridgeData = createElementBridgeData();
-    const values = await elementBridgeData.getInteractionPresentValue(57n);
+    const values = await elementBridgeData.getInteractionPresentValue(57n, 0n);
     expect(values).toStrictEqual([]);
   });
 

--- a/src/client/element/element-bridge-data.test.ts
+++ b/src/client/element/element-bridge-data.test.ts
@@ -153,9 +153,9 @@ describe('element bridge data', () => {
     const defiEvent = getDefiEvent(56)!;
     const [daiValue] = await elementBridgeData.getInteractionPresentValue(56n, totalInput / userShareDivisor);
     const delta = outputValue - defiEvent.totalInputValue;
-    const scalingFactor = elementBridgeData.scalingFactor;
-    const ratio = ((BigInt(now) - startDate) * scalingFactor) / (expiration1 - startDate);
-    const out = defiEvent.totalInputValue + (delta * ratio) / scalingFactor;
+    const timeElapsed = BigInt(now) - startDate;
+    const fullTime = expiration1 - startDate;
+    const out = defiEvent.totalInputValue + (delta * timeElapsed) / fullTime;
 
     expect(daiValue.amount).toStrictEqual(out / userShareDivisor);
     expect(Number(daiValue.assetId)).toStrictEqual(bridge1.inputAssetIdA);
@@ -181,9 +181,9 @@ describe('element bridge data', () => {
         totalInput / userShareDivisor,
       );
       const delta = interactions[nonce].quantityPT.toBigInt() - defiEvent.totalInputValue;
-      const scalingFactor = elementBridgeData.scalingFactor;
-      const ratio = ((BigInt(now) - startDate) * scalingFactor) / (BigInt(bridgeId.auxData) - startDate);
-      const out = defiEvent.totalInputValue + (delta * ratio) / scalingFactor;
+      const timeElapsed = BigInt(now) - startDate;
+      const fullTime = BigInt(bridgeId.auxData) - startDate;
+      const out = defiEvent.totalInputValue + (delta * timeElapsed) / fullTime;
       expect(daiValue.amount).toStrictEqual(out / userShareDivisor);
       expect(Number(daiValue.assetId)).toStrictEqual(bridgeId.inputAssetIdA);
     };

--- a/src/client/element/element-bridge-data.ts
+++ b/src/client/element/element-bridge-data.ts
@@ -204,8 +204,7 @@ export class ElementBridgeData implements BridgeDataFieldGetters {
     const timeRatio = divide(elapsedTime, totalTime, this.scalingFactor);
     const accruedInterest = (totalInterest * timeRatio) / this.scalingFactor;
     const totalPresentValue = defiEvent.totalInputValue + accruedInterest;
-    const shareRatio = divide(inputValue, defiEvent.totalInputValue, this.scalingFactor);
-    const userPresentValue = (totalPresentValue * shareRatio) / this.scalingFactor;
+    const userPresentValue = (totalPresentValue * defiEvent.totalInputValue) / defiEvent.totalInputValue;
 
     return [
       {

--- a/src/client/element/element-bridge-data.ts
+++ b/src/client/element/element-bridge-data.ts
@@ -201,10 +201,9 @@ export class ElementBridgeData implements BridgeDataFieldGetters {
     const totalInterest = endValue.toBigInt() - defiEvent.totalInputValue;
     const elapsedTime = BigInt(now - defiEvent.timestamp);
     const totalTime = exitTimestamp.toBigInt() - BigInt(defiEvent.timestamp);
-    const timeRatio = divide(elapsedTime, totalTime, this.scalingFactor);
-    const accruedInterest = (totalInterest * timeRatio) / this.scalingFactor;
+    const accruedInterest = (totalInterest * elapsedTime) / totalTime;
     const totalPresentValue = defiEvent.totalInputValue + accruedInterest;
-    const userPresentValue = (totalPresentValue * defiEvent.totalInputValue) / defiEvent.totalInputValue;
+    const userPresentValue = (totalPresentValue * inputValue) / defiEvent.totalInputValue;
 
     return [
       {

--- a/src/client/element/element-bridge-data.ts
+++ b/src/client/element/element-bridge-data.ts
@@ -54,7 +54,7 @@ function divide(a: bigint, b: bigint, precision: bigint) {
   return (a * precision) / b;
 }
 
-const decodeEvent = async (event: AsyncDefiBridgeProcessedEvent) => {
+const decodeEvent = async (event: AsyncDefiBridgeProcessedEvent): Promise<EventBlock> => {
   const {
     args: [bridgeId, nonce, totalInputValue],
   } = event;
@@ -181,7 +181,7 @@ export class ElementBridgeData implements BridgeDataFieldGetters {
   // @dev which define how much a given interaction is worth in terms of Aztec asset ids.
   // @param bigint interactionNonce the interaction nonce to return the value for
 
-  async getInteractionPresentValue(interactionNonce: bigint): Promise<AssetValue[]> {
+  async getInteractionPresentValue(interactionNonce: bigint, inputValue: bigint): Promise<AssetValue[]> {
     const interaction = await this.elementBridgeContract.interactions(interactionNonce);
     if (interaction === undefined) {
       return [];
@@ -202,12 +202,15 @@ export class ElementBridgeData implements BridgeDataFieldGetters {
     const elapsedTime = BigInt(now - defiEvent.timestamp);
     const totalTime = exitTimestamp.toBigInt() - BigInt(defiEvent.timestamp);
     const timeRatio = divide(elapsedTime, totalTime, this.scalingFactor);
-    const accruedInterst = (totalInterest * timeRatio) / this.scalingFactor;
+    const accruedInterest = (totalInterest * timeRatio) / this.scalingFactor;
+    const totalPresentValue = defiEvent.totalInputValue + accruedInterest;
+    const shareRatio = divide(inputValue, defiEvent.totalInputValue, this.scalingFactor);
+    const userPresentValue = (totalPresentValue * shareRatio) / this.scalingFactor;
 
     return [
       {
         assetId: BigInt(BridgeId.fromBigInt(defiEvent.bridgeId).inputAssetIdA),
-        amount: defiEvent.totalInputValue + accruedInterst,
+        amount: userPresentValue,
       },
     ];
   }


### PR DESCRIPTION
# Description

Pass a user's deposit value into `getInteractionPresentValue` such that we can calculate the user's share of the total value.

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] There are no unexpected formatting changes, or superfluous debug logs.
- [ ] The branch has been rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewers next convenience.
