### PR TITLE
Jcf/fix element get present value

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "rootDir": "./src"
   },
   "name": "@aztec/bridge-clients",
-  "version": "0.1.48",
+  "version": "0.1.49",
   "description": "This repo contains the solidity files and typescript helper class for all of the Aztec Connect Bridge Contracts",
   "repository": "git@github.com:AztecProtocol/aztec-connect-bridges.git",
   "license": "MIT",

--- a/src/client/element/element-bridge-data.ts
+++ b/src/client/element/element-bridge-data.ts
@@ -119,9 +119,7 @@ export class ElementBridgeData implements BridgeDataFieldGetters {
   }
 
   private async getCurrentBlock() {
-    const currentBlockNumber = await this.elementBridgeContract.provider.getBlockNumber();
-    const currentBlock = await this.elementBridgeContract.provider.getBlock(currentBlockNumber);
-    return currentBlock;
+    return this.elementBridgeContract.provider.getBlock("latest");
   }
 
   private async findDefiEventForNonce(interactionNonce: bigint) {


### PR DESCRIPTION
# Description

Occasionally `getInteractionPresentValue` errors from `provider.getBlock(currentBlockNumber)` returning `null`. It seems likely that `provider.getBlockNumber()` can return a number higher than that of the most recently parsed block, so it is safer to instead use `getBlock("latest")`.

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] There are no unexpected formatting changes, or superfluous debug logs.
- [ ] The branch has been rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewers next convenience.
