### PR TITLE
Uniswap LP Bridge: Updated testing, and fixed linting errors. 

### DIFF
--- a/src/bridges/uniswap_lp/AztecKeeper.sol
+++ b/src/bridges/uniswap_lp/AztecKeeper.sol
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.4;
+
+import {KeeperCompatibleInterface} from "../../interfaces/uniswapv3/KeeperCompatibleInterface.sol";
+import {TickMath} from "../../libraries/uniswapv3/TickMath.sol";
+import {IRollupProcessor} from "../../aztec/interfaces/IRollupProcessor.sol";
+import {IUniswapV3Pool} from "../../interfaces/uniswapv3/IUniswapV3Pool.sol";
+import {IUniswapV3Factory} from "../../interfaces/uniswapv3/IUniswapV3Factory.sol";
+
+interface IBridge {
+    function getDeposit(uint256 _interactionNonce)
+        external
+        view
+        returns (
+            uint256,
+            uint128,
+            uint256,
+            uint256,
+            int24,
+            int24,
+            uint24,
+            address,
+            address
+        );
+}
+
+contract AztecKeeper is KeeperCompatibleInterface {
+    /**
+     * Public counter variable
+     */
+    uint256 public counter;
+
+    /**
+     * Use an interval in seconds and a timestamp to slow execution of Upkeep
+     */
+
+    uint256 public immutable INTERVAL;
+    uint256 public lastTimeStamp;
+
+    IUniswapV3Factory private immutable FACTORY;
+    IBridge private immutable BRIDGE;
+    IRollupProcessor private immutable ROLLUP_PROCESSOR;
+
+    constructor(
+        uint256 _updateInterval,
+        address _factory,
+        address _rollupProcessor,
+        address _bridge
+    ) {
+        INTERVAL = _updateInterval;
+        lastTimeStamp = block.timestamp;
+        FACTORY = IUniswapV3Factory(_factory);
+        ROLLUP_PROCESSOR = IRollupProcessor(_rollupProcessor);
+        BRIDGE = IBridge(_bridge);
+        counter = 0;
+    }
+
+    function performUpkeep(bytes calldata _performData) external override(KeeperCompatibleInterface) {
+        lastTimeStamp = block.timestamp;
+        counter = counter + 1;
+        uint256[] memory finalisable = abi.decode(_performData, (uint256[]));
+        uint256 length = finalisable.length;
+        for (uint256 i = 0; i < length; i++) {
+            if (finalisable[i] != 0) {
+                bytes memory payload = abi.encodeWithSignature("trigger(uint256)", finalisable[i]);
+                (, bytes memory data) = address(BRIDGE).call(payload);
+                //not used, uncomment to use
+                //(uint256 out0, uint256 out1) = abi.decode(data, (uint256, uint256));
+                ROLLUP_PROCESSOR.processAsyncDefiInteraction(finalisable[i]);
+            }
+        }
+    }
+
+    function checkUpkeep(bytes calldata _checkData)
+        external
+        view
+        override(KeeperCompatibleInterface)
+        returns (bool upkeepNeeded, bytes memory performData)
+    {
+        // We don't use the checkData in this example. The checkData is defined when the Upkeep was registered.
+        uint256[] memory interactions = abi.decode(_checkData, (uint256[]));
+        uint256 length = interactions.length;
+        uint256[] memory finalisable = new uint256[](length);
+
+        uint256 finalisableCtr = 0;
+        IUniswapV3Pool pool;
+
+        for (uint256 i = 0; i < length; i++) {
+            (
+                ,
+                ,
+                uint256 amount0,
+                uint256 amount1,
+                int24 tickLower,
+                int24 tickUpper,
+                uint24 fee,
+                address token0,
+                address token1
+            ) = BRIDGE.getDeposit(interactions[i]);
+            pool = IUniswapV3Pool(FACTORY.getPool(token0, token1, fee));
+            (uint160 sqrtPriceX96, , , , , , ) = pool.slot0();
+            int24 currentTick = TickMath.getTickAtSqrtRatio(sqrtPriceX96);
+
+            if (tickLower <= currentTick && currentTick <= tickUpper) {
+                finalisable[finalisableCtr] = interactions[i];
+                finalisableCtr++;
+            }
+        }
+        performData = abi.encode(finalisable);
+        upkeepNeeded = (block.timestamp - lastTimeStamp) > INTERVAL && performData.length != 0;
+    }
+}

--- a/src/bridges/uniswap_lp/ParentUniLPBridge.sol
+++ b/src/bridges/uniswap_lp/ParentUniLPBridge.sol
@@ -1,0 +1,419 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2022 Aztec.
+pragma solidity >=0.8.4;
+
+import {IERC721Receiver} from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import {IRollupProcessor} from "../../aztec/interfaces/IRollupProcessor.sol";
+import {IQuoter} from "../../interfaces/uniswapv3/IQuoter.sol";
+import {INonfungiblePositionManager} from "../../interfaces/uniswapv3/INonfungiblePositionManager.sol";
+import {IUniswapV3Factory} from "../../interfaces/uniswapv3/IUniswapV3Factory.sol";
+import {IUniswapV3Pool} from "../../interfaces/uniswapv3/IUniswapV3Pool.sol";
+import {ISwapRouter} from "../../interfaces/uniswapv3/ISwapRouter.sol";
+import {IWETH9} from "../../interfaces/uniswapv3/IWETH9.sol";
+
+import {PeripheryImmutableState} from "../../interfaces/uniswapv3/base/PeripheryImmutableState.sol";
+import {LiquidityManagement} from "../../interfaces/uniswapv3/base/LiquidityManagement.sol";
+import {AztecTypes} from "../../aztec/libraries/AztecTypes.sol";
+import {LiquidityAmounts} from "../../libraries/uniswapv3/LiquidityAmounts.sol";
+import {TransferHelper} from "../../libraries/uniswapv3/TransferHelper.sol";
+import {TickMath} from "../../libraries/uniswapv3/TickMath.sol";
+
+contract ParentUniLPBridge is LiquidityManagement, IERC721Receiver {
+    using SafeERC20 for IERC20;
+
+    struct Deposit {
+        uint256 tokenId;
+        uint128 liquidity;
+        uint256 amount0;
+        uint256 amount1;
+        int24 tickLower;
+        int24 tickUpper;
+        uint24 fee;
+        address token0;
+        address token1;
+    }
+
+    error IncorrectSpacing();
+    error InsufficientLiquidity();
+    error InvalidOutputs();
+
+    mapping(uint256 => Deposit) public deposits; //interaction nonce -> deposit struct
+
+    IRollupProcessor public immutable ROLLUP_PROCESSOR;
+    ISwapRouter public immutable SWAP_ROUTER = ISwapRouter(0xE592427A0AEce92De3Edee1F18E0157C05861564);
+    INonfungiblePositionManager public immutable NONFUNGIBLE_POSITION_MANAGER =
+        INonfungiblePositionManager(0xC36442b4a4522E871399CD717aBDD847Ab11FE88);
+    IUniswapV3Factory public immutable UNISWAP_FACTORY = IUniswapV3Factory(0x1F98431c8aD98523631AE4a59f267346ea31F984);
+    IWETH9 public immutable WETH = IWETH9(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
+
+    constructor(address _rollupProcessor) public PeripheryImmutableState(address(UNISWAP_FACTORY), address(WETH)) {
+        ROLLUP_PROCESSOR = IRollupProcessor(_rollupProcessor);
+    }
+
+    function onERC721Received(
+        address,
+        address,
+        uint256,
+        bytes calldata
+    ) external override(IERC721Receiver) returns (bytes4) {
+        return this.onERC721Received.selector;
+    }
+
+    /**
+     * @notice  gets the present value of a position
+     * @dev gets the value of a position by converting liquidity to expected amounts using uniswap helper fxns
+     * we use this way because deposits.amount0 and deposits.amount1 might return positive for an interaction that
+     * is finalised or no longer live, and nonfungiblepositionamanger.positions() doesn't return an amount0 or amount1, only liquidity
+     * @param _interactionNonce the interactionNonce of the specific interaction in question
+     * @return amount0 the shalf of the position's value in token0 terms
+     * @return amount1 the half of the position's value in token1 terms
+     */
+    function getPresentValue(uint256 _interactionNonce) external view returns (uint256 amount0, uint256 amount1) {
+        //calculate using LIquidityAmounts.sol library
+        uint160 sqrtPriceX96;
+
+        {
+            IUniswapV3Pool pool = IUniswapV3Pool(
+                UNISWAP_FACTORY.getPool(
+                    deposits[_interactionNonce].token0,
+                    deposits[_interactionNonce].token0,
+                    deposits[_interactionNonce].fee
+                )
+            );
+
+            (sqrtPriceX96, , , , , , ) = pool.slot0();
+        }
+
+        (amount0, amount1) = LiquidityAmounts.getAmountsForLiquidity(
+            sqrtPriceX96,
+            TickMath.getSqrtRatioAtTick(deposits[_interactionNonce].tickLower),
+            TickMath.getSqrtRatioAtTick(deposits[_interactionNonce].tickUpper),
+            deposits[_interactionNonce].liquidity
+        );
+    }
+
+    /**
+     * @notice  gets the liquidity in a specific tick range within a pool
+     * @dev we are concerned with the specific liquidity of a tick range, not the overall liquidity.
+     * Uniswap pools do not provide this as a public variable unlike overall liquidity but we can calculate it
+     * by using tickBitmap which provides the liquidity of a specific tick. we simply iterate over the user's defined tick range
+     * and sum up the liquidity
+     * @param _tokenA the first token (not necessarily token0)
+     * @param _tokenB the second token
+     * @param _auxData auxdata containing ticklower, tickupper, and fee tier of pool
+     * @return balance0 liquidity in terms of token0
+     * @return balance1 liquidity in terms of token1
+     */
+    function getLiquidity(
+        address _tokenA,
+        address _tokenB,
+        uint64 _auxData
+    ) external view returns (uint256 balance0, uint256 balance1) {
+        uint24 fee = uint24(uint16(_auxData));
+        int24 tickLower = int24(uint24(_auxData >> 40));
+        int24 tickUpper = int24(uint24(_auxData >> 16));
+        address pool = UNISWAP_FACTORY.getPool(_tokenA, _tokenB, fee);
+        int24 tickSpacing = IUniswapV3Pool(pool).tickSpacing();
+        uint128 liquidity = 0;
+
+        if (tickLower % tickSpacing != 0 && tickUpper % tickSpacing != 0) revert IncorrectSpacing();
+
+        for (int24 i = tickLower; i <= tickUpper; i += tickSpacing) {
+            (uint128 liquidityGross, , , , , , , ) = IUniswapV3Pool(pool).ticks(i);
+
+            liquidity += liquidityGross;
+        }
+
+        (uint160 sqrtPriceX96, , , , , , ) = IUniswapV3Pool(pool).slot0();
+
+        (balance0, balance1) = LiquidityAmounts.getAmountsForLiquidity(
+            sqrtPriceX96,
+            TickMath.getSqrtRatioAtTick(tickLower),
+            TickMath.getSqrtRatioAtTick(tickUpper),
+            liquidity
+        );
+    }
+
+    /**
+     * @notice  Function used to get a deposit
+     * @dev gets a deposit
+     * @param _interactionNonce the nonce of the interaction
+     * @return Deposit the deposit/ its contents
+     */
+    function getDeposit(uint256 _interactionNonce)
+        external
+        view
+        returns (
+            uint256,
+            uint128,
+            uint256,
+            uint256,
+            int24,
+            int24,
+            uint24,
+            address,
+            address
+        )
+    {
+        Deposit memory deposit = deposits[_interactionNonce];
+
+        return (
+            deposit.tokenId,
+            deposit.liquidity,
+            deposit.amount0,
+            deposit.amount1,
+            deposit.tickLower,
+            deposit.tickUpper,
+            deposit.fee,
+            deposit.token0,
+            deposit.token1
+        );
+    }
+
+    /**
+     * @notice  Function used to withdraw liquidity
+     * @dev also handles bridge accounting.
+     * note that the bridge accounting only subtracts liquidity
+     * but does not subtract deposits[interactionnonce].amount0, so thes amounts will always be positive
+     * hence we do not rely on them as indicators of liquidity
+     * @param _interactionNonce the nonce of the interaction
+     * @param _liquidity the amount of liquidity to be withdrawn
+     * @return withdraw0 the amount of token0 received
+     * @return withdraw1 the amount of token1 received
+     */
+    function _withdraw(uint256 _interactionNonce, uint128 _liquidity)
+        internal
+        returns (uint256 withdraw0, uint256 withdraw1)
+    {
+        // get liquidity data for tokenId
+        // amount0Min and amount1Min are price slippage checks
+        // if the amount received after burning is not greater than these minimums, transaction will fail
+
+        INonfungiblePositionManager.DecreaseLiquidityParams memory params = INonfungiblePositionManager
+            .DecreaseLiquidityParams({
+                tokenId: deposits[_interactionNonce].tokenId,
+                liquidity: _liquidity,
+                amount0Min: 0,
+                amount1Min: 0,
+                deadline: block.timestamp
+            });
+
+        (uint256 amount0Out, uint256 amount1Out) = NONFUNGIBLE_POSITION_MANAGER.decreaseLiquidity(params);
+
+        {
+            (withdraw0, withdraw1) = _collect(
+                deposits[_interactionNonce].tokenId,
+                uint128(amount0Out),
+                uint128(amount1Out)
+            );
+        }
+
+        if (deposits[_interactionNonce].liquidity < _liquidity) revert InsufficientLiquidity();
+        deposits[_interactionNonce].liquidity = deposits[_interactionNonce].liquidity - _liquidity;
+
+        //decided this is irrelevant, as it triggers arithmetic overflow often, because in certain scenarios, amount0 is less
+        //than amount0Out. for example if ETH price went up in DAI alot, then it could trigger the error.further more,
+        //the bridges does not use amount0 or amount1 in deposits mapping for much.
+        //we use the following instead, which is used by asyncbridge as a record of how much output the position received
+        //after withdrawal.
+
+        deposits[_interactionNonce].amount0 = withdraw0;
+        deposits[_interactionNonce].amount1 = withdraw1;
+    }
+
+    /**
+     * @notice  collects the tokens after they are burned in _withdraw via decreaseliquidity
+     * @param _tokenId tokenId of the nft position
+     * @param _in0 the amount of token0 to be collected
+     * @param _in1 the amount of token1 to be collected
+     * @return amount0 amount0 actually collected
+     * @return amount1 amount1 actually collected
+     */
+    function _collect(
+        uint256 _tokenId,
+        uint128 _in0,
+        uint128 _in1
+    ) internal returns (uint256 amount0, uint256 amount1) {
+        INonfungiblePositionManager.CollectParams memory params = INonfungiblePositionManager.CollectParams({
+            tokenId: _tokenId,
+            recipient: address(this),
+            amount0Max: _in0,
+            amount1Max: _in1
+        });
+
+        (amount0, amount1) = NONFUNGIBLE_POSITION_MANAGER.collect(params);
+    }
+
+    /**
+     * @notice  Function used to get a deposit
+     * @dev creates the deposit for a new position , used by internal bridge accounting
+     * @param _tokenId tokenid of the nft position
+     * @param _interactionNonce the interaction nonce
+     * @param _amount0 the amount0 liquidity minted
+     * @param _amount1 the amount1 liquidity minted
+     * @param _fee the fee of the pool
+     */
+    function _createDeposit(
+        uint256 _tokenId,
+        uint256 _interactionNonce,
+        uint256 _amount0,
+        uint256 _amount1,
+        uint24 _fee
+    ) internal {
+        (
+            ,
+            ,
+            address token0,
+            address token1,
+            ,
+            int24 tickLower,
+            int24 tickUpper,
+            uint128 liquidity,
+            ,
+            ,
+            ,
+
+        ) = NONFUNGIBLE_POSITION_MANAGER.positions(_tokenId);
+
+        // set data for position
+        deposits[_interactionNonce] = Deposit({
+            tokenId: _tokenId,
+            liquidity: liquidity,
+            amount0: _amount0,
+            amount1: _amount1,
+            tickLower: tickLower,
+            tickUpper: tickUpper,
+            fee: _fee,
+            token0: token0,
+            token1: token1
+        });
+    }
+
+    /**
+     * @notice  mints a new position
+     * @dev mints a new position, and creates a new deposit
+     * @return liquidity the liquidty minted
+     * @return refund0 any refunds in token0
+     * @return refund1 any refunds in token1
+     */
+    function _mintNewPosition(
+        address _token0,
+        address _token1,
+        uint256 _amount0ToMint,
+        uint256 _amount1ToMint,
+        int24 _tickLower,
+        int24 _tickUpper,
+        uint24 _fee,
+        uint256 _interactionNonce
+    )
+        internal
+        returns (
+            uint128 liquidity,
+            uint256 refund0,
+            uint256 refund1
+        )
+    {
+        TransferHelper.safeApprove(_token0, address(NONFUNGIBLE_POSITION_MANAGER), _amount0ToMint);
+        TransferHelper.safeApprove(_token1, address(NONFUNGIBLE_POSITION_MANAGER), _amount1ToMint);
+        INonfungiblePositionManager.MintParams memory params = INonfungiblePositionManager.MintParams({
+            token0: _token0,
+            token1: _token1,
+            fee: _fee,
+            tickLower: _tickLower,
+            tickUpper: _tickUpper,
+            amount0Desired: _amount0ToMint,
+            amount1Desired: _amount1ToMint,
+            amount0Min: 0,
+            amount1Min: 0,
+            recipient: address(this),
+            deadline: block.timestamp
+        });
+
+        uint256 amount0;
+        uint256 amount1;
+
+        {
+            uint256 tokenId;
+            (tokenId, liquidity, amount0, amount1) = NONFUNGIBLE_POSITION_MANAGER.mint(params);
+            _createDeposit(tokenId, _interactionNonce, amount0, amount1, _fee);
+        }
+
+        // Remove allowance and refund in both assets.
+        if (amount0 < _amount0ToMint) {
+            TransferHelper.safeApprove(_token0, address(NONFUNGIBLE_POSITION_MANAGER), 0);
+            refund0 = _amount0ToMint - amount0;
+            //TransferHelper.safeTransfer(token0, rollupProcessor, refund0);
+        }
+
+        if (amount1 < _amount1ToMint) {
+            TransferHelper.safeApprove(_token1, address(NONFUNGIBLE_POSITION_MANAGER), 0);
+            refund1 = _amount1ToMint - amount1;
+            //TransferHelper.safeTransfer(token1, rollupProcessor, refund1);
+        }
+    }
+
+    /**
+     * @notice converts any refunds in token0 or token1 to a refund token(0 or 1)
+     * @dev if we have refunds in token 0 or 1 we need to conver all to 0 or all to 1.
+     * this is due to the fact that the brige can only have 2 real outputs, and 1 output slot is occupied by the virtual
+     * asset represneting the position itself. so if we have refunds in both tokens, one token's refund must be swapped to
+     * have the refund all in one token
+     * @param _refund0 any refunds in token0
+     * @param _refund1 any refunds in token1
+     * @param _refundAddress address of the refund token (0 or 1)
+     * @param _token0 token0 address
+     * @param _token1 token1 addr
+     * @param _fee fee
+     * @return refundedAmount the refund amount after swapping superfluous refunds
+     */
+    function _refundConversion(
+        uint256 _refund0,
+        uint256 _refund1,
+        address _refundAddress,
+        address _token0,
+        address _token1,
+        uint24 _fee
+    ) internal returns (uint256 refundedAmount) {
+        //we have refunds in token1, convert to token0 to match outputAssetB
+        //or we have refunds in token0, convert to token1 to match outputAssetB
+        // The call to `exactInputSingle` executes the swap.
+        uint256 amountIn = _refundAddress == _token0 ? _refund1 : _refund0;
+        address tokenIn = _refundAddress == _token0 ? _token1 : _token0;
+        TransferHelper.safeApprove(tokenIn, address(SWAP_ROUTER), 0);
+        TransferHelper.safeApprove(tokenIn, address(SWAP_ROUTER), amountIn);
+        //check balances next step
+        ISwapRouter.ExactInputSingleParams memory swapParams = ISwapRouter.ExactInputSingleParams({
+            tokenIn: tokenIn,
+            tokenOut: _refundAddress,
+            fee: _fee,
+            recipient: address(this),
+            deadline: block.timestamp,
+            amountIn: amountIn,
+            amountOutMinimum: 0,
+            sqrtPriceLimitX96: tokenIn == _token0 ? 0 : type(uint160).max / 1000000
+        });
+        refundedAmount = SWAP_ROUTER.exactInputSingle(swapParams);
+
+        TransferHelper.safeApprove(tokenIn, address(SWAP_ROUTER), 0);
+    }
+
+    /**
+     * @notice this function is used to check whether an AztecAsset is an ERC20 or ETH.
+     * @dev If it is ETH,
+     * then the underlying ETH is wrapped and the function returns the WETH address (since inputAsset.erc20Address returns 0 if
+     * the underlying is ETH).
+     * @param _inputAsset The Aztec input asset
+     * @return address the address of the asset, WETH if it is ETH, else erc20 address
+     */
+    function _handleETHReturnAddress(AztecTypes.AztecAsset calldata _inputAsset) internal returns (address) {
+        if (_inputAsset.assetType == AztecTypes.AztecAssetType.ETH) {
+            WETH.deposit{value: address(this).balance}();
+            return address(WETH);
+        } else {
+            return _inputAsset.erc20Address;
+        }
+    }
+}

--- a/src/bridges/uniswap_lp/UniLPBridge.sol
+++ b/src/bridges/uniswap_lp/UniLPBridge.sol
@@ -1,0 +1,572 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2022 Aztec.
+pragma solidity >=0.8.4;
+
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {AztecTypes} from "../../aztec/libraries/AztecTypes.sol";
+import {ParentUniLPBridge, TransferHelper, ISwapRouter} from "./ParentUniLPBridge.sol";
+import {IUniswapV3Pool} from "../../interfaces/uniswapv3/IUniswapV3Pool.sol";
+import {IDefiBridge} from "../../aztec/interfaces/IDefiBridge.sol";
+import {IQuoterV2} from "../../interfaces/uniswapv3/IQuoterV2.sol";
+import {IQuoter} from "../../interfaces/uniswapv3/IQuoter.sol";
+import {TickMath} from "../../libraries/uniswapv3/TickMath.sol";
+import {FullMath} from "../../libraries/uniswapv3/FullMath.sol";
+import {LiquidityAmounts} from "../../libraries/uniswapv3/LiquidityAmounts.sol";
+import {ErrorLib} from "../base/ErrorLib.sol";
+
+contract UniLPBridge is IDefiBridge, ParentUniLPBridge {
+    using SafeERC20 for IERC20;
+
+    error InvalidRefund();
+
+    //used as a record for MINT_PT1 & MINT_P2
+    struct MintFunding {
+        address token;
+        uint256 amount;
+    }
+
+    struct OptimalLiqParams {
+        address token0;
+        address token1;
+        uint24 fee;
+        uint256 amount0;
+        uint256 amount1;
+        uint160 sqrtRatioAX96;
+        uint160 sqrtRatioBX96;
+    }
+
+    mapping(uint256 => MintFunding) public syncMintFundingMap; //interaction nonce -> MintFunding struct for MINT_PT1 interactions
+
+    constructor(address _rollupProcessor) public ParentUniLPBridge(_rollupProcessor) {}
+
+    /**
+     * @notice  packs _auxData for front end user
+     * @dev The first 24 bits are tickLower. The second 24 are tickUpper. The last 16 the pool's fee.
+     * As a pool's fee ranges from 10 bps, 100 bps, 300 bps, and 1000 bps, there is no data loss and type conversion
+     * is acceptable.
+     * @param _tickLower the lower range of the position
+     * @param _tickUpper the upper range of the position
+     * @param _fee the fee tier of the pool
+     * @return _auxData the packed _auxData
+     */
+    function packData(
+        int24 _tickLower,
+        int24 _tickUpper,
+        uint24 _fee
+    ) external view returns (uint64 _auxData) {
+        uint24 a = uint24(_tickLower);
+        uint24 b = uint24(_tickUpper);
+        uint48 ticks = (uint48(a) << 24) | uint48(b);
+        uint16 fee = uint16(_fee);
+        _auxData = (uint64(ticks) << 16) | uint64(fee);
+    }
+
+    /**
+     * @notice  Functions are used to unpack _auxData in chunks of 24 or 16 bits.
+     * @dev The first 24 bits are tickLower. The second 24 are tickUpper. The last 16 the pool's fee.
+     * As a pool's fee ranges from 10 bps, 100 bps, 300 bps, and 1000 bps, there is no data loss and type conversion
+     * is acceptable.
+     * @param _a The uint64 to be unpacked
+     * @return b the uint24 or uint16
+     */
+    function unpackFirst24Bits(uint64 _a) public pure returns (uint24 b) {
+        b = uint24(_a >> 40);
+    }
+
+    function unpackSecond24Bits(uint64 _a) public pure returns (uint24 b) {
+        b = uint24(_a >> 16);
+    }
+
+    function unpackLast16Bits(uint64 _a) public pure returns (uint16 b) {
+        b = uint16(_a);
+    }
+
+    /**
+     * @notice This function performs 4 different types of interactions.
+     * @dev  Step 1 of minting a liquidity position. Step 2 of minting a
+     * liquidity position. The necessity of splitting this into two steps is necessitated by
+     * the bridge's constraints (only 1 real asset input per convert call).
+     * Lastly, redemption of liquidity for underlying. T
+     * The interactions are completed in some cases within the function,
+     *and sometimes by calls to internal functions where the logic is performed.
+     * note: "Virtual" means virtual note, which represents ownership of an interaction nonce.
+     * i.e. if you deposit some token in interaction 445 , you will receive a virtual note giving you ownership
+     * of nonce 445 so that you may use the virtual note to reedem later. In the case of Minting Part 1
+     * you receive a virtual note after depositing the first token in the pair you wish to LP for.
+     * In Minting Part 2, you input your virtual note representing your deposited token, along with
+     * the second token in the pair you wish to LP for. If the LP position is created successfully, you
+     * will receive a virtual note giving ownership of LP position via the nonce.
+     * At redemption, the virtual note is inputted and the LP position is redeemed.
+     * Some considerations: In Minting Part 2, the refund is constrained to be the token deposited in
+     * Minting Part 1, or inputAssetA's token. Additionally the token deposited in Minting Part1
+     * should NOT be the same as the token input as inputAssetA in Minting Part 2.
+     *                              Minting Part 1       Minting Part 2                 Redeeming
+     * @param _inputAssetA -        ETH or ERC20         ETH or ERC20                   Virtual
+     * @param _inputAssetB -        Unused               Virtual                        Unused
+     * @param _outputAssetA -       Virtual              Virtual                        ETH or ERC20
+     * @param _outputAssetB -       Unused               ETH or ERC20 (refund)          ETH or ERC20
+     * @param _inputValue -         ETH or ERC20 amount  _inputAssetA amount            liquidity to be redeemed
+     * @param _interactionNonce -   current nonce        current nonce                  current nonce
+     * @param _auxData -            0                    tickLower, tickUpper, pool fee 0
+     * @return outputValueA -       _inputValue          total liquidity of the position assetA amount redeemed
+     * @return outputValueB -       0                    any amount refunded             assetB amount redeemed
+     */
+    function convert(
+        AztecTypes.AztecAsset calldata _inputAssetA,
+        AztecTypes.AztecAsset calldata _inputAssetB,
+        AztecTypes.AztecAsset calldata _outputAssetA,
+        AztecTypes.AztecAsset calldata _outputAssetB,
+        uint256 _inputValue,
+        uint256 _interactionNonce,
+        uint64 _auxData,
+        address
+    )
+        external
+        payable
+        override(IDefiBridge)
+        returns (
+            uint256 outputValueA,
+            uint256 outputValueB,
+            bool
+        )
+    {
+        //require(inputValue == 0, "ZERO");
+
+        if (msg.sender != address(ROLLUP_PROCESSOR)) revert ErrorLib.InvalidCaller();
+
+        //INTERACTION TYPE 1
+        //1 real 1 not used
+        //1 virtual 1 not used
+
+        if (
+            _outputAssetB.assetType == AztecTypes.AztecAssetType.NOT_USED &&
+            (_inputAssetA.assetType == AztecTypes.AztecAssetType.ERC20 ||
+                _inputAssetA.assetType == AztecTypes.AztecAssetType.ETH) &&
+            _inputAssetB.assetType == AztecTypes.AztecAssetType.NOT_USED &&
+            _outputAssetA.assetType == AztecTypes.AztecAssetType.VIRTUAL
+        ) {
+            //sanity check
+            address inputAddress = _handleETHReturnAddress(_inputAssetA);
+
+            //state changes
+            //deposit funds
+            syncMintFundingMap[_interactionNonce] = MintFunding({token: inputAddress, amount: _inputValue});
+            //_outputAssetA.id = _interactionNonce;
+            //_outputAssetA.erc20Address = inputAddress;
+            outputValueA = _inputValue;
+        }
+        //INTERACTION TYPE 2
+        //1 real 1 virtual
+        //1 virtual 1 real (refund)
+        else if (
+            _inputAssetB.assetType == AztecTypes.AztecAssetType.VIRTUAL &&
+            (_inputAssetA.assetType == AztecTypes.AztecAssetType.ERC20 ||
+                _inputAssetA.assetType == AztecTypes.AztecAssetType.ETH) &&
+            _outputAssetA.assetType == AztecTypes.AztecAssetType.VIRTUAL &&
+            (_outputAssetB.assetType == AztecTypes.AztecAssetType.ERC20 ||
+                _outputAssetB.assetType == AztecTypes.AztecAssetType.ETH)
+        ) {
+            //minting LP position
+            //sanity checks + variable instantiation
+            address inputAddress = _handleETHReturnAddress(_inputAssetA);
+            address refundAddress = _handleETHReturnAddress(_outputAssetB); // this asset is used for refunds
+
+            //constrain refund to be one of the tokens
+            if (!(inputAddress == refundAddress || refundAddress == syncMintFundingMap[_inputAssetB.id].token))
+                revert InvalidRefund();
+
+            (outputValueA, outputValueB) = _convertMintPart2(
+                inputAddress,
+                refundAddress,
+                _interactionNonce,
+                _inputAssetB.id,
+                _inputValue,
+                _auxData
+            );
+        }
+        //INTERACTION TYPE 3
+        //1 real 1 not used
+        //1 virtual 1 real (the second pair)
+        else if (
+            _inputAssetB.assetType == AztecTypes.AztecAssetType.NOT_USED &&
+            (_inputAssetA.assetType == AztecTypes.AztecAssetType.ERC20 ||
+                _inputAssetA.assetType == AztecTypes.AztecAssetType.ETH) &&
+            _outputAssetA.assetType == AztecTypes.AztecAssetType.VIRTUAL &&
+            (_outputAssetB.assetType == AztecTypes.AztecAssetType.ERC20 ||
+                _outputAssetB.assetType == AztecTypes.AztecAssetType.ETH)
+        ) {
+            //sanity check
+            //note: _outputAssetB's address is assumed to be the secondary address necessary to retrieve the pool, but also for
+            //any refunds , if necessary
+            address inputAddress = _handleETHReturnAddress(_inputAssetA);
+            address outputAddress = _handleETHReturnAddress(_outputAssetB);
+
+            (outputValueA, outputValueB) = _convertMintBySwap(
+                inputAddress,
+                outputAddress,
+                _interactionNonce,
+                _inputValue,
+                _auxData
+            );
+        }
+        //INTERACTION TYPE 4
+        //1 virtual 1 not used
+        //1 real 1 real
+        else if (
+            (_outputAssetA.assetType == AztecTypes.AztecAssetType.ERC20 ||
+                _outputAssetA.assetType == AztecTypes.AztecAssetType.ETH) &&
+            _inputAssetB.assetType == AztecTypes.AztecAssetType.NOT_USED &&
+            _inputAssetA.assetType == AztecTypes.AztecAssetType.VIRTUAL &&
+            (_outputAssetB.assetType == AztecTypes.AztecAssetType.ERC20 ||
+                _outputAssetB.assetType == AztecTypes.AztecAssetType.ETH)
+        ) {
+            //withdrawing LP
+
+            //sanity check
+            uint256 id = _inputAssetA.id; //avoid stack too deep
+            address tokenA = _handleETHReturnAddress(_outputAssetA);
+            address tokenB = _handleETHReturnAddress(_outputAssetB);
+
+            {
+                // less storage reads
+                address token0 = deposits[id].token0;
+                address token1 = deposits[id].token1;
+                //sanity check: constrain the outputs to equal the tokens of the actual LP position.
+                bool validArgs = (tokenA == token0 && token1 == tokenB) || (tokenB == token0 && token1 == tokenA);
+                if (!validArgs) revert InvalidOutputs();
+            }
+
+            //state changes
+            //actual withdrawal via uniswap is done here
+            (outputValueA, outputValueB) = _withdraw(id, uint128(_inputValue));
+            //done because _decreaseLiquidity spits out amount0 amount1 and A && B not necessariy == token0 && token1
+            if (!(tokenA == deposits[id].token0)) {
+                (outputValueA, outputValueB) = (outputValueB, outputValueA);
+            }
+
+            //note: if the one of the tokens here is WETH, the rollupProcessor will
+            //receive approval for the WETH amount but then also receive ETH in
+            //receiveEthFromBridge. Proabbly not a problem but it's a sort of double counting of sorts?
+            //worth noting
+
+            TransferHelper.safeApprove(tokenA, address(ROLLUP_PROCESSOR), 0);
+            TransferHelper.safeApprove(tokenB, address(ROLLUP_PROCESSOR), 0);
+            TransferHelper.safeApprove(tokenA, address(ROLLUP_PROCESSOR), outputValueA);
+            TransferHelper.safeApprove(tokenB, address(ROLLUP_PROCESSOR), outputValueB);
+
+            if (_inputAssetA.assetType == AztecTypes.AztecAssetType.ETH) {
+                WETH.withdraw(outputValueA);
+                ROLLUP_PROCESSOR.receiveEthFromBridge{value: outputValueA}(_interactionNonce);
+            } else if (_inputAssetB.assetType == AztecTypes.AztecAssetType.ETH) {
+                WETH.withdraw(outputValueB);
+                ROLLUP_PROCESSOR.receiveEthFromBridge{value: outputValueB}(_interactionNonce);
+            }
+        }
+    }
+
+    /**
+     * @notice internal function to perform part 2 of the 2-step minting interaction
+     * @dev performs some checks, unpacks the _params, then mints a new position. handles refunding at the end.
+     * @param _input address of the input asset
+     * @param _refund address of the output/refund asset
+     * @param _interactionNonce the _interactionNonce
+     * @param _id the _interactionNonce of the virtual asset provided in the convert call, which is used to prove ownersip
+     * of an interaction that provided funding in step 1 for this step.
+     * @param _inputValue the input size of _inputAssetA.
+     * @param _params the _params, including the tickLower, the tickUpper, and the pool's fee.
+     * @return outputValueA outputvalueA , liquidity minted
+     * @return outputValueB outputvalueb, the refund
+     */
+    function _convertMintPart2(
+        address _input,
+        address _refund,
+        uint256 _interactionNonce,
+        uint256 _id,
+        uint256 _inputValue,
+        uint64 _params
+    ) internal returns (uint256 outputValueA, uint256 outputValueB) {
+        //no require check to make sure pool exists because uniswap will revert
+
+        address[] memory token = new address[](2);
+
+        {
+            //avoid stack too deep and avoids 3 reads to storage
+            address deposited = syncMintFundingMap[_id].token;
+            token[0] = _input < deposited ? _input : deposited;
+            token[1] = _input < deposited ? deposited : _input;
+        }
+
+        //state changes
+        //_outputAssetA.id = _interactionNonce;
+
+        uint24 fee;
+        uint256 refund0;
+        uint256 refund1;
+
+        {
+            //avoid stack too deep
+            uint256 amount0 = token[0] == _input ? _inputValue : syncMintFundingMap[_id].amount;
+            uint256 amount1 = token[0] == _input ? syncMintFundingMap[_id].amount : _inputValue;
+            uint256 stackholderNonce = _interactionNonce;
+            //outputValueA = liquidity here
+            fee = uint24(unpackLast16Bits(_params));
+            int24 tickLower = int24(unpackFirst24Bits(_params));
+            int24 tickUpper = int24(unpackSecond24Bits(_params));
+            (outputValueA, refund0, refund1) = _mintNewPosition(
+                token[0],
+                token[1],
+                amount0,
+                amount1,
+                tickLower,
+                tickUpper,
+                fee,
+                stackholderNonce
+            );
+        }
+
+        //refunding
+        if ((refund1 > 0 && _refund == token[0]) || (refund0 > 0 && _refund == token[1])) {
+            outputValueB = token[0] == _refund ? refund0 : refund1;
+            uint256 amountOut = _refundConversion(refund0, refund1, _refund, token[0], token[1], fee);
+            outputValueB = outputValueB + amountOut;
+            TransferHelper.safeApprove(_refund, address(ROLLUP_PROCESSOR), 0);
+        }
+
+        //we need to destroy record of MINT_PT1 funding to avoid virtual asset re-use
+        syncMintFundingMap[_id].amount = 0;
+
+        //approve rollupProcessor to receive refund
+        TransferHelper.safeApprove(_refund, address(ROLLUP_PROCESSOR), outputValueB);
+    }
+
+    /**
+     * @notice internal function to perform the mint-by-swap interaction
+     * @dev swaps half of the input. Mints a new position, and handles refunding.
+     * @param _input the input asset's address
+     * @param _output the output asset's address
+     * @param _interactionNonce the interaction nonce
+     * @param _inputValue the size of the input asset
+     * @param _params the _params for the liquidity position, i.e. tickLower, tickUpper, and the pool fee.
+     * @return outputValueA the liquidity minted
+     * @return outputValueB the refund if any
+     */
+    function _convertMintBySwap(
+        address _input,
+        address _output,
+        uint256 _interactionNonce,
+        uint256 _inputValue,
+        uint64 _params
+    ) internal returns (uint256 outputValueA, uint256 outputValueB) {
+        uint256[] memory amounts = new uint256[](2);
+        uint24 fee = uint24(unpackLast16Bits(_params));
+
+        //swap half of input
+        {
+            TransferHelper.safeApprove(_input, address(SWAP_ROUTER), _inputValue / 2);
+            ISwapRouter.ExactInputSingleParams memory swapParams = ISwapRouter.ExactInputSingleParams({
+                tokenIn: _input,
+                tokenOut: _output,
+                fee: fee,
+                recipient: address(this),
+                deadline: block.timestamp,
+                amountIn: _inputValue / 2,
+                amountOutMinimum: 0, //flashbots
+                sqrtPriceLimitX96: 0
+            });
+
+            uint256 amountOut = SWAP_ROUTER.exactInputSingle(swapParams);
+
+            amounts[0] = _input < _output ? _inputValue / 2 : amountOut;
+            amounts[1] = _input < _output ? amountOut : _inputValue / 2;
+        }
+        //_outputAssetA.id = _interactionNonce;
+        uint256 refund0;
+        uint256 refund1;
+        address token0 = _input < _output ? _input : _output;
+        address token1 = _input < _output ? _output : _input;
+
+        {
+            uint256 stackholderNonce = _interactionNonce; //avoid stack too deep
+            int24 tickLower = int24(unpackFirst24Bits(_params));
+            int24 tickUpper = int24(unpackSecond24Bits(_params));
+            (outputValueA, refund0, refund1) = _mintNewPosition(
+                token0,
+                token1,
+                amounts[0],
+                amounts[1],
+                tickLower,
+                tickUpper,
+                fee,
+                stackholderNonce
+            );
+        }
+
+        //refunding
+        //due to bridge limitations only 1 token can be specified as the asset in which refunds are received
+        //But a refund of two assets at the same time is possible and moreover we don't want the user to accidentally
+        //specify token0 as the refund but all the refund is in token1 and they don't receive it.
+        //so instead the bridge checks that any and all refunds are to be converted if necessary by swap
+        //to the designated refund asset. it then adds to this outputValueB.
+        //the defiBridgeProxy will call recoverTokens and the user should receive the refund.
+        //this approach is naive and the user will incur slippage and fees as well. so it would be smarter
+        //for them to simulate offchain to make sure they only receive a refund in one token or none.
+        if ((refund1 > 0 && _output == token0) || (refund0 > 0 && _output == token1)) {
+            outputValueB = token0 == _output ? refund0 : refund1;
+            amounts[0] = _refundConversion(refund0, refund1, _output, token0, token1, fee);
+            outputValueB = outputValueB + amounts[0];
+            TransferHelper.safeApprove(_output, address(ROLLUP_PROCESSOR), 0);
+        }
+
+        TransferHelper.safeApprove(_output, address(ROLLUP_PROCESSOR), outputValueB);
+    }
+
+    function _calculateOptimal0Alternative(
+        uint256 _deposit,
+        uint256 _amountOut,
+        uint160 _priceLower,
+        uint160 _priceUpper,
+        uint256 _supply,
+        address _pool
+    ) internal view returns (uint256) {
+        //require that pricelower < price < priceupper
+        //see https://atiselsts.github.io/pdfs/uniswap-v3-liquidity-math.pdf
+        //page 3 subsection 3 , equation 10 for the derivation of this equation
+        //let (sqrtP)(sqrtP_b)( sqrtP - sqrtP_a)/(sqrtP_b - sqrtP) = A
+        //we have xA = y. we substitute y for (S-x) * r where r = ratio of token 1 / token0
+        //then after substitution have xA = (S-x)r
+        //solving for x we have x = Sr / (A +r)
+        (uint160 sqrtPrice, , , , , , ) = IUniswapV3Pool(_pool).slot0();
+        uint256 denominator = FullMath.mulDiv(sqrtPrice, _priceUpper, _priceUpper - sqrtPrice);
+        denominator *= (sqrtPrice - _priceLower); //finish assembling A
+        denominator = denominator / 2**96; //get rid of first 2**96 in A, every other unit cancels out now or later
+        denominator += (_deposit * (2**96)) / _amountOut; //mul by 2**96 for floating point handling and match units w/ A
+        //at this point we have denominator = A*(10^b-a)*2**96 + r*(10^b-a)*2**96
+        uint256 numerator = FullMath.mulDiv(_supply, _deposit, _amountOut) * 2**96;
+        //numerator = Sr * (10^b)*2**96
+        //at this point the 2**96 will cancel out, and the 10^b / 10 ^ b-a = 10^a
+        //resulting in the application of our desired unit/scalar
+        //to produce optimal token0 qty with correct decimals
+        return FullMath.mulDiv(numerator, 1, denominator);
+    }
+
+    function optimizeLiquidity(OptimalLiqParams memory _params) external returns (uint256, uint256) {
+        uint256 amountOut;
+        (uint160 originalPrice, , , , , , ) = IUniswapV3Pool(
+            UNISWAP_FACTORY.getPool(_params.token0, _params.token1, _params.fee)
+        ).slot0();
+
+        {
+            //we are doing this by token0 (weth in this case)
+            //so we swap token1 to token0
+            //WETH is token0 and is also high priced. as we sell USDT price will increase.
+            //therefore our price limit if the max.
+            IQuoter quoter = IQuoter(0xb27308f9F90D607463bb33eA1BeBb41C27CE5AB6);
+            amountOut = quoter.quoteExactInputSingle(
+                _params.token1,
+                _params.token0,
+                _params.fee,
+                _params.amount1,
+                (originalPrice * 1000) / 100
+            );
+        }
+        uint256 optimal0 = _calculateOptimal0Alternative(
+            _params.amount1, //token1 amount to be used for r , which is token1 qty / amountOut
+            amountOut, //amountOut , to be used for r, which is token1 qty/ amountOut
+            _params.sqrtRatioAX96, //priceLower
+            _params.sqrtRatioBX96, //priceUpper
+            amountOut + _params.amount0, //supply, S term in Sr/(A+r), calculatd as amountOut+ initial token0 qty
+            UNISWAP_FACTORY.getPool(_params.token0, _params.token1, _params.fee) //pool, used to calculate current sqrtPriceX96
+        );
+
+        uint256 amountIn;
+        //token[0] is tokenIn NOT token0 token[1] is tokenOut NOT token1
+        address[] memory token = new address[](2);
+        {
+            bool flag = _params.amount0 < optimal0;
+            //if flag true
+            //we need to sell token1 to get more token0
+            //gives us token1 amount we need to sell
+            amountIn = flag
+                ? ((optimal0 - _params.amount0) * _params.amount1) / amountOut
+                : (_params.amount0 - optimal0);
+            token[0] = flag ? _params.token1 : _params.token0;
+            token[1] = flag ? _params.token0 : _params.token1;
+        }
+
+        uint160 sqrtPriceX96After;
+
+        {
+            //we are doing this by token0 (weth in this case)
+            //so we swap token1 to token0
+            //WETH is token0 and is also high priced. as we sell USDT price will increase.
+            //therefore our price limit if the max.
+
+            IQuoterV2 quoter = IQuoterV2(0x61fFE014bA17989E743c5F6cB21bF9697530B21e);
+            (amountOut, sqrtPriceX96After, , ) = quoter.quoteExactInputSingle(
+                IQuoterV2.QuoteExactInputSingleParams({
+                    tokenIn: token[0],
+                    tokenOut: token[1],
+                    fee: _params.fee,
+                    amountIn: amountIn,
+                    //intuitively we don't want price to move out of our range
+                    sqrtPriceLimitX96: token[0] < token[1] ? _params.sqrtRatioAX96 : _params.sqrtRatioBX96
+                })
+            );
+        }
+        //note: depending on which token was meant to be swapped in, we net the balances
+        //if liquiditybefore > liquidityafter
+        if (
+            uint256(
+                LiquidityAmounts.getLiquidityForAmounts(
+                    sqrtPriceX96After,
+                    _params.sqrtRatioAX96,
+                    _params.sqrtRatioBX96,
+                    token[0] == _params.token0 ? _params.amount0 - amountIn : _params.amount0 + amountOut,
+                    token[0] == _params.token1 ? _params.amount1 - amountIn : _params.amount1 + amountOut
+                )
+            ) <
+            uint256(
+                LiquidityAmounts.getLiquidityForAmounts(
+                    originalPrice,
+                    _params.sqrtRatioAX96,
+                    _params.sqrtRatioBX96,
+                    _params.amount0,
+                    _params.amount1
+                )
+            )
+        ) {
+            //IF WE REACH THIS, OUR OPTIMIZATION FAILED, WE USE INITIAL ARGS INSTEAD
+            return (_params.amount0, _params.amount1);
+        } else if (amountIn > 0) {
+            //OPTIMIZATION SUCCEEDED
+            //see above note preceding getLiquidityForAmounts calls on why we use _params.amount0+amountOut
+            //rather than using optimal0
+            return (
+                token[0] == _params.token0 ? _params.amount0 - amountIn : _params.amount0 + amountOut,
+                token[0] == _params.token1 ? _params.amount1 - amountIn : _params.amount1 + amountOut
+            );
+        }
+
+        return (_params.amount0, _params.amount1);
+    }
+
+    function finalise(
+        AztecTypes.AztecAsset calldata,
+        AztecTypes.AztecAsset calldata,
+        AztecTypes.AztecAsset calldata,
+        AztecTypes.AztecAsset calldata,
+        uint256,
+        uint64
+    )
+        external
+        payable
+        returns (
+            uint256 outputValueA,
+            uint256 outputValueB,
+            bool interactionComplete
+        )
+    {
+        revert ErrorLib.AsyncDisabled();
+    }
+}

--- a/src/bridges/uniswap_lp/UniRangeOrderBridge.sol
+++ b/src/bridges/uniswap_lp/UniRangeOrderBridge.sol
@@ -1,0 +1,286 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright 2022 Spilsbury Holdings Ltd
+pragma solidity >=0.8.4;
+
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import {AztecTypes} from "../../aztec/libraries/AztecTypes.sol";
+import {TickMath} from "../../libraries/uniswapv3/TickMath.sol";
+import {IUniswapV3Pool} from "../../interfaces/uniswapv3/IUniswapV3Pool.sol";
+import {ParentUniLPBridge} from "./ParentUniLPBridge.sol";
+import {IDefiBridge} from "../../aztec/interfaces/IDefiBridge.sol";
+import {ErrorLib} from "../base/ErrorLib.sol";
+import {IQuoter} from "../../interfaces/uniswapv3/IQuoter.sol";
+
+contract UniRangeOrderBridge is IDefiBridge, ParentUniLPBridge {
+    using SafeERC20 for IERC20;
+
+    error InvalidRefund();
+
+    struct AsyncOrder {
+        bool finalisable;
+        uint256 expiry;
+    }
+
+    mapping(uint256 => AsyncOrder) public asyncOrders;
+
+    uint256 public constant MAGIC_NUMBER_DAYS = 60 * 60 * 24; //seconds in a day
+
+    constructor(address _rollupProcessor) public ParentUniLPBridge(_rollupProcessor) {}
+
+    /**
+     * @notice  Function used to  set the finalisability of an order to true and withdraw liquidity
+     * @dev withdraws liquidity, and sets finalisability of an order to true, if the limit order conditions are met
+     * also rewards the msg.sender with the fees of limit order since limit orders are technically maker orders
+     * @param _interactionNonce the nonce of the interaction
+     * @return amount0 the amount of token0 returned by withdrawal of liquidity
+     * @return amount1 the amount of token1 returned by withdrawal of liquidity
+     */
+    function trigger(uint256 _interactionNonce) external returns (uint256 amount0, uint256 amount1) {
+        //for keepers / bot operators to trigger limit orders if conditions are met
+        if (_checkLimitConditions(_interactionNonce)) {
+            asyncOrders[_interactionNonce].finalisable = true;
+            (amount0, amount1) = _withdraw(_interactionNonce, deposits[_interactionNonce].liquidity);
+
+            //necessary?
+            //require(amount0 == 0 || amount1 == 0 , "NOT_RANGE");
+
+            //(,,,,,,,,,,uint128 tokensOwed0,uint128 tokensOwed1) = nonfungiblePositionManager.positions(deposits[_interactionNonce].tokenId);
+            //implement a fee percentage rather than approving whole thing?
+            // TODO: isn't using msg.sender a security vulnerability here given that the method doesn't do any entry checks and is called externally?
+            //Answer: no, because _checkLimitConditions ensures that the position only withdraws if the order's limit conditions
+            //are met. The caller receives a portion of the order's fees in return. This is analogous to the various
+            //keepers used in DeFi protocols.
+            IERC20(deposits[_interactionNonce].token0).safeIncreaseAllowance(
+                msg.sender,
+                amount0 * (deposits[_interactionNonce].fee / 1000000)
+            );
+            // TODO: why is amount 0 here and not amount 1?
+            IERC20(deposits[_interactionNonce].token1).safeIncreaseAllowance(
+                msg.sender,
+                amount1 * (deposits[_interactionNonce].fee / 1000000)
+            );
+        }
+    }
+
+    /**
+     * @notice  Function used to cancel if an order is past its expiry
+     * @dev if an order is past its expiry, this fxn withdraws the liquidity
+     * @param _interactionNonce the nonce of the interaction
+     * @return amount0 the amount of token0 returned by withdrawal of liquidity
+     * @return amount1 the amount of token1 returned by withdrawal of liquidity
+     */
+    function cancel(uint256 _interactionNonce) external returns (uint256 amount0, uint256 amount1) {
+        if (asyncOrders[_interactionNonce].expiry >= block.timestamp) {
+            asyncOrders[_interactionNonce].finalisable = true;
+            (amount0, amount1) = _withdraw(_interactionNonce, deposits[_interactionNonce].liquidity);
+            //user may now call processAsyncDefiInteraction successfully
+        }
+    }
+
+    /**
+     * @notice  convert function to that takes inputs and mints liquidity
+     * @dev takes an auxdata w/ ticklower, tickupper, and fee tier of pool.
+     * note that this bridge
+     * @param _inputAssetA input token
+     * @param _inputAssetB not used
+     * @param _outputAssetA output token
+     * @param _outputAssetB not used
+     * @param _inputValue size of input token
+     * @param _interactionNonce nonce
+     * @param _auxData ticklower tickupper and fee
+     * @return outputValueA liquidity minted
+     * @return outputValueB not used
+     * @return isAsync set to true always
+     */
+    function convert(
+        AztecTypes.AztecAsset calldata _inputAssetA,
+        AztecTypes.AztecAsset calldata _inputAssetB,
+        AztecTypes.AztecAsset calldata _outputAssetA,
+        AztecTypes.AztecAsset calldata _outputAssetB,
+        uint256 _inputValue,
+        uint256 _interactionNonce,
+        uint64 _auxData,
+        address
+    )
+        external
+        payable
+        override(IDefiBridge)
+        returns (
+            uint256 outputValueA,
+            uint256 outputValueB,
+            bool isAsync
+        )
+    {
+        if (msg.sender != address(ROLLUP_PROCESSOR)) revert ErrorLib.InvalidCaller();
+
+        //Uniswap V3 range limit order
+        isAsync = true;
+        //sanity checks
+        if (_inputAssetB.assetType != AztecTypes.AztecAssetType.NOT_USED) revert ErrorLib.InvalidInputB();
+        address input = _handleETHReturnAddress(_inputAssetA);
+        address output = _handleETHReturnAddress(_outputAssetA);
+
+        //_outputAssetA is already output, this must be input then
+        if (input != _handleETHReturnAddress(_outputAssetB)) revert InvalidRefund();
+
+        /* 
+                to fit all data into 64 bits, we constrict fee var to int8 size. we multiply uint8 fee by 10 to reach the appropriate basis
+                points size. i.e. if user wants 300 bps pool ,they will set uint8 fee = 30 , contract will pass in 30*10, 300 bps, 
+                which is a correct fee tier.
+                we use remaining 8 bits for days_to_cancel which is multiplied by MAGIC_NUMBER_DAY to get a timestamp of how many days
+                out the expiry is in uint256. 
+        */
+
+        //fee should be in hundredths of a bip. 1 bip = 1/100, i.e. 1e^-6. fee will range from 0 to 100, we will multiply
+        //by 100 to get the correct number. i.e. .3% is 3000, so 30 * 100
+
+        //state changes
+
+        _mintNewPosition(
+            (input < output ? input : output), //token0
+            (input < output ? output : input), //token1
+            (input < output ? _inputValue : 0), //amount0
+            (input < output ? 0 : _inputValue), //amount1
+            int24(uint24(_auxData >> 40)), //tickLower
+            int24(uint24(_auxData >> 16)), //tickUpper
+            uint24(uint8(_auxData >> 8)) * 100, ////fee should be in hundredths of a bip. 1 bip = 1/100, i.e. 1e^-6.
+            _interactionNonce
+        );
+
+        uint8 daysToCancel = uint8(_auxData);
+
+        asyncOrders[_interactionNonce] = AsyncOrder({
+            finalisable: false,
+            expiry: block.timestamp + uint256(daysToCancel) * MAGIC_NUMBER_DAYS
+        });
+
+        //no refunding necessary since a range order if properly executed will have no refunds
+        //note then that it is imperative that the order be executed properly, as any refunds will
+        //NOT be returned the user
+
+        //we handle the case of cancellation in finalise()
+    }
+
+    /**
+     * @notice finalises an interaction if possible.
+     * @dev performs safety checks, and then makes approval to the rollup processor, and changes to asyncOrders.
+     * @param _outputAssetA _outputAssetA, asset that will be returned
+     * @param _outputAssetB outputAsset B, asset that will be returned
+     * @param _interactionNonce the nonce, used to determine amounts returned via deposits[itneractionNonce]
+     * @return outputValueA amountA returned to bridge
+     * @return outputValueB amountB returned to bridge
+     */
+    function finalise(
+        AztecTypes.AztecAsset calldata,
+        AztecTypes.AztecAsset calldata,
+        AztecTypes.AztecAsset calldata _outputAssetA,
+        AztecTypes.AztecAsset calldata _outputAssetB,
+        uint256 _interactionNonce,
+        uint64
+    )
+        external
+        payable
+        override(IDefiBridge)
+        returns (
+            uint256 outputValueA,
+            uint256 outputValueB,
+            bool interactionComplete
+        )
+    {
+        if (msg.sender != address(ROLLUP_PROCESSOR)) revert ErrorLib.InvalidCaller();
+        //interactionComplete = false;
+        if (asyncOrders[_interactionNonce].finalisable) {
+            //withdrawing LP
+
+            //sanity check
+            address tokenA = _handleETHReturnAddress(_outputAssetA);
+            address tokenB = _handleETHReturnAddress(_outputAssetB);
+
+            {
+                // less storage reads
+                address token0 = deposits[_interactionNonce].token0;
+                address token1 = deposits[_interactionNonce].token1;
+
+                bool validArgs = ((tokenA == token0 && token1 == tokenB) || (tokenB == token0 && token1 == tokenA));
+                if (!validArgs) revert InvalidOutputs();
+            }
+
+            (outputValueA, outputValueB) = (deposits[_interactionNonce].amount0, deposits[_interactionNonce].amount1);
+
+            //done because _decreaseLiquidity spits out amount0 amount1 and A && B not necessariy == token0 && token1
+            if (!(tokenA == deposits[_interactionNonce].token0)) {
+                (outputValueA, outputValueB) = (outputValueB, outputValueA);
+            }
+
+            IERC20(tokenA).safeApprove(address(ROLLUP_PROCESSOR), 0);
+            IERC20(tokenB).safeApprove(address(ROLLUP_PROCESSOR), 0);
+            IERC20(tokenA).safeApprove(address(ROLLUP_PROCESSOR), outputValueA);
+            IERC20(tokenB).safeApprove(address(ROLLUP_PROCESSOR), outputValueB);
+            // TODO: simplify this logic
+            if (_outputAssetA.assetType == AztecTypes.AztecAssetType.ETH) {
+                WETH.withdraw(outputValueA);
+                ROLLUP_PROCESSOR.receiveEthFromBridge{value: outputValueA}(_interactionNonce);
+            } else if (_outputAssetB.assetType == AztecTypes.AztecAssetType.ETH) {
+                WETH.withdraw(outputValueB);
+                ROLLUP_PROCESSOR.receiveEthFromBridge{value: outputValueB}(_interactionNonce);
+            }
+
+            //now that the settlement is finalised and the rollup will return user funds, clear map element for this interaction
+            //deposits[_interactionNonce] = 0; unncessary as _decreaseLiquidity modifies     vars accordingly
+            asyncOrders[_interactionNonce].finalisable = true;
+            asyncOrders[_interactionNonce].expiry = 0;
+            interactionComplete = true;
+        }
+    }
+
+    /**
+     * @notice  packs _auxData for front end user
+     * @dev The first 24 bits are tickLower. The second 24 are tickUpper. The 3rd 8 the pool's fee / 10.
+     * As a pool's fee ranges from 10 bps, 100 bps, 300 bps, and 1000 bps, there is no data loss and type conversion
+     * is acceptable.
+     * @param _tickLower the lower range of the position
+     * @param _tickUpper the upper range of the position
+     * @param _daysToCancel the time limit for the order / expiry
+     * @param _fee the fee tier of the pool
+     * @return data the packed _auxData
+     */
+    function packData(
+        int24 _tickLower,
+        int24 _tickUpper,
+        uint8 _daysToCancel,
+        uint8 _fee
+    ) external view returns (uint64 data) {
+        uint24 a = uint24(_tickLower);
+        uint24 b = uint24(_tickUpper);
+        uint48 ticks = (uint48(a) << 24) | uint48(b);
+        uint16 last16 = ((uint16(_fee) << 8) | uint16(_daysToCancel));
+        data = (uint64(ticks) << 16) | uint64(last16);
+    }
+
+    function finalised(uint256 _interactionNonce) external view returns (bool) {
+        return asyncOrders[_interactionNonce].finalisable;
+    }
+
+    function getExpiry(uint256 _interactionNonce) external view returns (uint256) {
+        return asyncOrders[_interactionNonce].expiry;
+    }
+
+    /**
+     * @notice  Function used to check if limit conditions of an order have been met
+     * @dev if the order is denominated by lower price space, it is a buy limit order, so
+     * we check if the current tick is less than or equal to the tickLower of the order
+     * if the order is denominated by the higher price space, it is a sell limit order, so we check
+     * if the current tick is higher than or equal to the tickUpper of the order
+     * @param _interactionNonce the nonce of the interaction
+     * @return bool whether or not the limit conditions were met
+     */
+    function _checkLimitConditions(uint256 _interactionNonce) internal view returns (bool) {
+        Deposit memory deposit = deposits[_interactionNonce];
+        IUniswapV3Pool pool = IUniswapV3Pool(UNISWAP_FACTORY.getPool(deposit.token0, deposit.token1, deposit.fee));
+        (uint160 sqrtPriceX96, , , , , , ) = pool.slot0();
+        int24 currentTick = TickMath.getTickAtSqrtRatio(sqrtPriceX96);
+        return (deposit.tickLower <= currentTick && currentTick <= deposit.tickUpper);
+    }
+}

--- a/src/bridges/uniswap_lp/spec.md
+++ b/src/bridges/uniswap_lp/spec.md
@@ -1,0 +1,65 @@
+[![CircleCI](https://circleci.com/gh/AztecProtocol/aztec-connect-bridges/tree/master.svg?style=shield)](https://circleci.com/gh/AztecProtocol/aztec-connect-bridges/tree/master)
+
+# Uniswap V3 Bridge for Liquidity Provision
+
+These are the Aztec Connect bridges for Uniswap V3 Liquidity Provision. There is a main bridge, the SyncUniswapV3Bridge, and a
+secondary bridge, the UniRangeOrderBridge. The main bridge handles standard LPing where two assets are provided, and an NFT representing the position is returned, while the secondary bridge is used for range orders. which is just LPing outside the current tick range. See :
+https://docs.uniswap.org/protocol/concepts/V3-overview/range-orders#:~:text=In%20typical%20order%20book%20markets,liquidity%20within%20a%20specific%20range.
+
+The flows for the two bridges are presented as follows:
+
+SyncUniswapV3Bridge :
+There are 3 flows, the TwoPartMint interaction flow, the MintBySwap interaction flow, and the redemption flow.
+
+TwoPartMint has two parts. This flow is intended for users who already have as zkAssets the assets for which they
+intend to LP. E.g. zkDAI and zkETH are both held by the user and they want to LP for the DAI/ETH .3% pool. There exists a current limitation wherein only 1 real input asset can be provided to the bridge, per convert call. Hence we use two convert calls to process the interaction.
+
+    1st convert call:
+    1 real input (zkDAI/DAI), 1 not used
+    1 virtual output 1 not used
+
+The real input is essentially deposited into the bridge, and a record (in the form of a struct called MintFunding) of the funding amount and the funding token's address is made in a data structure (a map ) called SyncMintFundingMap. Thus the funding which is used to fund the 2nd convert call is recorded. Ownership of this funding is proven through ownership of virtual notes, which prove ownership of an interaction nonce / specific interaction.
+
+    2nd convert call:
+
+    1 real input (zkETH/ETH) 1 virtual input
+    1 virtual output 1 real output
+
+On the 2nd convert call, based on the structure of the inputs/outputs, the bridge will understand the interaction to be the 2nd part of the TwoPartMint flow, and will use the virtual input to check for fundings made for TwoPartMint interactions, and use the assets deposited on the interaction for which the virtual input has ownership of
+
+The bridge now has two assets which it can provide to a pool to LP, and the bridge will then call some internal functions which mostly amount to nonfungiblePositionManager.mint(...) being called. Once liquidity is minted, a record of this position's data is made in the form of a Deposit struct map. The position NFT is held by the bridge, and a virtual output is returned which the user can provide to redeem liquidity.
+
+The 1 real output is used for any refunds.
+
+MintBySwap is a flow where the user only has one asset but can indicate which pool they wish to LP for, and the bridge will swap half of their asset into the second asset of the pool, and then take the two assets and LP.
+
+    1 real (zkDAI/DAI) 1 not used
+    1 virtual 1 real (zkETH/ETH)
+
+The 1 real input (zkDAI/DAI) is used is as the first token/ swap input, and the 1 real output (zkETH/ETH) is used as the second token of the pool / swap output. After swapping, the bridge mints liquidity in the same pool (DAI/ETH) that it just swapped with. Any refunds are made to the 1 real output asset (superfluous amounts of refunded tokens are swapped to be the same token as the refund token). As in TwoPartMint, when liquidity is minted, a record of the position is made in the form of a Deposit struct mapping, and a virtual note output is returned , which proves ownership of the nonce/ deposit.
+
+Redemption flow:
+
+    1 virtual input 1 not used
+    1 real output 1 real output
+
+The virtual input proves ownership of a position via the "deposits" mapping which is a uint256 -> Deposit struct mapping, where the uint256 is an interaction nonce. The virtual input's id , which is the nonce, is inputted, the bridge checks the mapping, and redeems liquidity based on the tokenId recorded in the Deposit struct. The assets returned correspond to the two real outputs.
+
+UniRangeOrderBridge:
+There are two flows: the minting/range order flow, and the redemption flow.
+
+Minting/range order flow:
+
+    1 real input 1 not used
+    1 real output 1 real output
+
+This interaction is asynchronous. 1 real input used the first token, 1 real output used as the second token for the pool. The 2nd real output is for the later finalise() call made by the rollupProcessor, so that the rollupProcessor can "allocate" an AztecAsset. Range orders only need 1 token to be funded, so the bridge will assume the output to have an amount of 0 when making the nonfungiblePositionManager.mint(...) call. When liquidity is minted, a record is made in the "deposits" uint256->Deposit struct mapping, just as in the synchronous bridge. However an additional record is made in an "asyncOrders" mapping which contains the expiry of the range order and whether it can be finalised. It can only be finalised if the current tick of the Uniswap pool drifts into limit price/range of the order or the order expires. If the order can be finalised, liquidity can be redeemed.
+
+Redemption:
+As explained, when the order is finalisable, liquidity can be redeemed. Redemption occurs through an external function called trigger() which takes a nonce as an arg and checks if the order corresponding to the nonce has had its limit range met. If it has , then it sets the finalisable bool var to true, and withdraws/burns liquidity. Then the caller may call rollupProcessor.processAsyncDeFiInteraction(...) to process the interaction and they will receive the outputs of the transaction. The interaction can also be finalised by calling cancel(uint256 interactionNonce) which will withdraw/burn liquidity of the position owned by the nonce if the order has expired, and then calling processAsyncDeFiInteraction as before.
+
+Other notes:
+
+These bridges requires user-defined data to function, via the uint64 auxData. For the synchronous bridge, this auxiliary data contains the tickLower and tickUpper of the LP, as well as the fee of the pool so it knows where to swap / mint liquidity in. The asynchronous bridge requires a tickLower, a tickUpper, a fee, as well as a number of days until expiry.
+
+The Uniswap.t.sol test contains good examples of how these flows actually look like in Solidity.

--- a/src/interfaces/uniswapv3/IERC165.sol
+++ b/src/interfaces/uniswapv3/IERC165.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts v4.4.1 (utils/introspection/IERC165.sol)
+
+pragma solidity >=0.6.10 <=0.8.10;
+
+/**
+ * @dev Interface of the ERC165 standard, as defined in the
+ * https://eips.ethereum.org/EIPS/eip-165[EIP].
+ *
+ * Implementers can declare support of contract interfaces, which can then be
+ * queried by others ({ERC165Checker}).
+ *
+ * For an implementation, see {ERC165}.
+ */
+interface IERC165 {
+    /**
+     * @dev Returns true if this contract implements the interface defined by
+     * `interfaceId`. See the corresponding
+     * https://eips.ethereum.org/EIPS/eip-165#how-interfaces-are-identified[EIP section]
+     * to learn more about how these ids are created.
+     *
+     * This function call must use less than 30 000 gas.
+     */
+    function supportsInterface(bytes4 interfaceId) external view returns (bool);
+}

--- a/src/interfaces/uniswapv3/IERC721.sol
+++ b/src/interfaces/uniswapv3/IERC721.sol
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts v4.4.1 (token/ERC721/IERC721.sol)
+
+pragma solidity >=0.6.10 <=0.8.10;
+
+import "./IERC165.sol";
+
+/**
+ * @dev Required interface of an ERC721 compliant contract.
+ */
+interface IERC721 is IERC165 {
+    /**
+     * @dev Emitted when `tokenId` token is transferred from `from` to `to`.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 indexed tokenId);
+
+    /**
+     * @dev Emitted when `owner` enables `approved` to manage the `tokenId` token.
+     */
+    event Approval(address indexed owner, address indexed approved, uint256 indexed tokenId);
+
+    /**
+     * @dev Emitted when `owner` enables or disables (`approved`) `operator` to manage all of its assets.
+     */
+    event ApprovalForAll(address indexed owner, address indexed operator, bool approved);
+
+    /**
+     * @dev Returns the number of tokens in ``owner``'s account.
+     */
+    function balanceOf(address owner) external view returns (uint256 balance);
+
+    /**
+     * @dev Returns the owner of the `tokenId` token.
+     *
+     * Requirements:
+     *
+     * - `tokenId` must exist.
+     */
+    function ownerOf(uint256 tokenId) external view returns (address owner);
+
+    /**
+     * @dev Safely transfers `tokenId` token from `from` to `to`, checking first that contract recipients
+     * are aware of the ERC721 protocol to prevent tokens from being forever locked.
+     *
+     * Requirements:
+     *
+     * - `from` cannot be the zero address.
+     * - `to` cannot be the zero address.
+     * - `tokenId` token must exist and be owned by `from`.
+     * - If the caller is not `from`, it must be have been allowed to move this token by either {approve} or {setApprovalForAll}.
+     * - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.
+     *
+     * Emits a {Transfer} event.
+     */
+    function safeTransferFrom(
+        address from,
+        address to,
+        uint256 tokenId
+    ) external;
+
+    /**
+     * @dev Transfers `tokenId` token from `from` to `to`.
+     *
+     * WARNING: Usage of this method is discouraged, use {safeTransferFrom} whenever possible.
+     *
+     * Requirements:
+     *
+     * - `from` cannot be the zero address.
+     * - `to` cannot be the zero address.
+     * - `tokenId` token must be owned by `from`.
+     * - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(
+        address from,
+        address to,
+        uint256 tokenId
+    ) external;
+
+    /**
+     * @dev Gives permission to `to` to transfer `tokenId` token to another account.
+     * The approval is cleared when the token is transferred.
+     *
+     * Only a single account can be approved at a time, so approving the zero address clears previous approvals.
+     *
+     * Requirements:
+     *
+     * - The caller must own the token or be an approved operator.
+     * - `tokenId` must exist.
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address to, uint256 tokenId) external;
+
+    /**
+     * @dev Returns the account approved for `tokenId` token.
+     *
+     * Requirements:
+     *
+     * - `tokenId` must exist.
+     */
+    function getApproved(uint256 tokenId) external view returns (address operator);
+
+    /**
+     * @dev Approve or remove `operator` as an operator for the caller.
+     * Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller.
+     *
+     * Requirements:
+     *
+     * - The `operator` cannot be the caller.
+     *
+     * Emits an {ApprovalForAll} event.
+     */
+    function setApprovalForAll(address operator, bool _approved) external;
+
+    /**
+     * @dev Returns if the `operator` is allowed to manage all of the assets of `owner`.
+     *
+     * See {setApprovalForAll}
+     */
+    function isApprovedForAll(address owner, address operator) external view returns (bool);
+
+    /**
+     * @dev Safely transfers `tokenId` token from `from` to `to`.
+     *
+     * Requirements:
+     *
+     * - `from` cannot be the zero address.
+     * - `to` cannot be the zero address.
+     * - `tokenId` token must exist and be owned by `from`.
+     * - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.
+     * - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.
+     *
+     * Emits a {Transfer} event.
+     */
+    function safeTransferFrom(
+        address from,
+        address to,
+        uint256 tokenId,
+        bytes calldata data
+    ) external;
+}

--- a/src/interfaces/uniswapv3/IERC721Enumerable.sol
+++ b/src/interfaces/uniswapv3/IERC721Enumerable.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts v4.4.1 (token/ERC721/extensions/IERC721Enumerable.sol)
+
+pragma solidity >=0.6.10 <=0.8.10;
+
+import "./IERC721.sol";
+
+/**
+ * @title ERC-721 Non-Fungible Token Standard, optional enumeration extension
+ * @dev See https://eips.ethereum.org/EIPS/eip-721
+ */
+interface IERC721Enumerable is IERC721 {
+    /**
+     * @dev Returns the total amount of tokens stored by the contract.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns a token ID owned by `owner` at a given `index` of its token list.
+     * Use along with {balanceOf} to enumerate all of ``owner``'s tokens.
+     */
+    function tokenOfOwnerByIndex(address owner, uint256 index) external view returns (uint256 tokenId);
+
+    /**
+     * @dev Returns a token ID at a given `index` of all the tokens stored by the contract.
+     * Use along with {totalSupply} to enumerate all tokens.
+     */
+    function tokenByIndex(uint256 index) external view returns (uint256);
+}

--- a/src/interfaces/uniswapv3/IERC721Metadata.sol
+++ b/src/interfaces/uniswapv3/IERC721Metadata.sol
@@ -1,0 +1,24 @@
+pragma solidity >=0.6.10 <=0.8.10;
+
+import "./IERC721.sol";
+
+/**
+ * @title ERC-721 Non-Fungible Token Standard, optional metadata extension
+ * @dev See https://eips.ethereum.org/EIPS/eip-721
+ */
+interface IERC721Metadata is IERC721 {
+    /**
+     * @dev Returns the token collection name.
+     */
+    function name() external view returns (string memory);
+
+    /**
+     * @dev Returns the token collection symbol.
+     */
+    function symbol() external view returns (string memory);
+
+    /**
+     * @dev Returns the Uniform Resource Identifier (URI) for `tokenId` token.
+     */
+    function tokenURI(uint256 tokenId) external view returns (string memory);
+}

--- a/src/interfaces/uniswapv3/IERC721Permit.sol
+++ b/src/interfaces/uniswapv3/IERC721Permit.sol
@@ -1,0 +1,30 @@
+pragma solidity >=0.6.10 <=0.8.10;
+import {IERC721} from "./IERC721.sol";
+
+/// @title ERC721 with permit
+/// @notice Extension to ERC721 that includes a permit function for signature based approvals
+interface IERC721Permit is IERC721 {
+    /// @notice The permit typehash used in the permit signature
+    /// @return The typehash for the permit
+    function PERMIT_TYPEHASH() external pure returns (bytes32);
+
+    /// @notice The domain separator used in the permit signature
+    /// @return The domain seperator used in encoding of permit signature
+    function DOMAIN_SEPARATOR() external view returns (bytes32);
+
+    /// @notice Approve of a specific token ID for spending by spender via signature
+    /// @param spender The account that is being approved
+    /// @param tokenId The ID of the token that is being approved for spending
+    /// @param deadline The deadline timestamp by which the call must be mined for the approve to work
+    /// @param v Must produce valid secp256k1 signature from the holder along with `r` and `s`
+    /// @param r Must produce valid secp256k1 signature from the holder along with `v` and `s`
+    /// @param s Must produce valid secp256k1 signature from the holder along with `r` and `v`
+    function permit(
+        address spender,
+        uint256 tokenId,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external payable;
+}

--- a/src/interfaces/uniswapv3/INonfungiblePositionManager.sol
+++ b/src/interfaces/uniswapv3/INonfungiblePositionManager.sol
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.6.10 <=0.8.10;
+pragma abicoder v2;
+
+import "./IERC721Metadata.sol";
+import "./IERC721Enumerable.sol";
+
+import "./IPoolInitializer.sol";
+import "./IERC721Permit.sol";
+import "./IPeripheryPayments.sol";
+import "./IPeripheryImmutableState.sol";
+import "../../libraries/uniswapv3/PoolAddress.sol";
+
+/// @title Non-fungible token for positions
+/// @notice Wraps Uniswap V3 positions in a non-fungible token interface which allows for them to be transferred
+/// and authorized.
+interface INonfungiblePositionManager is
+    IPoolInitializer,
+    IPeripheryPayments,
+    IPeripheryImmutableState,
+    IERC721Metadata,
+    IERC721Enumerable,
+    IERC721Permit
+{
+    /// @notice Emitted when liquidity is increased for a position NFT
+    /// @dev Also emitted when a token is minted
+    /// @param tokenId The ID of the token for which liquidity was increased
+    /// @param liquidity The amount by which liquidity for the NFT position was increased
+    /// @param amount0 The amount of token0 that was paid for the increase in liquidity
+    /// @param amount1 The amount of token1 that was paid for the increase in liquidity
+    event IncreaseLiquidity(uint256 indexed tokenId, uint128 liquidity, uint256 amount0, uint256 amount1);
+    /// @notice Emitted when liquidity is decreased for a position NFT
+    /// @param tokenId The ID of the token for which liquidity was decreased
+    /// @param liquidity The amount by which liquidity for the NFT position was decreased
+    /// @param amount0 The amount of token0 that was accounted for the decrease in liquidity
+    /// @param amount1 The amount of token1 that was accounted for the decrease in liquidity
+    event DecreaseLiquidity(uint256 indexed tokenId, uint128 liquidity, uint256 amount0, uint256 amount1);
+    /// @notice Emitted when tokens are collected for a position NFT
+    /// @dev The amounts reported may not be exactly equivalent to the amounts transferred, due to rounding behavior
+    /// @param tokenId The ID of the token for which underlying tokens were collected
+    /// @param recipient The address of the account that received the collected tokens
+    /// @param amount0 The amount of token0 owed to the position that was collected
+    /// @param amount1 The amount of token1 owed to the position that was collected
+    event Collect(uint256 indexed tokenId, address recipient, uint256 amount0, uint256 amount1);
+
+    /// @notice Returns the position information associated with a given token ID.
+    /// @dev Throws if the token ID is not valid.
+    /// @param tokenId The ID of the token that represents the position
+    /// @return nonce The nonce for permits
+    /// @return operator The address that is approved for spending
+    /// @return token0 The address of the token0 for a specific pool
+    /// @return token1 The address of the token1 for a specific pool
+    /// @return fee The fee associated with the pool
+    /// @return tickLower The lower end of the tick range for the position
+    /// @return tickUpper The higher end of the tick range for the position
+    /// @return liquidity The liquidity of the position
+    /// @return feeGrowthInside0LastX128 The fee growth of token0 as of the last action on the individual position
+    /// @return feeGrowthInside1LastX128 The fee growth of token1 as of the last action on the individual position
+    /// @return tokensOwed0 The uncollected amount of token0 owed to the position as of the last computation
+    /// @return tokensOwed1 The uncollected amount of token1 owed to the position as of the last computation
+    function positions(uint256 tokenId)
+        external
+        view
+        returns (
+            uint96 nonce,
+            address operator,
+            address token0,
+            address token1,
+            uint24 fee,
+            int24 tickLower,
+            int24 tickUpper,
+            uint128 liquidity,
+            uint256 feeGrowthInside0LastX128,
+            uint256 feeGrowthInside1LastX128,
+            uint128 tokensOwed0,
+            uint128 tokensOwed1
+        );
+
+    struct MintParams {
+        address token0;
+        address token1;
+        uint24 fee;
+        int24 tickLower;
+        int24 tickUpper;
+        uint256 amount0Desired;
+        uint256 amount1Desired;
+        uint256 amount0Min;
+        uint256 amount1Min;
+        address recipient;
+        uint256 deadline;
+    }
+
+    /// @notice Creates a new position wrapped in a NFT
+    /// @dev Call this when the pool does exist and is initialized. Note that if the pool is created but not initialized
+    /// a method does not exist, i.e. the pool is assumed to be initialized.
+    /// @param params The params necessary to mint a position, encoded as `MintParams` in calldata
+    /// @return tokenId The ID of the token that represents the minted position
+    /// @return liquidity The amount of liquidity for this position
+    /// @return amount0 The amount of token0
+    /// @return amount1 The amount of token1
+    function mint(MintParams calldata params)
+        external
+        payable
+        returns (
+            uint256 tokenId,
+            uint128 liquidity,
+            uint256 amount0,
+            uint256 amount1
+        );
+
+    struct IncreaseLiquidityParams {
+        uint256 tokenId;
+        uint256 amount0Desired;
+        uint256 amount1Desired;
+        uint256 amount0Min;
+        uint256 amount1Min;
+        uint256 deadline;
+    }
+
+    /// @notice Increases the amount of liquidity in a position, with tokens paid by the `msg.sender`
+    /// @param params tokenId The ID of the token for which liquidity is being increased,
+    /// amount0Desired The desired amount of token0 to be spent,
+    /// amount1Desired The desired amount of token1 to be spent,
+    /// amount0Min The minimum amount of token0 to spend, which serves as a slippage check,
+    /// amount1Min The minimum amount of token1 to spend, which serves as a slippage check,
+    /// deadline The time by which the transaction must be included to effect the change
+    /// @return liquidity The new liquidity amount as a result of the increase
+    /// @return amount0 The amount of token0 to acheive resulting liquidity
+    /// @return amount1 The amount of token1 to acheive resulting liquidity
+    function increaseLiquidity(IncreaseLiquidityParams calldata params)
+        external
+        payable
+        returns (
+            uint128 liquidity,
+            uint256 amount0,
+            uint256 amount1
+        );
+
+    struct DecreaseLiquidityParams {
+        uint256 tokenId;
+        uint128 liquidity;
+        uint256 amount0Min;
+        uint256 amount1Min;
+        uint256 deadline;
+    }
+
+    /// @notice Decreases the amount of liquidity in a position and accounts it to the position
+    /// @param params tokenId The ID of the token for which liquidity is being decreased,
+    /// amount The amount by which liquidity will be decreased,
+    /// amount0Min The minimum amount of token0 that should be accounted for the burned liquidity,
+    /// amount1Min The minimum amount of token1 that should be accounted for the burned liquidity,
+    /// deadline The time by which the transaction must be included to effect the change
+    /// @return amount0 The amount of token0 accounted to the position's tokens owed
+    /// @return amount1 The amount of token1 accounted to the position's tokens owed
+    function decreaseLiquidity(DecreaseLiquidityParams calldata params)
+        external
+        payable
+        returns (uint256 amount0, uint256 amount1);
+
+    struct CollectParams {
+        uint256 tokenId;
+        address recipient;
+        uint128 amount0Max;
+        uint128 amount1Max;
+    }
+
+    /// @notice Collects up to a maximum amount of fees owed to a specific position to the recipient
+    /// @param params tokenId The ID of the NFT for which tokens are being collected,
+    /// recipient The account that should receive the tokens,
+    /// amount0Max The maximum amount of token0 to collect,
+    /// amount1Max The maximum amount of token1 to collect
+    /// @return amount0 The amount of fees collected in token0
+    /// @return amount1 The amount of fees collected in token1
+    function collect(CollectParams calldata params) external payable returns (uint256 amount0, uint256 amount1);
+
+    /// @notice Burns a token ID, which deletes it from the NFT contract. The token must have 0 liquidity and all tokens
+    /// must be collected first.
+    /// @param tokenId The ID of the token that is being burned
+    function burn(uint256 tokenId) external payable;
+}

--- a/src/interfaces/uniswapv3/IPeripheryImmutableState.sol
+++ b/src/interfaces/uniswapv3/IPeripheryImmutableState.sol
@@ -1,0 +1,11 @@
+pragma solidity >=0.6.10 <=0.8.10;
+
+/// @title Immutable state
+/// @notice Functions that return immutable state of the router
+interface IPeripheryImmutableState {
+    /// @return Returns the address of the Uniswap V3 factory
+    function factory() external view returns (address);
+
+    /// @return Returns the address of WETH9
+    function WETH9() external view returns (address);
+}

--- a/src/interfaces/uniswapv3/IPeripheryPayments.sol
+++ b/src/interfaces/uniswapv3/IPeripheryPayments.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.6.10 <=0.8.10;
+
+/// @title Periphery Payments
+/// @notice Functions to ease deposits and withdrawals of ETH
+interface IPeripheryPayments {
+    /// @notice Unwraps the contract's WETH9 balance and sends it to recipient as ETH.
+    /// @dev The amountMinimum parameter prevents malicious contracts from stealing WETH9 from users.
+    /// @param amountMinimum The minimum amount of WETH9 to unwrap
+    /// @param recipient The address receiving ETH
+    function unwrapWETH9(uint256 amountMinimum, address recipient) external payable;
+
+    /// @notice Refunds any ETH balance held by this contract to the `msg.sender`
+    /// @dev Useful for bundling with mint or increase liquidity that uses ether, or exact output swaps
+    /// that use ether for the input amount
+    function refundETH() external payable;
+
+    /// @notice Transfers the full amount of a token held by this contract to recipient
+    /// @dev The amountMinimum parameter prevents malicious contracts from stealing the token from users
+    /// @param token The contract address of the token which will be transferred to `recipient`
+    /// @param amountMinimum The minimum amount of token required for a transfer
+    /// @param recipient The destination address of the token
+    function sweepToken(
+        address token,
+        uint256 amountMinimum,
+        address recipient
+    ) external payable;
+}

--- a/src/interfaces/uniswapv3/IPoolInitializer.sol
+++ b/src/interfaces/uniswapv3/IPoolInitializer.sol
@@ -1,0 +1,20 @@
+pragma solidity >=0.6.10 <=0.8.10;
+
+/// @title Creates and initializes V3 Pools
+/// @notice Provides a method for creating and initializing a pool, if necessary, for bundling with other methods that
+/// require the pool to exist.
+interface IPoolInitializer {
+    /// @notice Creates a new pool if it does not exist, then initializes if not initialized
+    /// @dev This method can be bundled with others via IMulticall for the first action (e.g. mint) performed against a pool
+    /// @param token0 The contract address of token0 of the pool
+    /// @param token1 The contract address of token1 of the pool
+    /// @param fee The fee amount of the v3 pool for the specified token pair
+    /// @param sqrtPriceX96 The initial square root price of the pool as a Q64.96 value
+    /// @return pool Returns the pool address based on the pair of tokens and fee, will return the newly created pool address if necessary
+    function createAndInitializePoolIfNecessary(
+        address token0,
+        address token1,
+        uint24 fee,
+        uint160 sqrtPriceX96
+    ) external payable returns (address pool);
+}

--- a/src/interfaces/uniswapv3/IQuoterV2.sol
+++ b/src/interfaces/uniswapv3/IQuoterV2.sol
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.7.5;
+pragma abicoder v2;
+
+/// @title QuoterV2 Interface
+/// @notice Supports quoting the calculated amounts from exact input or exact output swaps.
+/// @notice For each pool also tells you the number of initialized ticks crossed and the sqrt price of the pool after the swap.
+/// @dev These functions are not marked view because they rely on calling non-view functions and reverting
+/// to compute the result. They are also not gas efficient and should not be called on-chain.
+interface IQuoterV2 {
+    /// @notice Returns the amount out received for a given exact input swap without executing the swap
+    /// @param path The path of the swap, i.e. each token pair and the pool fee
+    /// @param amountIn The amount of the first token to swap
+    /// @return amountOut The amount of the last token that would be received
+    /// @return sqrtPriceX96AfterList List of the sqrt price after the swap for each pool in the path
+    /// @return initializedTicksCrossedList List of the initialized ticks that the swap crossed for each pool in the path
+    /// @return gasEstimate The estimate of the gas that the swap consumes
+    function quoteExactInput(bytes memory path, uint256 amountIn)
+        external
+        returns (
+            uint256 amountOut,
+            uint160[] memory sqrtPriceX96AfterList,
+            uint32[] memory initializedTicksCrossedList,
+            uint256 gasEstimate
+        );
+
+    struct QuoteExactInputSingleParams {
+        address tokenIn;
+        address tokenOut;
+        uint256 amountIn;
+        uint24 fee;
+        uint160 sqrtPriceLimitX96;
+    }
+
+    /// @notice Returns the amount out received for a given exact input but for a swap of a single pool
+    /// @param params The params for the quote, encoded as `QuoteExactInputSingleParams`
+    /// tokenIn The token being swapped in
+    /// tokenOut The token being swapped out
+    /// fee The fee of the token pool to consider for the pair
+    /// amountIn The desired input amount
+    /// sqrtPriceLimitX96 The price limit of the pool that cannot be exceeded by the swap
+    /// @return amountOut The amount of `tokenOut` that would be received
+    /// @return sqrtPriceX96After The sqrt price of the pool after the swap
+    /// @return initializedTicksCrossed The number of initialized ticks that the swap crossed
+    /// @return gasEstimate The estimate of the gas that the swap consumes
+    function quoteExactInputSingle(QuoteExactInputSingleParams memory params)
+        external
+        returns (
+            uint256 amountOut,
+            uint160 sqrtPriceX96After,
+            uint32 initializedTicksCrossed,
+            uint256 gasEstimate
+        );
+
+    /// @notice Returns the amount in required for a given exact output swap without executing the swap
+    /// @param path The path of the swap, i.e. each token pair and the pool fee. Path must be provided in reverse order
+    /// @param amountOut The amount of the last token to receive
+    /// @return amountIn The amount of first token required to be paid
+    /// @return sqrtPriceX96AfterList List of the sqrt price after the swap for each pool in the path
+    /// @return initializedTicksCrossedList List of the initialized ticks that the swap crossed for each pool in the path
+    /// @return gasEstimate The estimate of the gas that the swap consumes
+    function quoteExactOutput(bytes memory path, uint256 amountOut)
+        external
+        returns (
+            uint256 amountIn,
+            uint160[] memory sqrtPriceX96AfterList,
+            uint32[] memory initializedTicksCrossedList,
+            uint256 gasEstimate
+        );
+
+    struct QuoteExactOutputSingleParams {
+        address tokenIn;
+        address tokenOut;
+        uint256 amount;
+        uint24 fee;
+        uint160 sqrtPriceLimitX96;
+    }
+
+    /// @notice Returns the amount in required to receive the given exact output amount but for a swap of a single pool
+    /// @param params The params for the quote, encoded as `QuoteExactOutputSingleParams`
+    /// tokenIn The token being swapped in
+    /// tokenOut The token being swapped out
+    /// fee The fee of the token pool to consider for the pair
+    /// amountOut The desired output amount
+    /// sqrtPriceLimitX96 The price limit of the pool that cannot be exceeded by the swap
+    /// @return amountIn The amount required as the input for the swap in order to receive `amountOut`
+    /// @return sqrtPriceX96After The sqrt price of the pool after the swap
+    /// @return initializedTicksCrossed The number of initialized ticks that the swap crossed
+    /// @return gasEstimate The estimate of the gas that the swap consumes
+    function quoteExactOutputSingle(QuoteExactOutputSingleParams memory params)
+        external
+        returns (
+            uint256 amountIn,
+            uint160 sqrtPriceX96After,
+            uint32 initializedTicksCrossed,
+            uint256 gasEstimate
+        );
+}

--- a/src/interfaces/uniswapv3/ISwapRouter.sol
+++ b/src/interfaces/uniswapv3/ISwapRouter.sol
@@ -1,9 +1,27 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity >=0.8.4;
+pragma solidity >=0.6.10 <=0.8.10;
+pragma abicoder v2;
+
+interface IUniswapV3SwapCallback {
+    /// @notice Called to `msg.sender` after executing a swap via IUniswapV3Pool#swap.
+    /// @dev In the implementation you must pay the pool tokens owed for the swap.
+    /// The caller of this method must be checked to be a UniswapV3Pool deployed by the canonical UniswapV3Factory.
+    /// amount0Delta and amount1Delta can both be 0 if no tokens were swapped.
+    /// @param amount0Delta The amount of token0 that was sent (negative) or must be received (positive) by the pool by
+    /// the end of the swap. If positive, the callback must send that amount of token0 to the pool.
+    /// @param amount1Delta The amount of token1 that was sent (negative) or must be received (positive) by the pool by
+    /// the end of the swap. If positive, the callback must send that amount of token1 to the pool.
+    /// @param data Any data passed through by the caller via the IUniswapV3PoolActions#swap call
+    function uniswapV3SwapCallback(
+        int256 amount0Delta,
+        int256 amount1Delta,
+        bytes calldata data
+    ) external;
+}
 
 /// @title Router token swapping functionality
 /// @notice Functions for swapping tokens via Uniswap V3
-interface ISwapRouter {
+interface ISwapRouter is IUniswapV3SwapCallback {
     struct ExactInputSingleParams {
         address tokenIn;
         address tokenOut;

--- a/src/interfaces/uniswapv3/IUniswapV3Factory.sol
+++ b/src/interfaces/uniswapv3/IUniswapV3Factory.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.6.10 <=0.8.10;
+
+/// @title The interface for the Uniswap V3 Factory
+/// @notice The Uniswap V3 Factory facilitates creation of Uniswap V3 pools and control over the protocol fees
+interface IUniswapV3Factory {
+    /// @notice Emitted when the owner of the factory is changed
+    /// @param oldOwner The owner before the owner was changed
+    /// @param newOwner The owner after the owner was changed
+    event OwnerChanged(address indexed oldOwner, address indexed newOwner);
+
+    /// @notice Emitted when a pool is created
+    /// @param token0 The first token of the pool by address sort order
+    /// @param token1 The second token of the pool by address sort order
+    /// @param fee The fee collected upon every swap in the pool, denominated in hundredths of a bip
+    /// @param tickSpacing The minimum number of ticks between initialized ticks
+    /// @param pool The address of the created pool
+    event PoolCreated(
+        address indexed token0,
+        address indexed token1,
+        uint24 indexed fee,
+        int24 tickSpacing,
+        address pool
+    );
+
+    /// @notice Emitted when a new fee amount is enabled for pool creation via the factory
+    /// @param fee The enabled fee, denominated in hundredths of a bip
+    /// @param tickSpacing The minimum number of ticks between initialized ticks for pools created with the given fee
+    event FeeAmountEnabled(uint24 indexed fee, int24 indexed tickSpacing);
+
+    /// @notice Returns the current owner of the factory
+    /// @dev Can be changed by the current owner via setOwner
+    /// @return The address of the factory owner
+    function owner() external view returns (address);
+
+    /// @notice Returns the tick spacing for a given fee amount, if enabled, or 0 if not enabled
+    /// @dev A fee amount can never be removed, so this value should be hard coded or cached in the calling context
+    /// @param fee The enabled fee, denominated in hundredths of a bip. Returns 0 in case of unenabled fee
+    /// @return The tick spacing
+    function feeAmountTickSpacing(uint24 fee) external view returns (int24);
+
+    /// @notice Returns the pool address for a given pair of tokens and a fee, or address 0 if it does not exist
+    /// @dev tokenA and tokenB may be passed in either token0/token1 or token1/token0 order
+    /// @param tokenA The contract address of either token0 or token1
+    /// @param tokenB The contract address of the other token
+    /// @param fee The fee collected upon every swap in the pool, denominated in hundredths of a bip
+    /// @return pool The pool address
+    function getPool(
+        address tokenA,
+        address tokenB,
+        uint24 fee
+    ) external view returns (address pool);
+
+    /// @notice Creates a pool for the given two tokens and fee
+    /// @param tokenA One of the two tokens in the desired pool
+    /// @param tokenB The other of the two tokens in the desired pool
+    /// @param fee The desired fee for the pool
+    /// @dev tokenA and tokenB may be passed in either order: token0/token1 or token1/token0. tickSpacing is retrieved
+    /// from the fee. The call will revert if the pool already exists, the fee is invalid, or the token arguments
+    /// are invalid.
+    /// @return pool The address of the newly created pool
+    function createPool(
+        address tokenA,
+        address tokenB,
+        uint24 fee
+    ) external returns (address pool);
+
+    /// @notice Updates the owner of the factory
+    /// @dev Must be called by the current owner
+    /// @param _owner The new owner of the factory
+    function setOwner(address _owner) external;
+
+    /// @notice Enables a fee amount with the given tickSpacing
+    /// @dev Fee amounts may never be removed once enabled
+    /// @param fee The fee amount to enable, denominated in hundredths of a bip (i.e. 1e-6)
+    /// @param tickSpacing The spacing between ticks to be enforced for all pools created with the given fee amount
+    function enableFeeAmount(uint24 fee, int24 tickSpacing) external;
+}

--- a/src/interfaces/uniswapv3/IUniswapV3Pool.sol
+++ b/src/interfaces/uniswapv3/IUniswapV3Pool.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.6.10 <=0.8.10;
+
+import "./pool/IUniswapV3PoolImmutables.sol";
+import "./pool/IUniswapV3PoolState.sol";
+import "./pool/IUniswapV3PoolDerivedState.sol";
+import "./pool/IUniswapV3PoolActions.sol";
+import "./pool/IUniswapV3PoolOwnerActions.sol";
+import "./pool/IUniswapV3PoolEvents.sol";
+
+/// @title The interface for a Uniswap V3 Pool
+/// @notice A Uniswap pool facilitates swapping and automated market making between any two assets that strictly conform
+/// to the ERC20 specification
+/// @dev The pool interface is broken up into many smaller pieces
+interface IUniswapV3Pool is
+    IUniswapV3PoolImmutables,
+    IUniswapV3PoolState,
+    IUniswapV3PoolDerivedState,
+    IUniswapV3PoolActions,
+    IUniswapV3PoolOwnerActions,
+    IUniswapV3PoolEvents
+{
+
+}

--- a/src/interfaces/uniswapv3/IUniswapV3PoolDeployer.sol
+++ b/src/interfaces/uniswapv3/IUniswapV3PoolDeployer.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.5.0;
+
+/// @title An interface for a contract that is capable of deploying Uniswap V3 Pools
+/// @notice A contract that constructs a pool must implement this to pass arguments to the pool
+/// @dev This is used to avoid having constructor arguments in the pool contract, which results in the init code hash
+/// of the pool being constant allowing the CREATE2 address of the pool to be cheaply computed on-chain
+interface IUniswapV3PoolDeployer {
+    /// @notice Get the parameters to be used in constructing the pool, set transiently during pool creation.
+    /// @dev Called by the pool constructor to fetch the parameters of the pool
+    /// Returns factory The factory address
+    /// Returns token0 The first token of the pool by address sort order
+    /// Returns token1 The second token of the pool by address sort order
+    /// Returns fee The fee collected upon every swap in the pool, denominated in hundredths of a bip
+    /// Returns tickSpacing The minimum number of ticks between initialized ticks
+    function parameters()
+        external
+        view
+        returns (
+            address factory,
+            address token0,
+            address token1,
+            uint24 fee,
+            int24 tickSpacing
+        );
+}

--- a/src/interfaces/uniswapv3/IWETH9.sol
+++ b/src/interfaces/uniswapv3/IWETH9.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.7.5;
+pragma abicoder v2;
+
+interface IWETH9 {
+    function deposit() external payable;
+
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    function transfer(address to, uint256 amount) external returns (bool);
+
+    function balanceOf(address user) external view returns (uint256);
+
+    function withdraw(uint256 wad) external;
+}

--- a/src/interfaces/uniswapv3/KeeperCompatibleInterface.sol
+++ b/src/interfaces/uniswapv3/KeeperCompatibleInterface.sol
@@ -1,0 +1,19 @@
+pragma solidity >=0.6.10 <=0.8.10;
+
+interface KeeperCompatibleInterface {
+    /*
+     * @notice method that is simulated by the keepers to see if any work actually
+     * needs to be performed. This method does does not actually need to be
+     * executable, and since it is only ever simulated it can consume lots of gas.
+     * @dev To ensure that it is never called, you may want to add the
+     * cannotExecute modifier from KeeperBase to your implementation of this
+     * method.
+     * @return success boolean to indicate whether the keeper should call
+     * performUpkeep or not.
+     * @return success bytes that the keeper should call performUpkeep with, if
+     * upkeep is needed.
+     */
+    function checkUpkeep(bytes calldata data) external returns (bool success, bytes memory dynamicData);
+
+    function performUpkeep(bytes calldata dynamicData) external;
+}

--- a/src/interfaces/uniswapv3/LICENSE
+++ b/src/interfaces/uniswapv3/LICENSE
@@ -1,0 +1,339 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/src/interfaces/uniswapv3/base/LiquidityManagement.sol
+++ b/src/interfaces/uniswapv3/base/LiquidityManagement.sol
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.6.10 <=0.8.10;
+pragma abicoder v2;
+
+import "../IUniswapV3Factory.sol";
+import "../callback/IUniswapV3MintCallback.sol";
+import "../../../libraries/uniswapv3/TickMath.sol";
+
+import "../../../libraries/uniswapv3/PoolAddress.sol";
+import "../../../libraries/uniswapv3/CallbackValidation.sol";
+import "../../../libraries/uniswapv3/LiquidityAmounts.sol";
+
+import "./PeripheryPayments.sol";
+import "./PeripheryImmutableState.sol";
+
+/// @title Liquidity management functions
+/// @notice Internal functions for safely managing liquidity in Uniswap V3
+abstract contract LiquidityManagement is IUniswapV3MintCallback, PeripheryImmutableState, PeripheryPayments {
+    struct MintCallbackData {
+        PoolAddress.PoolKey poolKey;
+        address payer;
+    }
+
+    /// @inheritdoc IUniswapV3MintCallback
+    function uniswapV3MintCallback(
+        uint256 amount0Owed,
+        uint256 amount1Owed,
+        bytes calldata data
+    ) external override {
+        MintCallbackData memory decoded = abi.decode(data, (MintCallbackData));
+        CallbackValidation.verifyCallback(factory, decoded.poolKey);
+
+        if (amount0Owed > 0) pay(decoded.poolKey.token0, decoded.payer, msg.sender, amount0Owed);
+        if (amount1Owed > 0) pay(decoded.poolKey.token1, decoded.payer, msg.sender, amount1Owed);
+    }
+
+    struct AddLiquidityParams {
+        address token0;
+        address token1;
+        uint24 fee;
+        address recipient;
+        int24 tickLower;
+        int24 tickUpper;
+        uint256 amount0Desired;
+        uint256 amount1Desired;
+        uint256 amount0Min;
+        uint256 amount1Min;
+    }
+
+    /// @notice Add liquidity to an initialized pool
+    function addLiquidity(AddLiquidityParams memory params)
+        internal
+        returns (
+            uint128 liquidity,
+            uint256 amount0,
+            uint256 amount1,
+            IUniswapV3Pool pool
+        )
+    {
+        PoolAddress.PoolKey memory poolKey = PoolAddress.PoolKey({
+            token0: params.token0,
+            token1: params.token1,
+            fee: params.fee
+        });
+
+        pool = IUniswapV3Pool(PoolAddress.computeAddress(factory, poolKey));
+
+        // compute the liquidity amount
+        {
+            (uint160 sqrtPriceX96, , , , , , ) = pool.slot0();
+            uint160 sqrtRatioAX96 = TickMath.getSqrtRatioAtTick(params.tickLower);
+            uint160 sqrtRatioBX96 = TickMath.getSqrtRatioAtTick(params.tickUpper);
+
+            liquidity = LiquidityAmounts.getLiquidityForAmounts(
+                sqrtPriceX96,
+                sqrtRatioAX96,
+                sqrtRatioBX96,
+                params.amount0Desired,
+                params.amount1Desired
+            );
+        }
+
+        (amount0, amount1) = pool.mint(
+            params.recipient,
+            params.tickLower,
+            params.tickUpper,
+            liquidity,
+            abi.encode(MintCallbackData({poolKey: poolKey, payer: msg.sender}))
+        );
+
+        require(amount0 >= params.amount0Min && amount1 >= params.amount1Min, "Price slippage check");
+    }
+}

--- a/src/interfaces/uniswapv3/base/PeripheryImmutableState.sol
+++ b/src/interfaces/uniswapv3/base/PeripheryImmutableState.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.6.10 <=0.8.10;
+
+/// @title Immutable state
+/// @notice Functions that return immutable state of the router
+interface IPeripheryImmutableState {
+    /// @return Returns the address of the Uniswap V3 factory
+    function factory() external view returns (address);
+
+    /// @return Returns the address of WETH9
+    function WETH9() external view returns (address);
+}
+
+/// @title Immutable state
+/// @notice Immutable state used by periphery contracts
+abstract contract PeripheryImmutableState is IPeripheryImmutableState {
+    /// @inheritdoc IPeripheryImmutableState
+    address public immutable override factory;
+    /// @inheritdoc IPeripheryImmutableState
+    address public immutable override WETH9;
+
+    constructor(address _factory, address _WETH9) {
+        factory = _factory;
+        WETH9 = _WETH9;
+    }
+}

--- a/src/interfaces/uniswapv3/base/PeripheryPayments.sol
+++ b/src/interfaces/uniswapv3/base/PeripheryPayments.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.6.10 <=0.8.10;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import "../IWETH9.sol";
+
+import "../../../libraries/uniswapv3/TransferHelper.sol";
+
+import "./PeripheryImmutableState.sol";
+
+/// @title Periphery Payments
+/// @notice Functions to ease deposits and withdrawals of ETH
+interface IPeripheryPayments {
+
+}
+
+abstract contract PeripheryPayments is IPeripheryPayments, PeripheryImmutableState {
+    receive() external payable {
+        require(msg.sender == WETH9, "Not WETH9");
+    }
+
+    /// @param token The token to pay
+    /// @param payer The entity that must pay
+    /// @param recipient The entity that will receive payment
+    /// @param value The amount to pay
+    function pay(
+        address token,
+        address payer,
+        address recipient,
+        uint256 value
+    ) internal {
+        if (token == WETH9 && address(this).balance >= value) {
+            // pay with WETH9
+            IWETH9(WETH9).deposit{value: value}(); // wrap only what is needed to pay
+            IWETH9(WETH9).transfer(recipient, value);
+        } else if (payer == address(this)) {
+            // pay with tokens already in the contract (for the exact input multihop case)
+            TransferHelper.safeTransfer(token, recipient, value);
+        } else {
+            // pull payment
+            TransferHelper.safeTransferFrom(token, payer, recipient, value);
+        }
+    }
+}

--- a/src/interfaces/uniswapv3/callback/IUniswapV3FlashCallback.sol
+++ b/src/interfaces/uniswapv3/callback/IUniswapV3FlashCallback.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.5.0;
+
+/// @title Callback for IUniswapV3PoolActions#flash
+/// @notice Any contract that calls IUniswapV3PoolActions#flash must implement this interface
+interface IUniswapV3FlashCallback {
+    /// @notice Called to `msg.sender` after transferring to the recipient from IUniswapV3Pool#flash.
+    /// @dev In the implementation you must repay the pool the tokens sent by flash plus the computed fee amounts.
+    /// The caller of this method must be checked to be a UniswapV3Pool deployed by the canonical UniswapV3Factory.
+    /// @param fee0 The fee amount in token0 due to the pool by the end of the flash
+    /// @param fee1 The fee amount in token1 due to the pool by the end of the flash
+    /// @param data Any data passed through by the caller via the IUniswapV3PoolActions#flash call
+    function uniswapV3FlashCallback(
+        uint256 fee0,
+        uint256 fee1,
+        bytes calldata data
+    ) external;
+}

--- a/src/interfaces/uniswapv3/callback/IUniswapV3MintCallback.sol
+++ b/src/interfaces/uniswapv3/callback/IUniswapV3MintCallback.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.6.10 <=0.8.10;
+
+/// @title Callback for IUniswapV3PoolActions#mint
+/// @notice Any contract that calls IUniswapV3PoolActions#mint must implement this interface
+interface IUniswapV3MintCallback {
+    /// @notice Called to `msg.sender` after minting liquidity to a position from IUniswapV3Pool#mint.
+    /// @dev In the implementation you must pay the pool tokens owed for the minted liquidity.
+    /// The caller of this method must be checked to be a UniswapV3Pool deployed by the canonical UniswapV3Factory.
+    /// @param amount0Owed The amount of token0 due to the pool for the minted liquidity
+    /// @param amount1Owed The amount of token1 due to the pool for the minted liquidity
+    /// @param data Any data passed through by the caller via the IUniswapV3PoolActions#mint call
+    function uniswapV3MintCallback(
+        uint256 amount0Owed,
+        uint256 amount1Owed,
+        bytes calldata data
+    ) external;
+}

--- a/src/interfaces/uniswapv3/pool/IUniswapV3PoolActions.sol
+++ b/src/interfaces/uniswapv3/pool/IUniswapV3PoolActions.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity >=0.5.0;
+pragma solidity >=0.6.10 <=0.8.10;
 
 /// @title Permissionless pool actions
 /// @notice Contains pool methods that can be called by anyone

--- a/src/interfaces/uniswapv3/pool/IUniswapV3PoolEvents.sol
+++ b/src/interfaces/uniswapv3/pool/IUniswapV3PoolEvents.sol
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.6.10 <=0.8.10;
+
+/// @title Events emitted by a pool
+/// @notice Contains all events emitted by the pool
+interface IUniswapV3PoolEvents {
+    /// @notice Emitted exactly once by a pool when #initialize is first called on the pool
+    /// @dev Mint/Burn/Swap cannot be emitted by the pool before Initialize
+    /// @param sqrtPriceX96 The initial sqrt price of the pool, as a Q64.96
+    /// @param tick The initial tick of the pool, i.e. log base 1.0001 of the starting price of the pool
+    event Initialize(uint160 sqrtPriceX96, int24 tick);
+
+    /// @notice Emitted when liquidity is minted for a given position
+    /// @param sender The address that minted the liquidity
+    /// @param owner The owner of the position and recipient of any minted liquidity
+    /// @param tickLower The lower tick of the position
+    /// @param tickUpper The upper tick of the position
+    /// @param amount The amount of liquidity minted to the position range
+    /// @param amount0 How much token0 was required for the minted liquidity
+    /// @param amount1 How much token1 was required for the minted liquidity
+    event Mint(
+        address sender,
+        address indexed owner,
+        int24 indexed tickLower,
+        int24 indexed tickUpper,
+        uint128 amount,
+        uint256 amount0,
+        uint256 amount1
+    );
+
+    /// @notice Emitted when fees are collected by the owner of a position
+    /// @dev Collect events may be emitted with zero amount0 and amount1 when the caller chooses not to collect fees
+    /// @param owner The owner of the position for which fees are collected
+    /// @param tickLower The lower tick of the position
+    /// @param tickUpper The upper tick of the position
+    /// @param amount0 The amount of token0 fees collected
+    /// @param amount1 The amount of token1 fees collected
+    event Collect(
+        address indexed owner,
+        address recipient,
+        int24 indexed tickLower,
+        int24 indexed tickUpper,
+        uint128 amount0,
+        uint128 amount1
+    );
+
+    /// @notice Emitted when a position's liquidity is removed
+    /// @dev Does not withdraw any fees earned by the liquidity position, which must be withdrawn via #collect
+    /// @param owner The owner of the position for which liquidity is removed
+    /// @param tickLower The lower tick of the position
+    /// @param tickUpper The upper tick of the position
+    /// @param amount The amount of liquidity to remove
+    /// @param amount0 The amount of token0 withdrawn
+    /// @param amount1 The amount of token1 withdrawn
+    event Burn(
+        address indexed owner,
+        int24 indexed tickLower,
+        int24 indexed tickUpper,
+        uint128 amount,
+        uint256 amount0,
+        uint256 amount1
+    );
+
+    /// @notice Emitted by the pool for any swaps between token0 and token1
+    /// @param sender The address that initiated the swap call, and that received the callback
+    /// @param recipient The address that received the output of the swap
+    /// @param amount0 The delta of the token0 balance of the pool
+    /// @param amount1 The delta of the token1 balance of the pool
+    /// @param sqrtPriceX96 The sqrt(price) of the pool after the swap, as a Q64.96
+    /// @param liquidity The liquidity of the pool after the swap
+    /// @param tick The log base 1.0001 of price of the pool after the swap
+    event Swap(
+        address indexed sender,
+        address indexed recipient,
+        int256 amount0,
+        int256 amount1,
+        uint160 sqrtPriceX96,
+        uint128 liquidity,
+        int24 tick
+    );
+
+    /// @notice Emitted by the pool for any flashes of token0/token1
+    /// @param sender The address that initiated the swap call, and that received the callback
+    /// @param recipient The address that received the tokens from flash
+    /// @param amount0 The amount of token0 that was flashed
+    /// @param amount1 The amount of token1 that was flashed
+    /// @param paid0 The amount of token0 paid for the flash, which can exceed the amount0 plus the fee
+    /// @param paid1 The amount of token1 paid for the flash, which can exceed the amount1 plus the fee
+    event Flash(
+        address indexed sender,
+        address indexed recipient,
+        uint256 amount0,
+        uint256 amount1,
+        uint256 paid0,
+        uint256 paid1
+    );
+
+    /// @notice Emitted by the pool for increases to the number of observations that can be stored
+    /// @dev observationCardinalityNext is not the observation cardinality until an observation is written at the index
+    /// just before a mint/swap/burn.
+    /// @param observationCardinalityNextOld The previous value of the next observation cardinality
+    /// @param observationCardinalityNextNew The updated value of the next observation cardinality
+    event IncreaseObservationCardinalityNext(
+        uint16 observationCardinalityNextOld,
+        uint16 observationCardinalityNextNew
+    );
+
+    /// @notice Emitted when the protocol fee is changed by the pool
+    /// @param feeProtocol0Old The previous value of the token0 protocol fee
+    /// @param feeProtocol1Old The previous value of the token1 protocol fee
+    /// @param feeProtocol0New The updated value of the token0 protocol fee
+    /// @param feeProtocol1New The updated value of the token1 protocol fee
+    event SetFeeProtocol(uint8 feeProtocol0Old, uint8 feeProtocol1Old, uint8 feeProtocol0New, uint8 feeProtocol1New);
+
+    /// @notice Emitted when the collected protocol fees are withdrawn by the factory owner
+    /// @param sender The address that collects the protocol fees
+    /// @param recipient The address that receives the collected protocol fees
+    /// @param amount0 The amount of token0 protocol fees that is withdrawn
+    /// @param amount0 The amount of token1 protocol fees that is withdrawn
+    event CollectProtocol(address indexed sender, address indexed recipient, uint128 amount0, uint128 amount1);
+}

--- a/src/interfaces/uniswapv3/pool/IUniswapV3PoolOwnerActions.sol
+++ b/src/interfaces/uniswapv3/pool/IUniswapV3PoolOwnerActions.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.6.10 <=0.8.10;
+
+/// @title Permissioned pool actions
+/// @notice Contains pool methods that may only be called by the factory owner
+interface IUniswapV3PoolOwnerActions {
+    /// @notice Set the denominator of the protocol's % share of the fees
+    /// @param feeProtocol0 new protocol fee for token0 of the pool
+    /// @param feeProtocol1 new protocol fee for token1 of the pool
+    function setFeeProtocol(uint8 feeProtocol0, uint8 feeProtocol1) external;
+
+    /// @notice Collect the protocol fee accrued to the pool
+    /// @param recipient The address to which collected protocol fees should be sent
+    /// @param amount0Requested The maximum amount of token0 to send, can be 0 to collect fees in only token1
+    /// @param amount1Requested The maximum amount of token1 to send, can be 0 to collect fees in only token0
+    /// @return amount0 The protocol fee collected in token0
+    /// @return amount1 The protocol fee collected in token1
+    function collectProtocol(
+        address recipient,
+        uint128 amount0Requested,
+        uint128 amount1Requested
+    ) external returns (uint128 amount0, uint128 amount1);
+}

--- a/src/interfaces/uniswapv3/pool/IUniswapV3PoolState.sol
+++ b/src/interfaces/uniswapv3/pool/IUniswapV3PoolState.sol
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.6.10 <=0.8.10;
+
+/// @title Pool state that can change
+/// @notice These methods compose the pool's state, and can change with any frequency including multiple times
+/// per transaction
+interface IUniswapV3PoolState {
+    /// @notice The 0th storage slot in the pool stores many values, and is exposed as a single method to save gas
+    /// when accessed externally.
+    /// @return sqrtPriceX96 The current price of the pool as a sqrt(token1/token0) Q64.96 value
+    /// tick The current tick of the pool, i.e. according to the last tick transition that was run.
+    /// This value may not always be equal to SqrtTickMath.getTickAtSqrtRatio(sqrtPriceX96) if the price is on a tick
+    /// boundary.
+    /// observationIndex The index of the last oracle observation that was written,
+    /// observationCardinality The current maximum number of observations stored in the pool,
+    /// observationCardinalityNext The next maximum number of observations, to be updated when the observation.
+    /// feeProtocol The protocol fee for both tokens of the pool.
+    /// Encoded as two 4 bit values, where the protocol fee of token1 is shifted 4 bits and the protocol fee of token0
+    /// is the lower 4 bits. Used as the denominator of a fraction of the swap fee, e.g. 4 means 1/4th of the swap fee.
+    /// unlocked Whether the pool is currently locked to reentrancy
+    function slot0()
+        external
+        view
+        returns (
+            uint160 sqrtPriceX96,
+            int24 tick,
+            uint16 observationIndex,
+            uint16 observationCardinality,
+            uint16 observationCardinalityNext,
+            uint8 feeProtocol,
+            bool unlocked
+        );
+
+    /// @notice The fee growth as a Q128.128 fees of token0 collected per unit of liquidity for the entire life of the pool
+    /// @dev This value can overflow the uint256
+    function feeGrowthGlobal0X128() external view returns (uint256);
+
+    /// @notice The fee growth as a Q128.128 fees of token1 collected per unit of liquidity for the entire life of the pool
+    /// @dev This value can overflow the uint256
+    function feeGrowthGlobal1X128() external view returns (uint256);
+
+    /// @notice The amounts of token0 and token1 that are owed to the protocol
+    /// @dev Protocol fees will never exceed uint128 max in either token
+    function protocolFees() external view returns (uint128 token0, uint128 token1);
+
+    /// @notice The currently in range liquidity available to the pool
+    /// @dev This value has no relationship to the total liquidity across all ticks
+    function liquidity() external view returns (uint128);
+
+    /// @notice Look up information about a specific tick in the pool
+    /// @param tick The tick to look up
+    /// @return liquidityGross the total amount of position liquidity that uses the pool either as tick lower or
+    /// tick upper,
+    /// liquidityNet how much liquidity changes when the pool price crosses the tick,
+    /// feeGrowthOutside0X128 the fee growth on the other side of the tick from the current tick in token0,
+    /// feeGrowthOutside1X128 the fee growth on the other side of the tick from the current tick in token1,
+    /// tickCumulativeOutside the cumulative tick value on the other side of the tick from the current tick
+    /// secondsPerLiquidityOutsideX128 the seconds spent per liquidity on the other side of the tick from the current tick,
+    /// secondsOutside the seconds spent on the other side of the tick from the current tick,
+    /// initialized Set to true if the tick is initialized, i.e. liquidityGross is greater than 0, otherwise equal to false.
+    /// Outside values can only be used if the tick is initialized, i.e. if liquidityGross is greater than 0.
+    /// In addition, these values are only relative and must be used only in comparison to previous snapshots for
+    /// a specific position.
+    function ticks(int24 tick)
+        external
+        view
+        returns (
+            uint128 liquidityGross,
+            int128 liquidityNet,
+            uint256 feeGrowthOutside0X128,
+            uint256 feeGrowthOutside1X128,
+            int56 tickCumulativeOutside,
+            uint160 secondsPerLiquidityOutsideX128,
+            uint32 secondsOutside,
+            bool initialized
+        );
+
+    /// @notice Returns 256 packed tick initialized boolean values. See TickBitmap for more information
+    function tickBitmap(int16 wordPosition) external view returns (uint256);
+
+    /// @notice Returns the information about a position by the position's key
+    /// @param key The position's key is a hash of a preimage composed by the owner, tickLower and tickUpper
+    /// @return _liquidity The amount of liquidity in the position,
+    /// Returns feeGrowthInside0LastX128 fee growth of token0 inside the tick range as of the last mint/burn/poke,
+    /// Returns feeGrowthInside1LastX128 fee growth of token1 inside the tick range as of the last mint/burn/poke,
+    /// Returns tokensOwed0 the computed amount of token0 owed to the position as of the last mint/burn/poke,
+    /// Returns tokensOwed1 the computed amount of token1 owed to the position as of the last mint/burn/poke
+    function positions(bytes32 key)
+        external
+        view
+        returns (
+            uint128 _liquidity,
+            uint256 feeGrowthInside0LastX128,
+            uint256 feeGrowthInside1LastX128,
+            uint128 tokensOwed0,
+            uint128 tokensOwed1
+        );
+
+    /// @notice Returns data about a specific observation index
+    /// @param index The element of the observations array to fetch
+    /// @dev You most likely want to use #observe() instead of this method to get an observation as of some amount of time
+    /// ago, rather than at a specific index in the array.
+    /// @return blockTimestamp The timestamp of the observation,
+    /// Returns tickCumulative the tick multiplied by seconds elapsed for the life of the pool as of the observation timestamp,
+    /// Returns secondsPerLiquidityCumulativeX128 the seconds per in range liquidity for the life of the pool as of the observation timestamp,
+    /// Returns initialized whether the observation has been initialized and the values are safe to use
+    function observations(uint256 index)
+        external
+        view
+        returns (
+            uint32 blockTimestamp,
+            int56 tickCumulative,
+            uint160 secondsPerLiquidityCumulativeX128,
+            bool initialized
+        );
+}

--- a/src/libraries/uniswapv3/BitMath.sol
+++ b/src/libraries/uniswapv3/BitMath.sol
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.5.0;
+
+/// @title BitMath
+/// @dev This library provides functionality for computing bit properties of an unsigned integer
+library BitMath {
+    /// @notice Returns the index of the most significant bit of the number,
+    ///     where the least significant bit is at index 0 and the most significant bit is at index 255
+    /// @dev The function satisfies the property:
+    ///     x >= 2**mostSignificantBit(x) and x < 2**(mostSignificantBit(x)+1)
+    /// @param x the value for which to compute the most significant bit, must be greater than 0
+    /// @return r the index of the most significant bit
+    function mostSignificantBit(uint256 x) internal pure returns (uint8 r) {
+        require(x > 0);
+
+        if (x >= 0x100000000000000000000000000000000) {
+            x >>= 128;
+            r += 128;
+        }
+        if (x >= 0x10000000000000000) {
+            x >>= 64;
+            r += 64;
+        }
+        if (x >= 0x100000000) {
+            x >>= 32;
+            r += 32;
+        }
+        if (x >= 0x10000) {
+            x >>= 16;
+            r += 16;
+        }
+        if (x >= 0x100) {
+            x >>= 8;
+            r += 8;
+        }
+        if (x >= 0x10) {
+            x >>= 4;
+            r += 4;
+        }
+        if (x >= 0x4) {
+            x >>= 2;
+            r += 2;
+        }
+        if (x >= 0x2) r += 1;
+    }
+
+    /// @notice Returns the index of the least significant bit of the number,
+    ///     where the least significant bit is at index 0 and the most significant bit is at index 255
+    /// @dev The function satisfies the property:
+    ///     (x & 2**leastSignificantBit(x)) != 0 and (x & (2**(leastSignificantBit(x)) - 1)) == 0)
+    /// @param x the value for which to compute the least significant bit, must be greater than 0
+    /// @return r the index of the least significant bit
+    function leastSignificantBit(uint256 x) internal pure returns (uint8 r) {
+        require(x > 0);
+
+        r = 255;
+        if (x & type(uint128).max > 0) {
+            r -= 128;
+        } else {
+            x >>= 128;
+        }
+        if (x & type(uint64).max > 0) {
+            r -= 64;
+        } else {
+            x >>= 64;
+        }
+        if (x & type(uint32).max > 0) {
+            r -= 32;
+        } else {
+            x >>= 32;
+        }
+        if (x & type(uint16).max > 0) {
+            r -= 16;
+        } else {
+            x >>= 16;
+        }
+        if (x & type(uint8).max > 0) {
+            r -= 8;
+        } else {
+            x >>= 8;
+        }
+        if (x & 0xf > 0) {
+            r -= 4;
+        } else {
+            x >>= 4;
+        }
+        if (x & 0x3 > 0) {
+            r -= 2;
+        } else {
+            x >>= 2;
+        }
+        if (x & 0x1 > 0) r -= 1;
+    }
+}

--- a/src/libraries/uniswapv3/CallbackValidation.sol
+++ b/src/libraries/uniswapv3/CallbackValidation.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//pragma solidity =0.7.6;
+pragma solidity >=0.6.10 <=0.8.10;
+
+import "../../interfaces/uniswapv3/IUniswapV3Pool.sol";
+import "./PoolAddress.sol";
+
+/// @notice Provides validation for callbacks from Uniswap V3 Pools
+library CallbackValidation {
+    /// @notice Returns the address of a valid Uniswap V3 Pool
+    /// @param factory The contract address of the Uniswap V3 factory
+    /// @param tokenA The contract address of either token0 or token1
+    /// @param tokenB The contract address of the other token
+    /// @param fee The fee collected upon every swap in the pool, denominated in hundredths of a bip
+    /// @return pool The V3 pool contract address
+    function verifyCallback(
+        address factory,
+        address tokenA,
+        address tokenB,
+        uint24 fee
+    ) internal view returns (IUniswapV3Pool pool) {
+        return verifyCallback(factory, PoolAddress.getPoolKey(tokenA, tokenB, fee));
+    }
+
+    /// @notice Returns the address of a valid Uniswap V3 Pool
+    /// @param factory The contract address of the Uniswap V3 factory
+    /// @param poolKey The identifying key of the V3 pool
+    /// @return pool The V3 pool contract address
+    function verifyCallback(address factory, PoolAddress.PoolKey memory poolKey)
+        internal
+        view
+        returns (IUniswapV3Pool pool)
+    {
+        pool = IUniswapV3Pool(PoolAddress.computeAddress(factory, poolKey));
+        require(msg.sender == address(pool));
+    }
+}

--- a/src/libraries/uniswapv3/FixedPoint128.sol
+++ b/src/libraries/uniswapv3/FixedPoint128.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.4.0;
+
+/// @title FixedPoint128
+/// @notice A library for handling binary fixed point numbers, see https://en.wikipedia.org/wiki/Q_(number_format)
+library FixedPoint128 {
+    uint256 internal constant Q128 = 0x100000000000000000000000000000000;
+}

--- a/src/libraries/uniswapv3/FixedPoint96.sol
+++ b/src/libraries/uniswapv3/FixedPoint96.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.6.10 <=0.8.10;
+
+/// @title FixedPoint96
+/// @notice A library for handling binary fixed point numbers, see https://en.wikipedia.org/wiki/Q_(number_format)
+/// @dev Used in SqrtPriceMath.sol
+library FixedPoint96 {
+    uint8 internal constant RESOLUTION = 96;
+    uint256 internal constant Q96 = 0x1000000000000000000000000;
+}

--- a/src/libraries/uniswapv3/LiquidityAmounts.sol
+++ b/src/libraries/uniswapv3/LiquidityAmounts.sol
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.6.10 <=0.8.10;
+
+import "./FullMath.sol";
+import "./FixedPoint96.sol";
+
+/// @title Liquidity amount functions
+/// @notice Provides functions for computing liquidity amounts from token amounts and prices
+library LiquidityAmounts {
+    /// @notice Downcasts uint256 to uint128
+    /// @param x The uint258 to be downcasted
+    /// @return y The passed value, downcasted to uint128
+    function toUint128(uint256 x) private pure returns (uint128 y) {
+        require((y = uint128(x)) == x);
+    }
+
+    /// @notice Computes the amount of liquidity received for a given amount of token0 and price range
+    /// @dev Calculates amount0 * (sqrt(upper) * sqrt(lower)) / (sqrt(upper) - sqrt(lower))
+    /// @param sqrtRatioAX96 A sqrt price representing the first tick boundary
+    /// @param sqrtRatioBX96 A sqrt price representing the second tick boundary
+    /// @param amount0 The amount0 being sent in
+    /// @return liquidity The amount of returned liquidity
+    function getLiquidityForAmount0(
+        uint160 sqrtRatioAX96,
+        uint160 sqrtRatioBX96,
+        uint256 amount0
+    ) internal pure returns (uint128 liquidity) {
+        if (sqrtRatioAX96 > sqrtRatioBX96) (sqrtRatioAX96, sqrtRatioBX96) = (sqrtRatioBX96, sqrtRatioAX96);
+        uint256 intermediate = FullMath.mulDiv(sqrtRatioAX96, sqrtRatioBX96, FixedPoint96.Q96);
+        return toUint128(FullMath.mulDiv(amount0, intermediate, sqrtRatioBX96 - sqrtRatioAX96));
+    }
+
+    /// @notice Computes the amount of liquidity received for a given amount of token1 and price range
+    /// @dev Calculates amount1 / (sqrt(upper) - sqrt(lower)).
+    /// @param sqrtRatioAX96 A sqrt price representing the first tick boundary
+    /// @param sqrtRatioBX96 A sqrt price representing the second tick boundary
+    /// @param amount1 The amount1 being sent in
+    /// @return liquidity The amount of returned liquidity
+    function getLiquidityForAmount1(
+        uint160 sqrtRatioAX96,
+        uint160 sqrtRatioBX96,
+        uint256 amount1
+    ) internal pure returns (uint128 liquidity) {
+        if (sqrtRatioAX96 > sqrtRatioBX96) (sqrtRatioAX96, sqrtRatioBX96) = (sqrtRatioBX96, sqrtRatioAX96);
+        return toUint128(FullMath.mulDiv(amount1, FixedPoint96.Q96, sqrtRatioBX96 - sqrtRatioAX96));
+    }
+
+    /// @notice Computes the maximum amount of liquidity received for a given amount of token0, token1, the current
+    /// pool prices and the prices at the tick boundaries
+    /// @param sqrtRatioX96 A sqrt price representing the current pool prices
+    /// @param sqrtRatioAX96 A sqrt price representing the first tick boundary
+    /// @param sqrtRatioBX96 A sqrt price representing the second tick boundary
+    /// @param amount0 The amount of token0 being sent in
+    /// @param amount1 The amount of token1 being sent in
+    /// @return liquidity The maximum amount of liquidity received
+    function getLiquidityForAmounts(
+        uint160 sqrtRatioX96,
+        uint160 sqrtRatioAX96,
+        uint160 sqrtRatioBX96,
+        uint256 amount0,
+        uint256 amount1
+    ) internal pure returns (uint128 liquidity) {
+        if (sqrtRatioAX96 > sqrtRatioBX96) (sqrtRatioAX96, sqrtRatioBX96) = (sqrtRatioBX96, sqrtRatioAX96);
+
+        if (sqrtRatioX96 <= sqrtRatioAX96) {
+            liquidity = getLiquidityForAmount0(sqrtRatioAX96, sqrtRatioBX96, amount0);
+        } else if (sqrtRatioX96 < sqrtRatioBX96) {
+            uint128 liquidity0 = getLiquidityForAmount0(sqrtRatioX96, sqrtRatioBX96, amount0);
+            uint128 liquidity1 = getLiquidityForAmount1(sqrtRatioAX96, sqrtRatioX96, amount1);
+
+            liquidity = liquidity0 < liquidity1 ? liquidity0 : liquidity1;
+        } else {
+            liquidity = getLiquidityForAmount1(sqrtRatioAX96, sqrtRatioBX96, amount1);
+        }
+    }
+
+    /// @notice Computes the amount of token0 for a given amount of liquidity and a price range
+    /// @param sqrtRatioAX96 A sqrt price representing the first tick boundary
+    /// @param sqrtRatioBX96 A sqrt price representing the second tick boundary
+    /// @param liquidity The liquidity being valued
+    /// @return amount0 The amount of token0
+    function getAmount0ForLiquidity(
+        uint160 sqrtRatioAX96,
+        uint160 sqrtRatioBX96,
+        uint128 liquidity
+    ) internal pure returns (uint256 amount0) {
+        if (sqrtRatioAX96 > sqrtRatioBX96) (sqrtRatioAX96, sqrtRatioBX96) = (sqrtRatioBX96, sqrtRatioAX96);
+
+        return
+            FullMath.mulDiv(
+                uint256(liquidity) << FixedPoint96.RESOLUTION,
+                sqrtRatioBX96 - sqrtRatioAX96,
+                sqrtRatioBX96
+            ) / sqrtRatioAX96;
+    }
+
+    /// @notice Computes the amount of token1 for a given amount of liquidity and a price range
+    /// @param sqrtRatioAX96 A sqrt price representing the first tick boundary
+    /// @param sqrtRatioBX96 A sqrt price representing the second tick boundary
+    /// @param liquidity The liquidity being valued
+    /// @return amount1 The amount of token1
+    function getAmount1ForLiquidity(
+        uint160 sqrtRatioAX96,
+        uint160 sqrtRatioBX96,
+        uint128 liquidity
+    ) internal pure returns (uint256 amount1) {
+        if (sqrtRatioAX96 > sqrtRatioBX96) (sqrtRatioAX96, sqrtRatioBX96) = (sqrtRatioBX96, sqrtRatioAX96);
+
+        return FullMath.mulDiv(liquidity, sqrtRatioBX96 - sqrtRatioAX96, FixedPoint96.Q96);
+    }
+
+    /// @notice Computes the token0 and token1 value for a given amount of liquidity, the current
+    /// pool prices and the prices at the tick boundaries
+    /// @param sqrtRatioX96 A sqrt price representing the current pool prices
+    /// @param sqrtRatioAX96 A sqrt price representing the first tick boundary
+    /// @param sqrtRatioBX96 A sqrt price representing the second tick boundary
+    /// @param liquidity The liquidity being valued
+    /// @return amount0 The amount of token0
+    /// @return amount1 The amount of token1
+    function getAmountsForLiquidity(
+        uint160 sqrtRatioX96,
+        uint160 sqrtRatioAX96,
+        uint160 sqrtRatioBX96,
+        uint128 liquidity
+    ) internal pure returns (uint256 amount0, uint256 amount1) {
+        if (sqrtRatioAX96 > sqrtRatioBX96) (sqrtRatioAX96, sqrtRatioBX96) = (sqrtRatioBX96, sqrtRatioAX96);
+
+        if (sqrtRatioX96 <= sqrtRatioAX96) {
+            amount0 = getAmount0ForLiquidity(sqrtRatioAX96, sqrtRatioBX96, liquidity);
+        } else if (sqrtRatioX96 < sqrtRatioBX96) {
+            amount0 = getAmount0ForLiquidity(sqrtRatioX96, sqrtRatioBX96, liquidity);
+            amount1 = getAmount1ForLiquidity(sqrtRatioAX96, sqrtRatioX96, liquidity);
+        } else {
+            amount1 = getAmount1ForLiquidity(sqrtRatioAX96, sqrtRatioBX96, liquidity);
+        }
+    }
+}

--- a/src/libraries/uniswapv3/LiquidityMath.sol
+++ b/src/libraries/uniswapv3/LiquidityMath.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.5.0;
+
+/// @title Math library for liquidity
+library LiquidityMath {
+    /// @notice Add a signed liquidity delta to liquidity and revert if it overflows or underflows
+    /// @param x The liquidity before change
+    /// @param y The delta by which liquidity should be changed
+    /// @return z The liquidity delta
+    function addDelta(uint128 x, int128 y) internal pure returns (uint128 z) {
+        if (y < 0) {
+            require((z = x - uint128(-y)) < x, "LS");
+        } else {
+            require((z = x + uint128(y)) >= x, "LA");
+        }
+    }
+}

--- a/src/libraries/uniswapv3/LowGasSafeMath.sol
+++ b/src/libraries/uniswapv3/LowGasSafeMath.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.7.0;
+
+/// @title Optimized overflow and underflow safe math operations
+/// @notice Contains methods for doing math operations that revert on overflow or underflow for minimal gas cost
+library LowGasSafeMath {
+    /// @notice Returns x + y, reverts if sum overflows uint256
+    /// @param x The augend
+    /// @param y The addend
+    /// @return z The sum of x and y
+    function add(uint256 x, uint256 y) internal pure returns (uint256 z) {
+        require((z = x + y) >= x);
+    }
+
+    /// @notice Returns x - y, reverts if underflows
+    /// @param x The minuend
+    /// @param y The subtrahend
+    /// @return z The difference of x and y
+    function sub(uint256 x, uint256 y) internal pure returns (uint256 z) {
+        require((z = x - y) <= x);
+    }
+
+    /// @notice Returns x * y, reverts if overflows
+    /// @param x The multiplicand
+    /// @param y The multiplier
+    /// @return z The product of x and y
+    function mul(uint256 x, uint256 y) internal pure returns (uint256 z) {
+        require(x == 0 || (z = x * y) / x == y);
+    }
+
+    /// @notice Returns x + y, reverts if overflows or underflows
+    /// @param x The augend
+    /// @param y The addend
+    /// @return z The sum of x and y
+    function add(int256 x, int256 y) internal pure returns (int256 z) {
+        require((z = x + y) >= x == (y >= 0));
+    }
+
+    /// @notice Returns x - y, reverts if overflows or underflows
+    /// @param x The minuend
+    /// @param y The subtrahend
+    /// @return z The difference of x and y
+    function sub(int256 x, int256 y) internal pure returns (int256 z) {
+        require((z = x - y) <= x == (y >= 0));
+    }
+}

--- a/src/libraries/uniswapv3/PoolAddress.sol
+++ b/src/libraries/uniswapv3/PoolAddress.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.6.10 <=0.8.10;
+
+///note: @dev of Aztec Connect Uniswap V3 Bridge for LP. This library has been modified to conform to version 0.8.x of solidity.
+///the change is in lines 37-38, which were originally an explicit type conversion from uint256 to address like thus:
+///address( uint256 ( .... ))
+/// certain kinds of explicit type conversions have been disallowed in solidity versions 0.8.x
+///the fix for this is to change line 37-38 from address(uint256(...)) to address(uint160(uint256(...))), i.e. add an intermediate type conversion
+///see https://docs.soliditylang.org/en/v0.8.11/080-breaking-changes.html
+///this is the only change in the entire file
+/// @title Provides functions for deriving a pool address from the factory, tokens, and the fee
+library PoolAddress {
+    bytes32 internal constant POOL_INIT_CODE_HASH = 0xe34f199b19b2b4f47f68442619d555527d244f78a3297ea89325f843f87b8b54;
+
+    /// @notice The identifying key of the pool
+    struct PoolKey {
+        address token0;
+        address token1;
+        uint24 fee;
+    }
+
+    /// @notice Returns PoolKey: the ordered tokens with the matched fee levels
+    /// @param tokenA The first token of a pool, unsorted
+    /// @param tokenB The second token of a pool, unsorted
+    /// @param fee The fee level of the pool
+    /// @return Poolkey The pool details with ordered token0 and token1 assignments
+    function getPoolKey(
+        address tokenA,
+        address tokenB,
+        uint24 fee
+    ) internal pure returns (PoolKey memory) {
+        if (tokenA > tokenB) (tokenA, tokenB) = (tokenB, tokenA);
+        return PoolKey({token0: tokenA, token1: tokenB, fee: fee});
+    }
+
+    /// @notice Deterministically computes the pool address given the factory and PoolKey
+    /// @param factory The Uniswap V3 factory contract address
+    /// @param key The PoolKey
+    /// @return pool The contract address of the V3 pool
+    function computeAddress(address factory, PoolKey memory key) internal pure returns (address pool) {
+        require(key.token0 < key.token1);
+        pool = address(
+            uint160( //this line has been modified from the original Uniswap V3 library
+                uint256(
+                    keccak256(
+                        abi.encodePacked(
+                            hex"ff",
+                            factory,
+                            keccak256(abi.encode(key.token0, key.token1, key.fee)),
+                            POOL_INIT_CODE_HASH
+                        )
+                    )
+                )
+            )
+        );
+    }
+}

--- a/src/libraries/uniswapv3/SafeCast.sol
+++ b/src/libraries/uniswapv3/SafeCast.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.5.0;
+
+/// @title Safe casting methods
+/// @notice Contains methods for safely casting between types
+library SafeCast {
+    /// @notice Cast a uint256 to a uint160, revert on overflow
+    /// @param y The uint256 to be downcasted
+    /// @return z The downcasted integer, now type uint160
+    function toUint160(uint256 y) internal pure returns (uint160 z) {
+        require((z = uint160(y)) == y);
+    }
+
+    /// @notice Cast a int256 to a int128, revert on overflow or underflow
+    /// @param y The int256 to be downcasted
+    /// @return z The downcasted integer, now type int128
+    function toInt128(int256 y) internal pure returns (int128 z) {
+        require((z = int128(y)) == y);
+    }
+
+    /// @notice Cast a uint256 to a int256, revert on overflow
+    /// @param y The uint256 to be casted
+    /// @return z The casted integer, now type int256
+    function toInt256(uint256 y) internal pure returns (int256 z) {
+        require(y < 2**255);
+        z = int256(y);
+    }
+}

--- a/src/libraries/uniswapv3/SqrtPriceMath.sol
+++ b/src/libraries/uniswapv3/SqrtPriceMath.sol
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity >=0.5.0;
+
+import "./LowGasSafeMath.sol";
+import "./SafeCast.sol";
+
+import "./FullMath.sol";
+import "./UnsafeMath.sol";
+import "./FixedPoint96.sol";
+
+/// @title Functions based on Q64.96 sqrt price and liquidity
+/// @notice Contains the math that uses square root of price as a Q64.96 and liquidity to compute deltas
+library SqrtPriceMath {
+    using LowGasSafeMath for uint256;
+    using SafeCast for uint256;
+
+    /// @notice Gets the next sqrt price given a delta of token0
+    /// @dev Always rounds up, because in the exact output case (increasing price) we need to move the price at least
+    /// far enough to get the desired output amount, and in the exact input case (decreasing price) we need to move the
+    /// price less in order to not send too much output.
+    /// The most precise formula for this is liquidity * sqrtPX96 / (liquidity +- amount * sqrtPX96),
+    /// if this is impossible because of overflow, we calculate liquidity / (liquidity / sqrtPX96 +- amount).
+    /// @param sqrtPX96 The starting price, i.e. before accounting for the token0 delta
+    /// @param liquidity The amount of usable liquidity
+    /// @param amount How much of token0 to add or remove from virtual reserves
+    /// @param add Whether to add or remove the amount of token0
+    /// @return The price after adding or removing amount, depending on add
+    function getNextSqrtPriceFromAmount0RoundingUp(
+        uint160 sqrtPX96,
+        uint128 liquidity,
+        uint256 amount,
+        bool add
+    ) internal pure returns (uint160) {
+        // we short circuit amount == 0 because the result is otherwise not guaranteed to equal the input price
+        if (amount == 0) return sqrtPX96;
+        uint256 numerator1 = uint256(liquidity) << FixedPoint96.RESOLUTION;
+
+        if (add) {
+            uint256 product;
+            if ((product = amount * sqrtPX96) / amount == sqrtPX96) {
+                uint256 denominator = numerator1 + product;
+                if (denominator >= numerator1)
+                    // always fits in 160 bits
+                    return uint160(FullMath.mulDivRoundingUp(numerator1, sqrtPX96, denominator));
+            }
+
+            return uint160(UnsafeMath.divRoundingUp(numerator1, (numerator1 / sqrtPX96).add(amount)));
+        } else {
+            uint256 product;
+            // if the product overflows, we know the denominator underflows
+            // in addition, we must check that the denominator does not underflow
+            require((product = amount * sqrtPX96) / amount == sqrtPX96 && numerator1 > product);
+            uint256 denominator = numerator1 - product;
+            return FullMath.mulDivRoundingUp(numerator1, sqrtPX96, denominator).toUint160();
+        }
+    }
+
+    /// @notice Gets the next sqrt price given a delta of token1
+    /// @dev Always rounds down, because in the exact output case (decreasing price) we need to move the price at least
+    /// far enough to get the desired output amount, and in the exact input case (increasing price) we need to move the
+    /// price less in order to not send too much output.
+    /// The formula we compute is within <1 wei of the lossless version: sqrtPX96 +- amount / liquidity
+    /// @param sqrtPX96 The starting price, i.e., before accounting for the token1 delta
+    /// @param liquidity The amount of usable liquidity
+    /// @param amount How much of token1 to add, or remove, from virtual reserves
+    /// @param add Whether to add, or remove, the amount of token1
+    /// @return The price after adding or removing `amount`
+    function getNextSqrtPriceFromAmount1RoundingDown(
+        uint160 sqrtPX96,
+        uint128 liquidity,
+        uint256 amount,
+        bool add
+    ) internal pure returns (uint160) {
+        // if we're adding (subtracting), rounding down requires rounding the quotient down (up)
+        // in both cases, avoid a mulDiv for most inputs
+        if (add) {
+            uint256 quotient = (
+                amount <= type(uint160).max
+                    ? (amount << FixedPoint96.RESOLUTION) / liquidity
+                    : FullMath.mulDiv(amount, FixedPoint96.Q96, liquidity)
+            );
+
+            return uint256(sqrtPX96).add(quotient).toUint160();
+        } else {
+            uint256 quotient = (
+                amount <= type(uint160).max
+                    ? UnsafeMath.divRoundingUp(amount << FixedPoint96.RESOLUTION, liquidity)
+                    : FullMath.mulDivRoundingUp(amount, FixedPoint96.Q96, liquidity)
+            );
+
+            require(sqrtPX96 > quotient);
+            // always fits 160 bits
+            return uint160(sqrtPX96 - quotient);
+        }
+    }
+
+    /// @notice Gets the next sqrt price given an input amount of token0 or token1
+    /// @dev Throws if price or liquidity are 0, or if the next price is out of bounds
+    /// @param sqrtPX96 The starting price, i.e., before accounting for the input amount
+    /// @param liquidity The amount of usable liquidity
+    /// @param amountIn How much of token0, or token1, is being swapped in
+    /// @param zeroForOne Whether the amount in is token0 or token1
+    /// @return sqrtQX96 The price after adding the input amount to token0 or token1
+    function getNextSqrtPriceFromInput(
+        uint160 sqrtPX96,
+        uint128 liquidity,
+        uint256 amountIn,
+        bool zeroForOne
+    ) internal pure returns (uint160 sqrtQX96) {
+        require(sqrtPX96 > 0);
+        require(liquidity > 0);
+
+        // round to make sure that we don't pass the target price
+        return
+            zeroForOne
+                ? getNextSqrtPriceFromAmount0RoundingUp(sqrtPX96, liquidity, amountIn, true)
+                : getNextSqrtPriceFromAmount1RoundingDown(sqrtPX96, liquidity, amountIn, true);
+    }
+
+    /// @notice Gets the next sqrt price given an output amount of token0 or token1
+    /// @dev Throws if price or liquidity are 0 or the next price is out of bounds
+    /// @param sqrtPX96 The starting price before accounting for the output amount
+    /// @param liquidity The amount of usable liquidity
+    /// @param amountOut How much of token0, or token1, is being swapped out
+    /// @param zeroForOne Whether the amount out is token0 or token1
+    /// @return sqrtQX96 The price after removing the output amount of token0 or token1
+    function getNextSqrtPriceFromOutput(
+        uint160 sqrtPX96,
+        uint128 liquidity,
+        uint256 amountOut,
+        bool zeroForOne
+    ) internal pure returns (uint160 sqrtQX96) {
+        require(sqrtPX96 > 0);
+        require(liquidity > 0);
+
+        // round to make sure that we pass the target price
+        return
+            zeroForOne
+                ? getNextSqrtPriceFromAmount1RoundingDown(sqrtPX96, liquidity, amountOut, false)
+                : getNextSqrtPriceFromAmount0RoundingUp(sqrtPX96, liquidity, amountOut, false);
+    }
+
+    /// @notice Gets the amount0 delta between two prices
+    /// @dev Calculates liquidity / sqrt(lower) - liquidity / sqrt(upper),
+    /// i.e. liquidity * (sqrt(upper) - sqrt(lower)) / (sqrt(upper) * sqrt(lower))
+    /// @param sqrtRatioAX96 A sqrt price
+    /// @param sqrtRatioBX96 Another sqrt price
+    /// @param liquidity The amount of usable liquidity
+    /// @param roundUp Whether to round the amount up or down
+    /// @return amount0 Amount of token0 required to cover a position of size liquidity between the two passed prices
+    function getAmount0Delta(
+        uint160 sqrtRatioAX96,
+        uint160 sqrtRatioBX96,
+        uint128 liquidity,
+        bool roundUp
+    ) internal pure returns (uint256 amount0) {
+        if (sqrtRatioAX96 > sqrtRatioBX96) (sqrtRatioAX96, sqrtRatioBX96) = (sqrtRatioBX96, sqrtRatioAX96);
+
+        uint256 numerator1 = uint256(liquidity) << FixedPoint96.RESOLUTION;
+        uint256 numerator2 = sqrtRatioBX96 - sqrtRatioAX96;
+
+        require(sqrtRatioAX96 > 0);
+
+        return
+            roundUp
+                ? UnsafeMath.divRoundingUp(
+                    FullMath.mulDivRoundingUp(numerator1, numerator2, sqrtRatioBX96),
+                    sqrtRatioAX96
+                )
+                : FullMath.mulDiv(numerator1, numerator2, sqrtRatioBX96) / sqrtRatioAX96;
+    }
+
+    /// @notice Gets the amount1 delta between two prices
+    /// @dev Calculates liquidity * (sqrt(upper) - sqrt(lower))
+    /// @param sqrtRatioAX96 A sqrt price
+    /// @param sqrtRatioBX96 Another sqrt price
+    /// @param liquidity The amount of usable liquidity
+    /// @param roundUp Whether to round the amount up, or down
+    /// @return amount1 Amount of token1 required to cover a position of size liquidity between the two passed prices
+    function getAmount1Delta(
+        uint160 sqrtRatioAX96,
+        uint160 sqrtRatioBX96,
+        uint128 liquidity,
+        bool roundUp
+    ) internal pure returns (uint256 amount1) {
+        if (sqrtRatioAX96 > sqrtRatioBX96) (sqrtRatioAX96, sqrtRatioBX96) = (sqrtRatioBX96, sqrtRatioAX96);
+
+        return
+            roundUp
+                ? FullMath.mulDivRoundingUp(liquidity, sqrtRatioBX96 - sqrtRatioAX96, FixedPoint96.Q96)
+                : FullMath.mulDiv(liquidity, sqrtRatioBX96 - sqrtRatioAX96, FixedPoint96.Q96);
+    }
+
+    /// @notice Helper that gets signed token0 delta
+    /// @param sqrtRatioAX96 A sqrt price
+    /// @param sqrtRatioBX96 Another sqrt price
+    /// @param liquidity The change in liquidity for which to compute the amount0 delta
+    /// @return amount0 Amount of token0 corresponding to the passed liquidityDelta between the two prices
+    function getAmount0Delta(
+        uint160 sqrtRatioAX96,
+        uint160 sqrtRatioBX96,
+        int128 liquidity
+    ) internal pure returns (int256 amount0) {
+        return
+            liquidity < 0
+                ? -getAmount0Delta(sqrtRatioAX96, sqrtRatioBX96, uint128(-liquidity), false).toInt256()
+                : getAmount0Delta(sqrtRatioAX96, sqrtRatioBX96, uint128(liquidity), true).toInt256();
+    }
+
+    /// @notice Helper that gets signed token1 delta
+    /// @param sqrtRatioAX96 A sqrt price
+    /// @param sqrtRatioBX96 Another sqrt price
+    /// @param liquidity The change in liquidity for which to compute the amount1 delta
+    /// @return amount1 Amount of token1 corresponding to the passed liquidityDelta between the two prices
+    function getAmount1Delta(
+        uint160 sqrtRatioAX96,
+        uint160 sqrtRatioBX96,
+        int128 liquidity
+    ) internal pure returns (int256 amount1) {
+        return
+            liquidity < 0
+                ? -getAmount1Delta(sqrtRatioAX96, sqrtRatioBX96, uint128(-liquidity), false).toInt256()
+                : getAmount1Delta(sqrtRatioAX96, sqrtRatioBX96, uint128(liquidity), true).toInt256();
+    }
+}

--- a/src/libraries/uniswapv3/SwapMath.sol
+++ b/src/libraries/uniswapv3/SwapMath.sol
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity >=0.5.0;
+
+import "./FullMath.sol";
+import "./SqrtPriceMath.sol";
+
+/// @title Computes the result of a swap within ticks
+/// @notice Contains methods for computing the result of a swap within a single tick price range, i.e., a single tick.
+library SwapMath {
+    /// @notice Computes the result of swapping some amount in, or amount out, given the parameters of the swap
+    /// @dev The fee, plus the amount in, will never exceed the amount remaining if the swap's `amountSpecified` is positive
+    /// @param sqrtRatioCurrentX96 The current sqrt price of the pool
+    /// @param sqrtRatioTargetX96 The price that cannot be exceeded, from which the direction of the swap is inferred
+    /// @param liquidity The usable liquidity
+    /// @param amountRemaining How much input or output amount is remaining to be swapped in/out
+    /// @param feePips The fee taken from the input amount, expressed in hundredths of a bip
+    /// @return sqrtRatioNextX96 The price after swapping the amount in/out, not to exceed the price target
+    /// @return amountIn The amount to be swapped in, of either token0 or token1, based on the direction of the swap
+    /// @return amountOut The amount to be received, of either token0 or token1, based on the direction of the swap
+    /// @return feeAmount The amount of input that will be taken as a fee
+    function computeSwapStep(
+        uint160 sqrtRatioCurrentX96,
+        uint160 sqrtRatioTargetX96,
+        uint128 liquidity,
+        int256 amountRemaining,
+        uint24 feePips
+    )
+        internal
+        pure
+        returns (
+            uint160 sqrtRatioNextX96,
+            uint256 amountIn,
+            uint256 amountOut,
+            uint256 feeAmount
+        )
+    {
+        bool zeroForOne = sqrtRatioCurrentX96 >= sqrtRatioTargetX96;
+        bool exactIn = amountRemaining >= 0;
+
+        if (exactIn) {
+            uint256 amountRemainingLessFee = FullMath.mulDiv(uint256(amountRemaining), 1e6 - feePips, 1e6);
+            amountIn = zeroForOne
+                ? SqrtPriceMath.getAmount0Delta(sqrtRatioTargetX96, sqrtRatioCurrentX96, liquidity, true)
+                : SqrtPriceMath.getAmount1Delta(sqrtRatioCurrentX96, sqrtRatioTargetX96, liquidity, true);
+            if (amountRemainingLessFee >= amountIn) sqrtRatioNextX96 = sqrtRatioTargetX96;
+            else
+                sqrtRatioNextX96 = SqrtPriceMath.getNextSqrtPriceFromInput(
+                    sqrtRatioCurrentX96,
+                    liquidity,
+                    amountRemainingLessFee,
+                    zeroForOne
+                );
+        } else {
+            amountOut = zeroForOne
+                ? SqrtPriceMath.getAmount1Delta(sqrtRatioTargetX96, sqrtRatioCurrentX96, liquidity, false)
+                : SqrtPriceMath.getAmount0Delta(sqrtRatioCurrentX96, sqrtRatioTargetX96, liquidity, false);
+            if (uint256(-amountRemaining) >= amountOut) sqrtRatioNextX96 = sqrtRatioTargetX96;
+            else
+                sqrtRatioNextX96 = SqrtPriceMath.getNextSqrtPriceFromOutput(
+                    sqrtRatioCurrentX96,
+                    liquidity,
+                    uint256(-amountRemaining),
+                    zeroForOne
+                );
+        }
+
+        bool max = sqrtRatioTargetX96 == sqrtRatioNextX96;
+
+        // get the input/output amounts
+        if (zeroForOne) {
+            amountIn = max && exactIn
+                ? amountIn
+                : SqrtPriceMath.getAmount0Delta(sqrtRatioNextX96, sqrtRatioCurrentX96, liquidity, true);
+            amountOut = max && !exactIn
+                ? amountOut
+                : SqrtPriceMath.getAmount1Delta(sqrtRatioNextX96, sqrtRatioCurrentX96, liquidity, false);
+        } else {
+            amountIn = max && exactIn
+                ? amountIn
+                : SqrtPriceMath.getAmount1Delta(sqrtRatioCurrentX96, sqrtRatioNextX96, liquidity, true);
+            amountOut = max && !exactIn
+                ? amountOut
+                : SqrtPriceMath.getAmount0Delta(sqrtRatioCurrentX96, sqrtRatioNextX96, liquidity, false);
+        }
+
+        // cap the output amount to not exceed the remaining output amount
+        if (!exactIn && amountOut > uint256(-amountRemaining)) {
+            amountOut = uint256(-amountRemaining);
+        }
+
+        if (exactIn && sqrtRatioNextX96 != sqrtRatioTargetX96) {
+            // we didn't reach the target, so take the remainder of the maximum input as fee
+            feeAmount = uint256(amountRemaining) - amountIn;
+        } else {
+            feeAmount = FullMath.mulDivRoundingUp(amountIn, feePips, 1e6 - feePips);
+        }
+    }
+}

--- a/src/libraries/uniswapv3/TickBitmap.sol
+++ b/src/libraries/uniswapv3/TickBitmap.sol
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity >=0.5.0;
+
+import "./BitMath.sol";
+
+/// Note: For some reason this file keeps throwing 'explicit type conversion error'. I had to handfix the errors in lines 16, 61, 62,
+/// 74, and 75 by throwing in some intermediary types.
+/// @title Packed tick initialized state library
+/// @notice Stores a packed mapping of tick index to its initialized state
+/// @dev The mapping uses int16 for keys since ticks are represented as int24 and there are 256 (2^8) values per word.
+library TickBitmap {
+    /// @notice Computes the position in the mapping where the initialized bit for a tick lives
+    /// @param tick The tick for which to compute the position
+    /// @return wordPos The key in the mapping containing the word in which the bit is stored
+    /// @return bitPos The bit position in the word where the flag is stored
+    function position(int24 tick) private pure returns (int16 wordPos, uint8 bitPos) {
+        wordPos = int16(tick >> 8);
+        bitPos = uint8(uint24(tick % 256));
+    }
+
+    /// @notice Flips the initialized state for a given tick from false to true, or vice versa
+    /// @param self The mapping in which to flip the tick
+    /// @param tick The tick to flip
+    /// @param tickSpacing The spacing between usable ticks
+    function flipTick(
+        mapping(int16 => uint256) storage self,
+        int24 tick,
+        int24 tickSpacing
+    ) internal {
+        require(tick % tickSpacing == 0); // ensure that the tick is spaced
+        (int16 wordPos, uint8 bitPos) = position(tick / tickSpacing);
+        uint256 mask = 1 << bitPos;
+        self[wordPos] ^= mask;
+    }
+
+    /// @notice Returns the next initialized tick contained in the same word (or adjacent word) as the tick that is either
+    /// to the left (less than or equal to) or right (greater than) of the given tick
+    /// @param self The mapping in which to compute the next initialized tick
+    /// @param tick The starting tick
+    /// @param tickSpacing The spacing between usable ticks
+    /// @param lte Whether to search for the next initialized tick to the left (less than or equal to the starting tick)
+    /// @return next The next initialized or uninitialized tick up to 256 ticks away from the current tick
+    /// @return initialized Whether the next tick is initialized, as the function only searches within up to 256 ticks
+    function nextInitializedTickWithinOneWord(
+        mapping(int16 => uint256) storage self,
+        int24 tick,
+        int24 tickSpacing,
+        bool lte
+    ) internal view returns (int24 next, bool initialized) {
+        int24 compressed = tick / tickSpacing;
+        if (tick < 0 && tick % tickSpacing != 0) compressed--; // round towards negative infinity
+
+        if (lte) {
+            (int16 wordPos, uint8 bitPos) = position(compressed);
+            // all the 1s at or to the right of the current bitPos
+            uint256 mask = (1 << bitPos) - 1 + (1 << bitPos);
+            uint256 masked = self[wordPos] & mask;
+
+            // if there are no initialized ticks to the right of or at the current tick, return rightmost in the word
+            initialized = masked != 0;
+            // overflow/underflow is possible, but prevented externally by limiting both tickSpacing and tick
+            next = initialized
+                ? (compressed - int24(int8(bitPos - BitMath.mostSignificantBit(masked)))) * tickSpacing
+                : (compressed - int24(int8(bitPos))) * tickSpacing;
+        } else {
+            // start from the word of the next tick, since the current tick state doesn't matter
+            (int16 wordPos, uint8 bitPos) = position(compressed + 1);
+            // all the 1s at or to the left of the bitPos
+            uint256 mask = ~((1 << bitPos) - 1);
+            uint256 masked = self[wordPos] & mask;
+
+            // if there are no initialized ticks to the left of the current tick, return leftmost in the word
+            initialized = masked != 0;
+            // overflow/underflow is possible, but prevented externally by limiting both tickSpacing and tick
+            next = initialized
+                ? (compressed + 1 + int24(int8(BitMath.leastSignificantBit(masked) - bitPos))) * tickSpacing
+                : (compressed + 1 + int24(int8(type(uint8).max - bitPos))) * tickSpacing;
+        }
+    }
+}

--- a/src/libraries/uniswapv3/TransferHelper.sol
+++ b/src/libraries/uniswapv3/TransferHelper.sol
@@ -1,0 +1,61 @@
+pragma solidity >=0.6.10 <=0.8.10;
+pragma abicoder v2;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+library TransferHelper {
+    /// @notice Transfers tokens from the targeted address to the given destination
+    /// @notice Errors with 'STF' if transfer fails
+    /// @param token The contract address of tshe token to be transferred
+    /// @param from The originating address from which the tokens will be transferred
+    /// @param to The destination address of the transfer
+    /// @param value The amount to be transferred
+    function safeTransferFrom(
+        address token,
+        address from,
+        address to,
+        uint256 value
+    ) internal {
+        (bool success, bytes memory data) = token.call(
+            abi.encodeWithSelector(IERC20.transferFrom.selector, from, to, value)
+        );
+        require(success && (data.length == 0 || abi.decode(data, (bool))), "STF");
+    }
+
+    /// @notice Transfers tokens from msg.sender to a recipient
+    /// @dev Errors with ST if transfer fails
+    /// @param token The contract address of the token which will be transferred
+    /// @param to The recipient of the transfer
+    /// @param value The value of the transfer
+    function safeTransfer(
+        address token,
+        address to,
+        uint256 value
+    ) internal {
+        (bool success, bytes memory data) = token.call(abi.encodeWithSelector(IERC20.transfer.selector, to, value));
+        require(success && (data.length == 0 || abi.decode(data, (bool))), "ST");
+    }
+
+    /// @notice Approves the stipulated contract to spend the given allowance in the given token
+    /// @dev Errors with 'SA' if transfer fails
+    /// @param token The contract address of the token to be approved
+    /// @param to The target of the approval
+    /// @param value The amount of the given token the target will be allowed to spend
+    function safeApprove(
+        address token,
+        address to,
+        uint256 value
+    ) internal {
+        (bool success, bytes memory data) = token.call(abi.encodeWithSelector(IERC20.approve.selector, to, value));
+        require(success && (data.length == 0 || abi.decode(data, (bool))), "SA");
+    }
+
+    /// @notice Transfers ETH to the recipient address
+    /// @dev Fails with `STE`
+    /// @param to The destination of the transfer
+    /// @param value The value to be transferred
+    function safeTransferETH(address to, uint256 value) internal {
+        (bool success, ) = to.call{value: value}(new bytes(0));
+        require(success, "STE");
+    }
+}

--- a/src/libraries/uniswapv3/UnsafeMath.sol
+++ b/src/libraries/uniswapv3/UnsafeMath.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.5.0;
+
+/// @title Math functions that do not check inputs or outputs
+/// @notice Contains methods that perform common math functions but do not do any overflow or underflow checks
+library UnsafeMath {
+    /// @notice Returns ceil(x / y)
+    /// @dev division by 0 has unspecified behavior, and must be checked externally
+    /// @param x The dividend
+    /// @param y The divisor
+    /// @return z The quotient, ceil(x / y)
+    function divRoundingUp(uint256 x, uint256 y) internal pure returns (uint256 z) {
+        assembly {
+            z := add(div(x, y), gt(mod(x, y), 0))
+        }
+    }
+}

--- a/src/test/bridges/uniswap_lp/UniRangerOrder.t.sol
+++ b/src/test/bridges/uniswap_lp/UniRangerOrder.t.sol
@@ -1,0 +1,427 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.10;
+pragma experimental ABIEncoderV2;
+import {BridgeTestBase} from "./../../aztec/base/BridgeTestBase.sol";
+import {ErrorLib} from "../../../bridges/base/ErrorLib.sol";
+
+import {Vm} from "../../../../lib/forge-std/src/Vm.sol";
+
+// Example-specific imports
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+import {INonfungiblePositionManager} from "../../../interfaces/uniswapv3/INonfungiblePositionManager.sol";
+import {IUniswapV3Factory} from "../../../interfaces/uniswapv3/IUniswapV3Factory.sol";
+import {IUniswapV3Pool} from "../../../interfaces/uniswapv3/IUniswapV3Pool.sol";
+import {TickMath} from "../../../libraries/uniswapv3/TickMath.sol";
+import {UniRangeOrderBridge} from "../../../bridges/uniswap_lp/UniRangeOrderBridge.sol";
+import {TransferHelper, ISwapRouter} from "../../../bridges/uniswap_lp/ParentUniLPBridge.sol";
+import {AztecTypes} from "../../../aztec/libraries/AztecTypes.sol";
+import {LiquidityAmounts} from "../../../libraries/uniswapv3/LiquidityAmounts.sol";
+import {AztecKeeper} from "../../../bridges/uniswap_lp/AztecKeeper.sol";
+
+contract UniRange is BridgeTestBase {
+    address private constant DAI = 0x6B175474E89094C44Da98b954EedeAC495271d0F;
+    address private constant USDT = 0xdAC17F958D2ee523a2206206994597C13D831ec7;
+    address private constant WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
+    address private constant USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
+    address private constant WBTC = 0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599;
+    address private constant FACTORY = 0x1F98431c8aD98523631AE4a59f267346ea31F984;
+    address private constant ROUTER = 0xE592427A0AEce92De3Edee1F18E0157C05861564;
+    address private constant NONFUNGIBLE_POSITION_MANAGER = 0xC36442b4a4522E871399CD717aBDD847Ab11FE88;
+    address private constant QUOTER = 0xb27308f9F90D607463bb33eA1BeBb41C27CE5AB6;
+    address private pool = 0x4e68Ccd3E89f51C3074ca5072bbAC773960dFa36;
+    address[] private tokens = [USDT, DAI, WETH, USDC, WBTC];
+    //                                  1           2              3            4           5               6           7               8
+
+    address[][] private pairs = [[USDT, WETH], [WETH, USDC], [USDT, WBTC], [WETH, WBTC], [USDC, WBTC]];
+    //                              1      2    3       4   5       6   7     8
+    uint256[] private poolFees = [500, 3000, 3000, 3000, 3000, 100, 3000, 3000];
+    uint16 private poolFee;
+
+    UniRangeOrderBridge private asyncBridge;
+
+    uint256 private id;
+
+    error NotInTickRange();
+
+    function setUp() public {
+        asyncBridge = new UniRangeOrderBridge(address(ROLLUP_PROCESSOR));
+
+        vm.label(FACTORY, "FACTORY");
+        vm.label(ROUTER, "ROUTER");
+        vm.label(NONFUNGIBLE_POSITION_MANAGER, "MANAGER");
+        vm.label(address(DAI), "DAI");
+        vm.label(address(WETH), "WETH");
+        vm.label(address(USDC), "USDC");
+        vm.label(address(asyncBridge), "ASYNCBRIDGE");
+
+        vm.deal(address(asyncBridge), uint256(10000));
+        vm.deal(address(this), uint256(10000));
+
+        vm.startPrank(MULTI_SIG);
+        ROLLUP_PROCESSOR.setSupportedBridge(address(asyncBridge), 200000000);
+        id = ROLLUP_PROCESSOR.getSupportedBridgesLength();
+
+        for (uint256 i = 0; i < tokens.length; i++) {
+            if (!isSupportedAsset(tokens[i])) {
+                ROLLUP_PROCESSOR.setSupportedAsset(tokens[i], 100000);
+            }
+        }
+
+        vm.stopPrank();
+    }
+
+    function testAsyncLimitOrder(uint256 _deposit) public {
+        for (uint256 i = 0; i < pairs.length - 4; i++) {
+            poolFee = uint16(poolFees[i]);
+            pool = IUniswapV3Factory(FACTORY).getPool(pairs[i][0], pairs[i][1], uint24(poolFee));
+            (uint160 originalPrice, , , , , , ) = IUniswapV3Pool(pool).slot0();
+            address token0 = pairs[i][0] < pairs[i][1] ? pairs[i][0] : pairs[i][1];
+            address token1 = pairs[i][0] < pairs[i][1] ? pairs[i][1] : pairs[i][0];
+            bool token0HighPrice = _token0Price(originalPrice, 40, token0, token1) > 0;
+            (uint256 lower, uint256 higher) = _limitsOfPool(pool, token0HighPrice ? token1 : token0);
+            _deposit = bound(_deposit, lower, higher);
+            _testAsyncLimitOrder(_deposit, pairs[i][0], pairs[i][1]);
+        }
+    }
+
+    function testAsyncLimitOrderThenCancel(uint256 _deposit) public {
+        for (uint256 i = 0; i < pairs.length - 4; i++) {
+            poolFee = uint16(poolFees[i]);
+            pool = IUniswapV3Factory(FACTORY).getPool(pairs[i][0], pairs[i][1], uint24(poolFee));
+            (uint160 originalPrice, , , , , , ) = IUniswapV3Pool(pool).slot0();
+            address token0 = pairs[i][0] < pairs[i][1] ? pairs[i][0] : pairs[i][1];
+            address token1 = pairs[i][0] < pairs[i][1] ? pairs[i][1] : pairs[i][0];
+            bool token0HighPrice = _token0Price(originalPrice, 40, token0, token1) > 0;
+            (uint256 lower, uint256 higher) = _limitsOfPool(pool, token0HighPrice ? token1 : token0);
+            _deposit = bound(_deposit, lower, higher);
+            _testAsyncLimitOrderThenCancel(_deposit, pairs[i][0], pairs[i][1]);
+        }
+    }
+
+    function _testAsyncLimitOrderThenCancel(
+        uint256 _deposit,
+        address _tokenA,
+        address _tokenB
+    ) internal {
+        uint64 data = _packData(uint160(50));
+
+        //this isnt working because we called it directly from the bridge but we need the
+        //rollup processor to record the interactionnonce since we prodd the rollup to call finalise
+
+        {
+            //BEGIN SCOPE
+            address inToken;
+            address outToken;
+            (uint160 originalPrice, , , , , , ) = IUniswapV3Pool(pool).slot0();
+            if (
+                _token0Price(
+                    originalPrice,
+                    40,
+                    _tokenA < _tokenB ? _tokenA : _tokenB,
+                    _tokenA < _tokenB ? _tokenB : _tokenA
+                ) > 0
+            ) {
+                inToken = _tokenA;
+                outToken = _tokenB;
+            } else {
+                inToken = _tokenB;
+                outToken = _tokenA;
+            }
+            deal(inToken, address(asyncBridge), _deposit);
+            //vm.startPrank(address(ROLLUP_PROCESSOR));
+
+            uint256 bridgeId = encodeBridgeCallData(
+                id,
+                getRealAztecAsset(inToken),
+                emptyAsset,
+                getRealAztecAsset(outToken),
+                getRealAztecAsset(inToken),
+                data
+            );
+
+            //vm.expectEmit(true, true, false, true);
+
+            //adjust this
+            emit DefiBridgeProcessed(bridgeId, getNextNonce(), 1, 0, 0, true, "");
+
+            sendDefiRollup(bridgeId, _deposit);
+
+            //vm.stopPrank();
+            //END OF SCOPE
+        }
+        (, , uint256 amount0, uint256 amount1, , , , , ) = asyncBridge.getDeposit(1);
+
+        (uint256 out0, uint256 out1) = asyncBridge.cancel(1);
+        //ROLLUP_PROCESSOR.processAsyncDefiInteraction(0);
+        vm.startPrank(address(ROLLUP_PROCESSOR));
+        asyncBridge.finalise(
+            emptyAsset,
+            emptyAsset,
+            getRealAztecAsset(address(_tokenA)),
+            getRealAztecAsset(address(_tokenB)),
+            uint256(1),
+            uint64(0)
+        );
+        vm.stopPrank();
+        //one of the outputs will always be 0, we will onyl need to test the non zero one
+
+        assertTrue(
+            (out0 == 0 ? out1 : out0) >= ((amount0 == 0 ? amount1 : amount0) * 99999) / 100000,
+            "failed .000001 margin"
+        );
+    }
+
+    function _testAsyncLimitOrder(
+        uint256 _deposit,
+        address _tokenA,
+        address _tokenB
+    ) internal {
+        uint64 data = _packData(uint160(80));
+
+        address inToken;
+        address outToken;
+
+        if (true) {
+            (uint160 originalPrice, , , , , , ) = IUniswapV3Pool(pool).slot0();
+            //we will be executing a buy limit order
+            //a buy limit order requires that the lower price asset be provided. then wwhen the price decreases
+            //and we remove liquidity, we will receive the higher price asset
+            //since solidity is integer only if token0Price is for example .005 eth it will be 0.
+            //so to find out which is higher priced we need to check if token0Price > 0.
+            //if yes then token0 is higher priced. so we use token1.
+            //if no then token0 is lower priced. so we use token0.
+            if (
+                _token0Price(
+                    originalPrice,
+                    40,
+                    _tokenA < _tokenB ? _tokenA : _tokenB,
+                    _tokenA < _tokenB ? _tokenB : _tokenA
+                ) > 0
+            ) {
+                inToken = _tokenA;
+                outToken = _tokenB;
+            } else {
+                inToken = _tokenB;
+                outToken = _tokenA;
+            }
+            deal(inToken, address(asyncBridge), _deposit);
+            vm.startPrank(address(ROLLUP_PROCESSOR));
+            asyncBridge.convert(
+                getRealAztecAsset(inToken),
+                emptyAsset,
+                getRealAztecAsset(outToken),
+                getRealAztecAsset(inToken),
+                _deposit,
+                1,
+                data,
+                address(0)
+            );
+
+            vm.stopPrank();
+            _lowerPriceToTickRange(outToken, inToken);
+        }
+        if (false) {
+            uint256 bridgeId = encodeBridgeCallData(
+                id,
+                getRealAztecAsset(address(_tokenA)),
+                emptyAsset,
+                getRealAztecAsset(address(_tokenB)),
+                getRealAztecAsset(address(_tokenA)),
+                data
+            );
+
+            vm.expectEmit(true, true, false, true);
+
+            //adjust this
+            emit DefiBridgeProcessed(bridgeId, getNextNonce(), 1, 0, 0, true, "");
+
+            sendDefiRollup(bridgeId, _deposit);
+        }
+
+        (, , uint256 amount0, uint256 amount1, , , , , ) = asyncBridge.getDeposit(1);
+        (uint256 out0, uint256 out1) = asyncBridge.trigger(1);
+        vm.startPrank(address(ROLLUP_PROCESSOR));
+        asyncBridge.finalise(
+            emptyAsset,
+            emptyAsset,
+            getRealAztecAsset(address(_tokenB)),
+            getRealAztecAsset(address(_tokenA)),
+            1,
+            data
+        );
+        vm.stopPrank();
+
+        //ROLLUP_PROCESSOR.processAsyncDefiInteraction(1);
+
+        {
+            if (amount1 > 0) {
+                assertTrue(out1 < amount1);
+                assertTrue(out1 > 0 && out0 > 0);
+            } else {
+                assertTrue(out1 > 0 && out0 > 0);
+            }
+        }
+    }
+
+    function _marginOfError(
+        uint256 _amount0,
+        uint256 _redeem0,
+        uint256 _amount1,
+        uint256 _redeem1,
+        uint256 _marginFrac
+    ) internal {
+        //tests for rounding error
+
+        //necessary when testing smaller values, which have larger margin % but are smaller in absolute terms
+        //e.g. 1000 wei -> 999 wei, which is .1% error, very high
+
+        //we dont care if the amount redeemed is more than the amount minted, only less than
+
+        uint256 scale = 1000000;
+
+        //sometimes when 1 output is much less than the input , the other output is much larger than its original input
+        //e.g. token0 input of 100, output of 99, but token1 input of 100 and output of 101
+
+        uint256 sum = ((_redeem0 * scale) / _amount0) + ((_redeem1 * scale) / _amount1);
+
+        assertTrue(sum >= (2 * scale) - scale / _marginFrac, "not within %margin");
+    }
+
+    function _packData(uint160 _priceDiff) internal returns (uint64 data) {
+        //we need to do these checks because token0Price is not always the higher priced asset as
+        //explained elsewhere. If DAI is token1 and ETH is token0, then using slot0 sqrtPriceX96
+        //is acceptable. However if say USDC is token0 and ETH is token1, then slot0 sqrtPriceX96
+        //when converted to token0Price is USDC's price, which is the lower priced asset.
+        //so then if we multiply USDC's price by 80% , decreasing it, we are actually increasing ETH's price!!
+        //ex: token0Price = USDC price = ratio ETH / USDC. decreasing this means USDC denominator, increasing ETH price
+        //so then their will be errors, as you are actually specifying that your range order will be
+        //executed when the ETH price increases, which isn't what you wanted nor what you attempted.
+
+        (uint160 price, int24 currentTick, , , , , ) = IUniswapV3Pool(pool).slot0();
+        int24 _a;
+        int24 _b;
+        address token0 = IUniswapV3Pool(pool).token0();
+        address token1 = IUniswapV3Pool(pool).token1();
+        uint256 token0Price = _token0Price(price, 20, token0, token1);
+        if (token0Price > 0) {
+            price = (price * _priceDiff) / 100;
+            currentTick = TickMath.getTickAtSqrtRatio(price); //get new target tick
+            (_a, _b) = _adjustTickParams(currentTick - IUniswapV3Pool(pool).tickSpacing(), currentTick, pool);
+        } else {
+            // since 'price' is price of lower priced asset, we need to increase it to decrease high price asset's price
+            price = (price * (200 - _priceDiff)) / 100;
+            currentTick = TickMath.getTickAtSqrtRatio(price); //get new target tick
+            (_a, _b) = _adjustTickParams(currentTick, currentTick + IUniswapV3Pool(pool).tickSpacing(), pool);
+        }
+
+        uint24 a = uint24(_a);
+        uint24 b = uint24(_b);
+        uint48 ticks = (uint48(a) << 24) | uint48(b);
+        uint8 fee = uint8(poolFee / 100);
+        uint8 daysToCancel = 0;
+        uint16 last16 = ((uint16(fee) << 8) | uint16(daysToCancel));
+        data = (uint64(ticks) << 16) | uint64(last16);
+    }
+
+    function _lowerPriceToTickRange(address _tokenIn, address _tokenOut) internal {
+        (, , , , int24 tickLower, int24 tickUpper, , , ) = asyncBridge.getDeposit(1);
+        {
+            ISwapRouter.ExactInputSingleParams memory swapParams = ISwapRouter.ExactInputSingleParams({
+                tokenIn: _tokenIn,
+                tokenOut: _tokenOut,
+                fee: uint24(poolFee),
+                recipient: address(this),
+                deadline: block.timestamp,
+                amountIn: IERC20(_tokenIn).totalSupply() / 10000,
+                amountOutMinimum: 0,
+                sqrtPriceLimitX96: 0
+            });
+
+            (uint160 newPrice, , , , , , ) = IUniswapV3Pool(pool).slot0();
+            //if price / token0Price is the price of higher priced asset, then flag is true. else false.
+            //see packData for description of why this is necessary.
+            //tokenIn is the higher priced token.
+            //if tokenIn token0, then flag is true.
+            bool flag = _tokenIn < _tokenOut;
+            int24 whichTick = flag ? tickUpper : tickLower;
+            //token0Price = higher priced asset case -> newTick >= tickLower
+            //lower price until it reaches tickLower
+            //token0Price = lower priced asset case ->
+            //we want to increase token0Price until it reaches tickLower
+            //    tickUpper    1200 < 1500 newPrice while this is TRUE swap
+            //    tickLower    1/1200 <  1/1500 newPrice while this is FALSE swap
+            //we swap in smaller increments to ensure we meet the range and don't over shoot it
+            while ((TickMath.getTickAtSqrtRatio(newPrice) >= whichTick) == flag) {
+                deal(_tokenIn, address(this), IERC20(_tokenIn).totalSupply() / 10000);
+                TransferHelper.safeApprove(_tokenIn, ROUTER, IERC20(_tokenIn).totalSupply() / 10000);
+                ISwapRouter(ROUTER).exactInputSingle(swapParams);
+                (newPrice, , , , , , ) = IUniswapV3Pool(pool).slot0();
+            }
+            //we ensure the price of the pool meets the target range of our order
+            //this is important as otherwise the range order will not execute
+            if (
+                !(TickMath.getTickAtSqrtRatio(newPrice) <= tickUpper &&
+                    TickMath.getTickAtSqrtRatio(newPrice) >= tickLower)
+            ) revert NotInTickRange();
+        }
+    }
+
+    function _adjustTickParams(
+        int24 _tickLower,
+        int24 _tickUpper,
+        address _pool
+    ) internal returns (int24 newTickLower, int24 newTickUpper) {
+        //adjust the params s.t. they conform to tick spacing and do not fail the tick % tickSpacing == 0 check
+        IUniswapV3Pool pool = IUniswapV3Pool(_pool);
+
+        newTickLower = _tickLower % pool.tickSpacing() == 0
+            ? _tickLower
+            : _tickLower - (_tickLower % pool.tickSpacing());
+        newTickUpper = _tickUpper % pool.tickSpacing() == 0
+            ? _tickUpper
+            : _tickUpper - (_tickUpper % pool.tickSpacing());
+    }
+
+    function _token0Price(
+        uint160 _sqrtPriceX96,
+        uint256 _x,
+        address _token0,
+        address _token1
+    ) internal returns (uint256) {
+        address token0 = _token0 < _token1 ? _token0 : _token1;
+        address token1 = _token0 < _token1 ? _token1 : _token0;
+        uint256 scalar = (10**IERC20Metadata(token0).decimals()) / (10**IERC20Metadata(token1).decimals());
+        return (scalar * (_sqrtPriceX96 / (2**_x))**2) / (2**(192 - (2 * _x)));
+    }
+
+    function _limitsOfPool(address _pool, address _token) internal returns (uint256, uint256) {
+        //there are max liquidity constraints per pool, therefore it makes sense to define custom limits
+        //on a per pool basis rather than a per token basis alone.
+        //USDT WETH 500
+        if (_pool == 0x11b815efB8f581194ae79006d24E0d814B7697F6) {
+            if (_token == USDT) return (1000000000000, 18479553865698585296224760);
+            else if (_token == WETH) return (16990826690438413, 218809284046322613163859525526366);
+        }
+        //WETH USDC 3000
+        else if (_pool == 0x8ad599c3A0ff1De082011EFDDc58f1908eb6e6D8) {
+            if (_token == WETH) return (16990826690438413, 218809284046322613163859525526366);
+            else if (_token == USDC) return (1000000000000, 10659313385221375029114507794201510);
+        }
+        //USDT WBTC 3000
+        else if (_pool == 0x9Db9e0e53058C89e5B94e29621a205198648425B) {
+            if (_token == USDT) return (10000000, 26567527292104433082061);
+            else if (_token == WBTC) return (10000, 16990826690438413);
+        }
+        //WETH WBTC 3000
+        else if (_pool == 0xCBCdF9626bC03E24f779434178A73a0B4bad62eD) {
+            if (_token == WETH) return (1699082669043840, 2188092840463226131638595111);
+            else if (_token == WBTC) return (100000, 2790826690438412);
+        }
+        //USDC WBTC 3000
+        else if (_pool == 0x99ac8cA7087fA4A2A1FB6357269965A2014ABc35) {
+            if (_token == USDC) return (1000000, 10659313385221300);
+            else if (_token == WBTC) return (100000, 16990826690438413);
+        }
+    }
+}

--- a/src/test/bridges/uniswap_lp/Uniswap.t.sol
+++ b/src/test/bridges/uniswap_lp/Uniswap.t.sol
@@ -1,0 +1,676 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.10;
+pragma experimental ABIEncoderV2;
+import {BridgeTestBase} from "./../../aztec/base/BridgeTestBase.sol";
+import {ErrorLib} from "../../../bridges/base/ErrorLib.sol";
+import {Vm} from "../../../../lib/forge-std/src/Vm.sol";
+
+// Example-specific imports
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {INonfungiblePositionManager} from "../../../interfaces/uniswapv3/INonfungiblePositionManager.sol";
+import {IUniswapV3Factory} from "../../../interfaces/uniswapv3/IUniswapV3Factory.sol";
+import {IUniswapV3Pool} from "../../../interfaces/uniswapv3/IUniswapV3Pool.sol";
+import {IQuoterV2} from "../../../interfaces/uniswapv3/IQuoterV2.sol";
+import {TickMath} from "../../../libraries/uniswapv3/TickMath.sol";
+import {FullMath} from "../../../libraries/uniswapv3/FullMath.sol";
+import {UniLPBridge} from "../../../bridges/uniswap_lp/UniLPBridge.sol";
+import {TransferHelper, ISwapRouter, ParentUniLPBridge} from "../../../bridges/uniswap_lp/ParentUniLPBridge.sol";
+import {AztecTypes} from "../../../aztec/libraries/AztecTypes.sol";
+import {LiquidityAmounts} from "../../../libraries/uniswapv3/LiquidityAmounts.sol";
+
+contract UniswapLPTest is BridgeTestBase {
+    address private constant DAI = 0x6B175474E89094C44Da98b954EedeAC495271d0F;
+    address private constant USDT = 0xdAC17F958D2ee523a2206206994597C13D831ec7;
+    address private constant WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
+    address private constant USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
+    address private constant WBTC = 0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599;
+    address private constant FACTORY = 0x1F98431c8aD98523631AE4a59f267346ea31F984;
+    address private constant ROUTER = 0xE592427A0AEce92De3Edee1F18E0157C05861564;
+    address private constant NONFUNGIBLE_POSITION_MANAGER = 0xC36442b4a4522E871399CD717aBDD847Ab11FE88;
+    address private constant QUOTER = 0xb27308f9F90D607463bb33eA1BeBb41C27CE5AB6;
+    address private pool = 0x4e68Ccd3E89f51C3074ca5072bbAC773960dFa36;
+    address[] private tokens = [USDT, DAI, WETH, USDC, WBTC];
+    //                                  1           2              3            4           5               6           7               8
+
+    address[][] private pairs = [[USDT, WETH], [WETH, USDC], [USDT, WBTC], [WETH, WBTC], [USDC, WBTC]];
+    //                              1      2    3       4   5       6   7     8
+    uint256[] private poolFees = [500, 3000, 3000, 3000, 3000, 100, 3000, 3000];
+    uint16 private poolFee;
+    UniLPBridge private syncBridge;
+    uint256 private id;
+
+    function setUp() public {
+        vm.label(FACTORY, "FACTORY");
+        vm.label(ROUTER, "ROUTER");
+        vm.label(NONFUNGIBLE_POSITION_MANAGER, "MANAGER");
+        vm.label(address(USDT), "USDT");
+        vm.label(address(WETH), "WETH");
+        vm.label(address(USDC), "USDC");
+
+        syncBridge = new UniLPBridge(address(ROLLUP_PROCESSOR));
+        vm.label(address(syncBridge), "SYNCBRIDGE");
+        vm.prank(MULTI_SIG);
+        ROLLUP_PROCESSOR.setSupportedBridge(address(syncBridge), 20000000000000000000);
+        vm.deal(address(this), 20000000000);
+        vm.deal(address(ROLLUP_PROCESSOR), 20000000000);
+        id = ROLLUP_PROCESSOR.getSupportedBridgesLength();
+
+        for (uint256 i = 0; i < tokens.length; i++) {
+            if (!isSupportedAsset(tokens[i])) {
+                vm.prank(MULTI_SIG);
+                ROLLUP_PROCESSOR.setSupportedAsset(tokens[i], 20000000000000000000);
+            }
+        }
+
+        vm.deal(address(syncBridge), uint256(10000));
+        vm.deal(address(this), uint256(10000));
+    }
+
+    //both testTwoPartMint and testMintBySwap are set to only try 2 pairs right now
+    //because otherwise testing takes too long (5-7 min to do both tests)
+    function testTwoPartMint(uint256 _deposit, uint256 _ethDeposit) public {
+        for (uint256 i = 0; i < pairs.length - 4; i++) {
+            poolFee = uint16(poolFees[i]);
+            address token0 = pairs[i][0] < pairs[i][1] ? pairs[i][0] : pairs[i][1];
+            address token1 = pairs[i][0] < pairs[i][1] ? pairs[i][1] : pairs[i][0];
+            _testTwoPartMint(_deposit, _ethDeposit, token0, token1);
+        }
+    }
+
+    function testMintBySwap(uint256 _deposit) public {
+        for (uint256 i = 0; i < pairs.length - 4; i++) {
+            poolFee = uint16(poolFees[i]);
+            pool = IUniswapV3Factory(FACTORY).getPool(pairs[i][0], pairs[i][1], uint24(poolFee));
+            address token0 = pairs[i][0] < pairs[i][1] ? pairs[i][0] : pairs[i][1];
+            address token1 = pairs[i][0] < pairs[i][1] ? pairs[i][1] : pairs[i][0];
+            _testMintBySwap(_deposit, token0, token1);
+            if (token0 == WETH) {
+                _testMintBySwap(_deposit, address(0), token1);
+            }
+        }
+    }
+
+    //INTERACTIONS
+    //INTERACTION TYPE 1 MINT PART 1
+    //1 real (token A) 1 not used
+    //1 virtual 1 not used
+    //INTERACTION TYPE 2 MINT PART 2
+    //1 real (tokenB) 1 virtual (tokenA virtualnote)
+    //1 virtual 1 real (refund) (tokenA or tokenB)
+    //INTERACTION TYPE 3 MINT BY SWAP
+    //1 real (tokenA) 1 not used
+    //1 virtual 1 real (tokenB)
+    //INTERACTION TYPE 4 LP REDEMPTION
+    //1 virtual 1 not used (LP virtualnote)
+    //1 real 1 real (tokenA, tokenB)
+    //expect revert test cases:
+    //case 1 : specify incorrect refund on interaction 2
+    //case 2: invalid outputs for liquidity position redemption / interaction 4
+    function testExpectReverts(uint256 _amount0, uint256 _amount1) public {
+        for (uint256 i = 0; i < pairs.length - 4; i++) {
+            poolFee = uint16(poolFees[i]);
+            pool = IUniswapV3Factory(FACTORY).getPool(pairs[i][0], pairs[i][1], uint24(poolFee));
+            address token0 = pairs[i][0] < pairs[i][1] ? pairs[i][0] : pairs[i][1];
+            address token1 = pairs[i][0] < pairs[i][1] ? pairs[i][1] : pairs[i][0];
+            _testExpectRevertInvalidRefund(_amount0, _amount1, token0, token1);
+            _testExpectRevertInvalidOutputs(_amount0, _amount1, token0, token1);
+            _testExpectRevertInvalidCaller(_amount0, _amount1, token0, token1);
+        }
+    }
+
+    function _testExpectRevertInvalidRefund(
+        uint256 _amount0,
+        uint256 _amount1,
+        address _token0,
+        address _token1
+    ) internal {
+        //most of these upper limits are as a result of the pools limited liquidity
+        //we constrain ETH to 1 trillion ETH, fairly reasonable IMO
+        pool = IUniswapV3Factory(FACTORY).getPool(_token0, _token1, uint24(poolFee));
+        {
+            (uint256 lower0, uint256 higher0, uint256 lower1, uint256 higher1) = _limitsOfPool(pool);
+            _amount0 = bound(_amount0, lower0, higher0);
+            _amount1 = bound(_amount1, lower1, higher1);
+        }
+
+        deal(_token1, address(syncBridge), _amount1);
+        deal(_token0, address(syncBridge), _amount0);
+
+        uint256 virtualNoteAmount;
+
+        vm.startPrank(address(ROLLUP_PROCESSOR));
+
+        {
+            (uint256 outputValueA, , ) = syncBridge.convert(
+                getRealAztecAsset(_token1),
+                emptyAsset,
+                AztecTypes.AztecAsset({id: 1, erc20Address: address(0), assetType: AztecTypes.AztecAssetType.VIRTUAL}),
+                emptyAsset,
+                _amount1,
+                1,
+                0,
+                address(0)
+            );
+
+            vm.stopPrank();
+
+            uint256 bridgeToken1Qty = IERC20(_token1).balanceOf(address(syncBridge));
+            virtualNoteAmount = outputValueA;
+            assertEq(_amount1, bridgeToken1Qty, "Balances must match ; first convert call");
+        }
+
+        {
+            uint64 data;
+            (uint160 price, , , , , , ) = IUniswapV3Pool(pool).slot0();
+
+            {
+                (int24 _a, int24 _b) = _adjustTickParams(
+                    TickMath.getTickAtSqrtRatio((price * 60) / 100),
+                    TickMath.getTickAtSqrtRatio((price * 120) / 100),
+                    pool
+                );
+                uint24 a = uint24(_a);
+                uint24 b = uint24(_b);
+                uint48 ticks = (uint48(a) << 24) | uint48(b);
+                uint16 fee = uint16(IUniswapV3Pool(pool).fee());
+                data = (uint64(ticks) << 16) | uint64(fee);
+            }
+
+            vm.startPrank(address(ROLLUP_PROCESSOR));
+            //third argument should be token0 or token1 not 0
+            vm.expectRevert(abi.encodeWithSelector(UniLPBridge.InvalidRefund.selector));
+            syncBridge.convert(
+                AztecTypes.AztecAsset({id: 2, erc20Address: _token0, assetType: AztecTypes.AztecAssetType.ERC20}),
+                AztecTypes.AztecAsset({id: 1, erc20Address: address(0), assetType: AztecTypes.AztecAssetType.VIRTUAL}),
+                AztecTypes.AztecAsset({id: 2, erc20Address: address(0), assetType: AztecTypes.AztecAssetType.VIRTUAL}),
+                AztecTypes.AztecAsset({id: 2, erc20Address: address(0), assetType: AztecTypes.AztecAssetType.ERC20}),
+                _amount0,
+                2,
+                data,
+                address(0)
+            );
+
+            vm.stopPrank();
+        }
+    }
+
+    function _testExpectRevertInvalidCaller(
+        uint256 _amount0,
+        uint256 _amount1,
+        address _token0,
+        address _token1
+    ) internal {
+        pool = IUniswapV3Factory(FACTORY).getPool(_token0, _token1, uint24(poolFee));
+        {
+            (uint256 lower0, uint256 higher0, uint256 lower1, uint256 higher1) = _limitsOfPool(pool);
+            _amount0 = bound(_amount0, lower0, higher0);
+            _amount1 = bound(_amount1, lower1, higher1);
+        }
+
+        vm.expectRevert(abi.encodeWithSelector(ErrorLib.InvalidCaller.selector));
+
+        syncBridge.convert(
+            AztecTypes.AztecAsset({id: 1, erc20Address: address(0), assetType: AztecTypes.AztecAssetType.VIRTUAL}),
+            emptyAsset,
+            AztecTypes.AztecAsset({id: 1, erc20Address: address(0), assetType: AztecTypes.AztecAssetType.VIRTUAL}),
+            emptyAsset,
+            _amount1,
+            1,
+            0,
+            address(0)
+        );
+    }
+
+    function _testExpectRevertInvalidOutputs(
+        uint256 _amount0,
+        uint256 _amount1,
+        address _token0,
+        address _token1
+    ) internal {
+        pool = IUniswapV3Factory(FACTORY).getPool(_token0, _token1, uint24(poolFee));
+
+        {
+            (uint256 lower0, uint256 higher0, uint256 lower1, uint256 higher1) = _limitsOfPool(pool);
+            _amount0 = bound(_amount0, lower0, higher0);
+            _amount1 = bound(_amount1, lower1, higher1);
+        }
+
+        deal(_token1, address(syncBridge), _amount1);
+        deal(_token0, address(syncBridge), _amount0);
+
+        uint256 virtualNoteAmount;
+
+        vm.startPrank(address(ROLLUP_PROCESSOR));
+
+        {
+            (uint256 outputValueA, , ) = syncBridge.convert(
+                getRealAztecAsset(_token1),
+                emptyAsset,
+                AztecTypes.AztecAsset({id: 1, erc20Address: address(0), assetType: AztecTypes.AztecAssetType.VIRTUAL}),
+                emptyAsset,
+                _amount1,
+                1,
+                0,
+                address(0)
+            );
+
+            vm.stopPrank();
+
+            uint256 bridgeToken1Qty = IERC20(_token1).balanceOf(address(syncBridge));
+            virtualNoteAmount = outputValueA;
+            assertEq(_amount1, bridgeToken1Qty, "Balances must match ; first convert call");
+        }
+
+        {
+            uint64 data;
+            (uint160 price, , , , , , ) = IUniswapV3Pool(pool).slot0();
+
+            {
+                (int24 _a, int24 _b) = _adjustTickParams(
+                    TickMath.getTickAtSqrtRatio((price * 60) / 100),
+                    TickMath.getTickAtSqrtRatio((price * 120) / 100),
+                    pool
+                );
+                uint24 a = uint24(_a);
+                uint24 b = uint24(_b);
+                uint48 ticks = (uint48(a) << 24) | uint48(b);
+                uint16 fee = uint16(IUniswapV3Pool(pool).fee());
+                data = (uint64(ticks) << 16) | uint64(fee);
+            }
+
+            vm.startPrank(address(ROLLUP_PROCESSOR));
+            (uint256 callTwoOutputValueA, , ) = syncBridge.convert(
+                AztecTypes.AztecAsset({id: 2, erc20Address: _token0, assetType: AztecTypes.AztecAssetType.ERC20}),
+                AztecTypes.AztecAsset({id: 1, erc20Address: address(0), assetType: AztecTypes.AztecAssetType.VIRTUAL}),
+                AztecTypes.AztecAsset({id: 2, erc20Address: address(0), assetType: AztecTypes.AztecAssetType.VIRTUAL}),
+                AztecTypes.AztecAsset({id: 2, erc20Address: _token0, assetType: AztecTypes.AztecAssetType.ERC20}),
+                _amount0,
+                2,
+                data,
+                address(0)
+            );
+
+            vm.stopPrank();
+
+            uint256 callTwoVirtualNoteAmount = callTwoOutputValueA;
+
+            (, , uint256 amount0, uint256 amount1, , , , , ) = syncBridge.getDeposit(2);
+            vm.startPrank(address(ROLLUP_PROCESSOR));
+            vm.expectRevert(abi.encodeWithSelector(ParentUniLPBridge.InvalidOutputs.selector));
+
+            syncBridge.convert(
+                AztecTypes.AztecAsset({id: 3, erc20Address: address(0), assetType: AztecTypes.AztecAssetType.VIRTUAL}),
+                AztecTypes.AztecAsset({id: 1, erc20Address: address(0), assetType: AztecTypes.AztecAssetType.NOT_USED}),
+                AztecTypes.AztecAsset({id: 2, erc20Address: address(0), assetType: AztecTypes.AztecAssetType.ERC20}),
+                AztecTypes.AztecAsset({id: 2, erc20Address: _token0, assetType: AztecTypes.AztecAssetType.ERC20}),
+                callTwoVirtualNoteAmount,
+                3,
+                0,
+                address(0)
+            );
+            vm.stopPrank();
+        }
+    }
+
+    function _testTwoPartMint(
+        uint256 _amount0,
+        uint256 _amount1,
+        address _token0,
+        address _token1
+    ) internal {
+        pool = IUniswapV3Factory(FACTORY).getPool(_token0, _token1, uint24(poolFee));
+        {
+            (uint256 lower0, uint256 higher0, uint256 lower1, uint256 higher1) = _limitsOfPool(pool);
+            _amount0 = bound(_amount0, lower0, higher0);
+            _amount1 = bound(_amount1, lower1, higher1);
+        }
+
+        //give our bridge token qties so it can swap and change pool price
+        deal(_token0, address(this), _amount0);
+        deal(_token1, address(this), _amount1);
+        if (true) {
+            (uint160 originalPrice, , , , , , ) = IUniswapV3Pool(pool).slot0();
+            UniLPBridge.OptimalLiqParams memory liqParams = UniLPBridge.OptimalLiqParams({
+                token0: _token0,
+                token1: _token1,
+                fee: IUniswapV3Pool(pool).fee(),
+                amount0: _amount0,
+                amount1: _amount1,
+                sqrtRatioAX96: (originalPrice * 60) / 100,
+                sqrtRatioBX96: originalPrice * 2
+            });
+            (_amount0, _amount1) = syncBridge.optimizeLiquidity(liqParams);
+            bool flag = IERC20(_token0).balanceOf(address(this)) > _amount0;
+            address tokenIn = flag ? _token0 : _token1;
+            address tokenOut = flag ? _token1 : _token0;
+            uint256 amountIn = flag
+                ? IERC20(_token0).balanceOf(address(this)) - _amount0
+                : IERC20(_token1).balanceOf(address(this)) - _amount1;
+            if (amountIn > 0) {
+                TransferHelper.safeApprove(tokenIn, ROUTER, 0);
+                TransferHelper.safeApprove(tokenIn, ROUTER, amountIn);
+                ISwapRouter.ExactInputSingleParams memory params = ISwapRouter.ExactInputSingleParams({
+                    tokenIn: tokenIn,
+                    tokenOut: tokenOut,
+                    fee: IUniswapV3Pool(pool).fee(),
+                    recipient: address(this),
+                    deadline: block.timestamp,
+                    amountIn: amountIn,
+                    amountOutMinimum: 0,
+                    sqrtPriceLimitX96: tokenIn < tokenOut ? (originalPrice * 60) / 100 : (originalPrice * 120) / 100
+                });
+
+                ISwapRouter(ROUTER).exactInputSingle(params);
+                TransferHelper.safeApprove(tokenIn, ROUTER, 0);
+            }
+        }
+        //(_amount0, _amount1) = _optimizeLiquidity(_amount1, _amount0);
+        deal(_token1, address(ROLLUP_PROCESSOR), _amount1);
+        deal(_token0, address(ROLLUP_PROCESSOR), _amount0);
+        //deal(_token1, address(syncBridge), _amount1);
+        //deal(_token0, address(syncBridge), _amount0);
+        (uint160 originalPrice, , , , , , ) = IUniswapV3Pool(pool).slot0();
+
+        uint256 virtualNoteAmount;
+
+        //vm.startPrank(address(ROLLUP_PROCESSOR));
+        uint256 mostRecentNonce = getNextNonce();
+        {
+            (uint256 outputValueA, , ) = _convert(
+                getRealAztecAsset(_token1),
+                emptyAsset,
+                AztecTypes.AztecAsset({
+                    id: getNextNonce(),
+                    erc20Address: address(0),
+                    assetType: AztecTypes.AztecAssetType.VIRTUAL
+                }),
+                emptyAsset,
+                _amount1,
+                0
+            );
+
+            //vm.stopPrank();
+            uint256 bridgeToken1Qty = IERC20(_token1).balanceOf(address(syncBridge));
+            virtualNoteAmount = outputValueA;
+            assertEq(_amount1, bridgeToken1Qty, "Balances must match ; first convert call");
+        }
+
+        {
+            uint64 data;
+
+            {
+                (uint160 price, , , , , , ) = IUniswapV3Pool(pool).slot0();
+
+                (int24 _a, int24 _b) = _adjustTickParams(
+                    TickMath.getTickAtSqrtRatio((price * 60) / 100),
+                    TickMath.getTickAtSqrtRatio((price * 120) / 100),
+                    pool
+                );
+                uint24 a = uint24(_a);
+                uint24 b = uint24(_b);
+                uint48 ticks = (uint48(a) << 24) | uint48(b);
+                uint16 fee = uint16(IUniswapV3Pool(pool).fee());
+                data = (uint64(ticks) << 16) | uint64(fee);
+            }
+
+            //vm.startPrank(address(ROLLUP_PROCESSOR));
+            uint256 newestNonce = getNextNonce();
+            (uint256 callTwoOutputValueA, , ) = _convert(
+                getRealAztecAsset(_token0),
+                AztecTypes.AztecAsset({
+                    id: mostRecentNonce,
+                    erc20Address: address(0),
+                    assetType: AztecTypes.AztecAssetType.VIRTUAL
+                }),
+                AztecTypes.AztecAsset({
+                    id: getNextNonce(),
+                    erc20Address: address(0),
+                    assetType: AztecTypes.AztecAssetType.VIRTUAL
+                }),
+                getRealAztecAsset(_token0),
+                _amount0,
+                data
+            );
+
+            //vm.stopPrank();
+
+            (, , uint256 amount0, uint256 amount1, , , , , ) = syncBridge.getDeposit(newestNonce);
+
+            (uint256 redeem0, uint256 redeem1) = _redeem(callTwoOutputValueA, newestNonce, _token0, _token1);
+
+            {
+                //sqrt(10^b-a * token0Price) * 2**96
+                originalPrice = originalPrice / (2**48); //sqrt(10^b-a * token0Price) * 2**48
+                originalPrice = originalPrice**2; //10^b-a * token0Price * 2**96
+
+                //convert amount0 to usdt value / qty
+                //sum converted amount with amount1 usdt qty
+                uint256 total1ValueBefore = amount1 + ((amount0 * originalPrice) / 2**96);
+                //convert redeem0 to usdt value qty
+                //sum converted redeemed amount with redeem1 usdt qty
+                uint256 total1ValueAfter = redeem1 + ((redeem0 * originalPrice) / 2**96);
+                //convert amount1 to eth equivalent qty / value
+                //sum converted amount1 eth value with amount0 eth value for total eth value
+                uint256 total0ValueBefore = amount0 + ((amount1 * (2**96)) / originalPrice);
+                //convert redeem1 to equivalent eth value
+                //sum converted redeem1 equivalent eth value with redeem0 eth value for total eth value
+                uint256 total0ValueAfter = redeem0 + ((redeem1 * (2**96)) / originalPrice);
+                assertTrue(
+                    (total0ValueBefore * 95) / 100 <= total0ValueAfter ||
+                        (total1ValueBefore * 95) / 100 <= total1ValueAfter,
+                    "Equivalent values in either token did not match upon redemption"
+                );
+            }
+        }
+    }
+
+    function _testMintBySwap(
+        uint256 _deposit,
+        address _token0,
+        address _token1
+    ) internal {
+        {
+            (uint256 lower, uint256 higher) = _limitsOfPoolSwap(pool, _token0 == address(0) ? WETH : _token0);
+            _deposit = bound(_deposit, lower, higher);
+        }
+
+        //0 address represents ETH
+        if (_token0 == address(0)) {
+            deal(address(ROLLUP_PROCESSOR), _deposit);
+        } else {
+            deal(_token0, address(ROLLUP_PROCESSOR), _deposit);
+        }
+
+        uint64 data;
+        //pack params into data
+
+        {
+            (int24 _a, int24 _b) = _adjustTickParams(TickMath.MIN_TICK, TickMath.MAX_TICK, pool);
+            uint24 a = uint24(_a);
+            uint24 b = uint24(_b);
+            uint48 ticks = (uint48(a) << 24) | uint48(b);
+            uint16 fee = poolFee;
+            data = (uint64(ticks) << 16) | uint64(fee);
+        }
+
+        //vm.startPrank(address(ROLLUP_PROCESSOR));
+        uint256 outputValueA;
+        uint256 outputValueB;
+
+        (outputValueA, outputValueB, ) = _convert(
+            getRealAztecAsset(_token0),
+            emptyAsset,
+            AztecTypes.AztecAsset({
+                id: getNextNonce(),
+                erc20Address: address(0),
+                assetType: AztecTypes.AztecAssetType.VIRTUAL
+            }),
+            getRealAztecAsset(_token1),
+            _deposit,
+            data
+        );
+        //vm.stopPrank();
+        (, , uint256 amount0, uint256 amount1, , , , , ) = syncBridge.getDeposit(1);
+
+        (uint256 redeem0, uint256 redeem1) = _redeem(outputValueA, getNextNonce() - 1, _token0, _token1);
+
+        {
+            (uint160 originalPrice, , , , , , ) = IUniswapV3Pool(pool).slot0();
+
+            //sqrt(10^b-a * token0Price) * 2**96
+            originalPrice = originalPrice / (2**48); //sqrt(10^b-a * token0Price) * 2**48
+            originalPrice = originalPrice**2; //10^b-a * token0Price * 2**96
+
+            //convert amount0 to usdt value / qty
+            //sum converted amount with amount1 usdt qty
+            uint256 total1ValueBefore = amount1 + ((amount0 * originalPrice) / 2**96);
+            //convert redeem0 to usdt value qty
+            //sum converted redeemed amount with redeem1 usdt qty
+            uint256 total1ValueAfter = redeem1 + ((redeem0 * originalPrice) / 2**96);
+            //convert amount1 to eth equivalent qty / value
+            //sum converted amount1 eth value with amount0 eth value for total eth value
+            uint256 total0ValueBefore = amount0 + ((amount1 * (2**96)) / originalPrice);
+            //convert redeem1 to equivalent eth value
+            //sum converted redeem1 equivalent eth value with redeem0 eth value for total eth value
+            uint256 total0ValueAfter = redeem0 + ((redeem1 * (2**96)) / originalPrice);
+            assertTrue(
+                (total0ValueBefore * 95) / 100 <= total0ValueAfter ||
+                    (total1ValueBefore * 95) / 100 <= total1ValueAfter,
+                "Equivalent values in either token did not match upon redemption"
+            );
+        }
+    }
+
+    function _redeem(
+        uint256 _inputValue,
+        uint256 _nonce,
+        address _token0,
+        address _token1
+    ) internal returns (uint256, uint256) {
+        AztecTypes.AztecAsset memory outputAssetA = getRealAztecAsset(_token0);
+
+        AztecTypes.AztecAsset memory outputAssetB = getRealAztecAsset(_token1);
+        (uint256 outputValueA, uint256 outputValueB, ) = _convert(
+            AztecTypes.AztecAsset({id: _nonce, erc20Address: address(0), assetType: AztecTypes.AztecAssetType.VIRTUAL}),
+            emptyAsset,
+            outputAssetA,
+            outputAssetB,
+            _inputValue,
+            0
+        );
+        //vm.stopPrank();
+        ///sort in terms of token0 or token1
+        return (
+            outputAssetA.erc20Address < outputAssetB.erc20Address
+                ? (outputValueA, outputValueB)
+                : (outputValueB, outputValueA)
+        );
+    }
+
+    function _limitsOfPoolSwap(address _pool, address _token) internal returns (uint256, uint256) {
+        //there are max liquidity constraints per pool, therefore it makes sense to define custom limits
+        //on a per pool basis rather than a per token basis alone.
+        //USDT WETH 500
+        if (_pool == 0x11b815efB8f581194ae79006d24E0d814B7697F6) {
+            if (_token == USDT) return (1000000000000, 1000000000000000000);
+            else if (_token == WETH) return (16990826690438413, 50000000 * (10**18));
+        }
+        //WETH USDC 3000
+        else if (_pool == 0x8ad599c3A0ff1De082011EFDDc58f1908eb6e6D8) {
+            if (_token == WETH) return (16990826690438413, 218809284046322613163859525526366);
+            else if (_token == USDC) return (1000000000000, 681295379303178355619856090732);
+        }
+        //USDT WBTC 3000
+        else if (_pool == 0x9Db9e0e53058C89e5B94e29621a205198648425B) {
+            if (_token == USDT) return (10000000, 26567527292104433082061);
+            else if (_token == WBTC) return (10000, 292678394196);
+        }
+        //WETH WBTC 3000
+        else if (_pool == 0xCBCdF9626bC03E24f779434178A73a0B4bad62eD) {
+            if (_token == WETH) return (1699082669043840, 2188092840463226131638595111);
+            else if (_token == WBTC) return (100000, 7000 * (10**8));
+        }
+        //USDC WBTC 3000
+        else if (_pool == 0x99ac8cA7087fA4A2A1FB6357269965A2014ABc35) {
+            if (_token == USDC) return (1000000, 10659313385221300);
+            else if (_token == WBTC) return (100000, 4228925722264);
+        }
+    }
+
+    function _convert(
+        AztecTypes.AztecAsset memory _inputAssetA,
+        AztecTypes.AztecAsset memory _inputAssetB,
+        AztecTypes.AztecAsset memory _outputAssetA,
+        AztecTypes.AztecAsset memory _outputAssetB,
+        uint256 _inputValue,
+        uint64 _auxData
+    )
+        internal
+        returns (
+            uint256 outputValueA,
+            uint256 outputValueB,
+            bool isAsync
+        )
+    {
+        uint256 bId = ROLLUP_PROCESSOR.getSupportedBridgesLength();
+        uint256 bridgeCallData = encodeBridgeCallData(
+            bId,
+            _inputAssetA,
+            _inputAssetB,
+            _outputAssetA,
+            _outputAssetB,
+            _auxData
+        );
+        (outputValueA, outputValueB, ) = sendDefiRollup(bridgeCallData, _inputValue);
+    }
+
+    function _limitsOfPool(address _pool)
+        internal
+        returns (
+            uint256,
+            uint256,
+            uint256,
+            uint256
+        )
+    {
+        //there are max liquidity constraints per pool, therefore it makes sense to define custom limits
+        //on a per pool basis rather than a per token basis alone.
+        //USDT WETH 500
+        if (_pool == 0x11b815efB8f581194ae79006d24E0d814B7697F6) {
+            //WETH first, USDT second
+            return (16990826690438413, 1227845160188079285473, 1000000000000, 1000000000000000000);
+        }
+        //WETH USDC 3000
+        else if (_pool == 0x8ad599c3A0ff1De082011EFDDc58f1908eb6e6D8) {
+            return (10000000, (10**(18)), 16990826690438413, 10**(30));
+        }
+        //USDT WBTC 3000
+        else if (_pool == 0x9Db9e0e53058C89e5B94e29621a205198648425B) {
+            return (10000, 40 * (10**14), 10000000, 10**18);
+        }
+        //WETH WBTC 3000
+        else if (_pool == 0xCBCdF9626bC03E24f779434178A73a0B4bad62eD) {
+            return (100000, 2790826690438412, 1699082669043840, 1188092840463226131638595111);
+        }
+        //USDC WBTC 3000
+        else if (_pool == 0x99ac8cA7087fA4A2A1FB6357269965A2014ABc35) {
+            return (100000, 16990826690438413, 1000000, 10659313385221300);
+        }
+    }
+
+    function _adjustTickParams(
+        int24 _tickLower,
+        int24 _tickUpper,
+        address _pool
+    ) internal returns (int24 newTickLower, int24 newTickUpper) {
+        //adjust the params s.t. they conform to tick spacing and do not fail the tick % tickSpacing == 0 check
+        IUniswapV3Pool pool = IUniswapV3Pool(_pool);
+
+        newTickLower = _tickLower % pool.tickSpacing() == 0
+            ? _tickLower
+            : _tickLower - (_tickLower % pool.tickSpacing());
+        newTickUpper = _tickUpper % pool.tickSpacing() == 0
+            ? _tickUpper
+            : _tickUpper - (_tickUpper % pool.tickSpacing());
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2479,11 +2479,6 @@ cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-data-uri-to-buffer@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz#b5db46aea50f6176428ac05b73be39a57701a64b"
-  integrity sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==
-
 debug@4, debug@4.3.4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.2.0, debug@^4.3.2, debug@^4.3.3, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
@@ -3093,14 +3088,6 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
-fetch-blob@^3.1.2, fetch-blob@^3.1.4:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/fetch-blob/-/fetch-blob-3.2.0.tgz#f09b8d4bbd45adc6f0c20b7e787e793e309dcce9"
-  integrity sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==
-  dependencies:
-    node-domexception "^1.0.0"
-    web-streams-polyfill "^3.0.3"
-
 figures@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
@@ -3195,13 +3182,6 @@ follow-redirects@^1.12.1:
   version "1.15.0"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.0.tgz#06441868281c86d0dda4ad8bdaead2d02dca89d4"
   integrity sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ==
-
-formdata-polyfill@^4.0.10:
-  version "4.0.10"
-  resolved "https://registry.yarnpkg.com/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz#24807c31c9d402e002ab3d8c720144ceb8848423"
-  integrity sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==
-  dependencies:
-    fetch-blob "^3.1.2"
 
 fp-ts@1.19.3:
   version "1.19.3"
@@ -4687,11 +4667,6 @@ node-addon-api@^2.0.0:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-2.0.2.tgz#432cfa82962ce494b132e9d72a15b29f71ff5d32"
   integrity sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==
 
-node-domexception@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/node-domexception/-/node-domexception-1.0.0.tgz#6888db46a1f71c0b76b3f7555016b63fe64766e5"
-  integrity sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==
-
 node-fetch@2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
@@ -4703,15 +4678,6 @@ node-fetch@^2.6.1:
   integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
   dependencies:
     whatwg-url "^5.0.0"
-
-node-fetch@^3.2.9:
-  version "3.2.9"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-3.2.9.tgz#3f6070bf854de20f21b9fe8479f823462e615d7d"
-  integrity sha512-/2lI+DBecVvVm9tDhjziTVjo2wmTsSxSk58saUYP0P/fRJ3xxtfMDY24+CKTkfm0Dlhyn3CSXNL0SoRiCZ8Rzg==
-  dependencies:
-    data-uri-to-buffer "^4.0.0"
-    fetch-blob "^3.1.4"
-    formdata-polyfill "^4.0.10"
 
 node-gyp-build@^4.2.0:
   version "4.4.0"
@@ -5915,11 +5881,6 @@ walker@^1.0.8:
   integrity sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==
   dependencies:
     makeerror "1.0.12"
-
-web-streams-polyfill@^3.0.3:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz#71c2718c52b45fd49dbeee88634b3a60ceab42a6"
-  integrity sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==
 
 webidl-conversions@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
I fixed the linting errors as requested, and have also updated the foundry tests to work with the new test base. I want to continue to improve the tests also to check other cases for the bridge to be safe, but as I understand Jan had some feedback, I wanted him to see the new updated version so he can review it so I can start working on those suggestions ASAP. 

My personal ideas for things I want to add/check:
-add some foundry tests to check that the bridge correctly reverts in the case of improper aztecasset inputs and outputs.
-perhaps delete the mintbyswap convert method, as now that Jan has created the Uniswap Swap bridge, the user can instead swap using that and then call my bridge to LP.
-Make sure the tests ,which currently only test the dai/weth pool, generalize well to other pools
-Find out why calling convert through the rolluprocessor fails. At the moment, I am impersonating the rollupprocessor using vm.prank and then calling my bridge directly. For some reason, calling through rollupprocessor triggers a revert in the Uniswap V3 Pool. I think the delegatecall the rollupprocessor performs is the culprit for some reason, but I'm not completely sure. 



# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] There are no unexpected formatting changes, or superfluous debug logs.
- [ ] The branch has been rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewers next convenience.
