### PR TITLE
Updated liquity tests to not use mocked RollupProcessor

### DIFF
--- a/src/test/bridges/liquity/StabilityPoolBridgeInternal.t.sol
+++ b/src/test/bridges/liquity/StabilityPoolBridgeInternal.t.sol
@@ -13,7 +13,7 @@ contract StabilityPoolBridgeTestInternal is TestUtil, StabilityPoolBridge(addres
     address public constant LUSD_USDC_POOL = 0x4e0924d3a751bE199C426d52fb1f2337fa96f736; // 500 bps fee tier
 
     function setUp() public {
-        _aztecPreSetup();
+        rollupProcessor = address(this);
         setUpTokens();
 
         // solhint-disable-next-line

--- a/src/test/bridges/liquity/StabilityPoolBridgeUnit.t.sol
+++ b/src/test/bridges/liquity/StabilityPoolBridgeUnit.t.sol
@@ -2,12 +2,13 @@
 // Copyright 2022 Spilsbury Holdings Ltd
 pragma solidity >=0.8.4;
 
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {AztecTypes} from "../../../aztec/libraries/AztecTypes.sol";
 import {ErrorLib} from "../../../bridges/base/ErrorLib.sol";
 import {TestUtil} from "./utils/TestUtil.sol";
 import {StabilityPoolBridge} from "../../../bridges/liquity/StabilityPoolBridge.sol";
 
-contract StabilityPoolBridgeTest is TestUtil {
+contract StabilityPoolBridgeUnitTest is TestUtil {
     address public constant LQTY_ETH_POOL = 0xD1D5A4c0eA98971894772Dcd6D2f1dc71083C44E; // 3000 bps fee tier
     address public constant USDC_ETH_POOL = 0x88e6A0c2dDD26FEEb64F039a2c41296FcB3f5640; // 500 bps fee tier
     address public constant LUSD_USDC_POOL = 0x4e0924d3a751bE199C426d52fb1f2337fa96f736; // 500 bps fee tier
@@ -15,10 +16,10 @@ contract StabilityPoolBridgeTest is TestUtil {
     StabilityPoolBridge private bridge;
 
     function setUp() public {
-        _aztecPreSetup();
+        rollupProcessor = address(this);
         setUpTokens();
 
-        bridge = new StabilityPoolBridge(address(rollupProcessor), address(0));
+        bridge = new StabilityPoolBridge(rollupProcessor, address(0));
         bridge.setApprovals();
 
         // EIP-1087 optimization related mints
@@ -38,42 +39,49 @@ contract StabilityPoolBridgeTest is TestUtil {
 
     function testIncorrectInput() public {
         // Call convert with incorrect input
-        vm.prank(address(rollupProcessor));
         vm.expectRevert(ErrorLib.InvalidInput.selector);
-        bridge.convert(
-            AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
-            AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
-            AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
-            AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
-            0,
-            0,
-            0,
-            address(0)
-        );
+        bridge.convert(emptyAsset, emptyAsset, emptyAsset, emptyAsset, 0, 0, 0, address(0));
     }
 
     function testFullDepositWithdrawalFlow() public {
         // I will deposit and withdraw 1 million LUSD
-        uint256 lusdAmount = 1e24;
-        _deposit(lusdAmount);
+        uint256 inputValue = 1e24;
+        _deposit(inputValue);
+
+        AztecTypes.AztecAsset memory inputAssetA = AztecTypes.AztecAsset(
+            2,
+            address(bridge),
+            AztecTypes.AztecAssetType.ERC20
+        );
+        AztecTypes.AztecAsset memory outputAssetA = AztecTypes.AztecAsset(
+            1,
+            tokens["LUSD"].addr,
+            AztecTypes.AztecAssetType.ERC20
+        );
+
+        // Transfer SPB back to the bridge
+        IERC20(inputAssetA.erc20Address).transfer(address(bridge), inputValue);
 
         // Withdraw LUSD from StabilityPool through the bridge
-        rollupProcessor.convert(
-            address(bridge),
-            AztecTypes.AztecAsset(2, address(bridge), AztecTypes.AztecAssetType.ERC20),
-            AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
-            AztecTypes.AztecAsset(1, tokens["LUSD"].addr, AztecTypes.AztecAssetType.ERC20),
-            AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
-            lusdAmount,
+        (uint256 outputValueA, , ) = bridge.convert(
+            inputAssetA,
+            emptyAsset,
+            outputAssetA,
+            emptyAsset,
+            inputValue,
             1,
-            0
+            0,
+            address(0)
         );
 
         // Check the total supply of SPB token is 0
         assertEq(bridge.totalSupply(), 0);
 
-        // Check the LUSD balance of rollupProcessor is equal to the initial LUSD deposit
-        assertEq(tokens["LUSD"].erc.balanceOf(address(rollupProcessor)), lusdAmount);
+        // Transfer the funds back from the bridge to the rollup processor
+        IERC20(outputAssetA.erc20Address).transferFrom(address(bridge), rollupProcessor, outputValueA);
+
+        // Check the LUSD balance of rollupProcessor is greater or equal to the initial LUSD deposit
+        assertGe(outputValueA, inputValue);
     }
 
     function testMultipleDepositsWithdrawals() public {
@@ -82,43 +90,69 @@ contract StabilityPoolBridgeTest is TestUtil {
         uint256 depositAmount = 203;
         uint256[] memory spbBalances = new uint256[](numIters);
 
+        AztecTypes.AztecAsset memory inputAssetA = AztecTypes.AztecAsset(
+            1,
+            tokens["LUSD"].addr,
+            AztecTypes.AztecAssetType.ERC20
+        );
+        AztecTypes.AztecAsset memory outputAssetA = AztecTypes.AztecAsset(
+            2,
+            address(bridge),
+            AztecTypes.AztecAssetType.ERC20
+        );
+
         while (i < numIters) {
             depositAmount = rand(depositAmount);
-            // 1. Mint deposit amount of LUSD to the rollupProcessor
-            deal(tokens["LUSD"].addr, address(rollupProcessor), depositAmount);
+            // 1. Mint deposit amount of LUSD to the directly to the bridge (to avoid transfer)
+            deal(inputAssetA.erc20Address, address(bridge), depositAmount);
             // 2. Mint rewards to the bridge
             deal(tokens["LQTY"].addr, address(bridge), 1e20);
             deal(tokens["WETH"].addr, address(bridge), 1e18);
 
             // 3. Deposit LUSD to StabilityPool through the bridge
-            (uint256 outputValueA, , ) = rollupProcessor.convert(
-                address(bridge),
-                AztecTypes.AztecAsset(1, tokens["LUSD"].addr, AztecTypes.AztecAssetType.ERC20),
-                AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
-                AztecTypes.AztecAsset(2, address(bridge), AztecTypes.AztecAssetType.ERC20),
-                AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
+            (uint256 outputValueA, , ) = bridge.convert(
+                inputAssetA,
+                emptyAsset,
+                outputAssetA,
+                emptyAsset,
                 depositAmount,
                 i,
-                0
+                0,
+                address(0)
             );
+
+            // 4. Transfer SPB back to RollupProcessor
+            IERC20(outputAssetA.erc20Address).transferFrom(address(bridge), rollupProcessor, outputValueA);
 
             spbBalances[i] = outputValueA;
             i++;
         }
 
+        // 5. Swap input/output assets to execute withdraw flow in the next convert call
+        (inputAssetA, outputAssetA) = (outputAssetA, inputAssetA);
+
         i = 0;
         while (i < numIters) {
-            // 4. Withdraw LUSD from StabilityPool through the bridge
-            rollupProcessor.convert(
-                address(bridge),
-                AztecTypes.AztecAsset(2, address(bridge), AztecTypes.AztecAssetType.ERC20),
-                AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
-                AztecTypes.AztecAsset(1, tokens["LUSD"].addr, AztecTypes.AztecAssetType.ERC20),
-                AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
-                spbBalances[i],
+            uint256 inputValue = spbBalances[i];
+
+            // 6. Transfer SPB back to the bridge
+            IERC20(inputAssetA.erc20Address).transfer(address(bridge), inputValue);
+
+            // 7. Withdraw LUSD from StabilityPool through the bridge
+            (uint256 outputValueA, , ) = bridge.convert(
+                inputAssetA,
+                emptyAsset,
+                outputAssetA,
+                emptyAsset,
+                inputValue,
                 numIters + i,
-                0
+                0,
+                address(0)
             );
+
+            // 4. Transfer LUSD back to RollupProcessor
+            IERC20(outputAssetA.erc20Address).transferFrom(address(bridge), rollupProcessor, outputValueA);
+
             i++;
         }
 
@@ -140,12 +174,11 @@ contract StabilityPoolBridgeTest is TestUtil {
 
         // Withdraw LUSD from StabilityPool through the bridge
         vm.expectRevert(StabilityPoolBridge.SwapFailed.selector);
-        vm.prank(address(rollupProcessor));
         bridge.convert(
             AztecTypes.AztecAsset(2, address(bridge), AztecTypes.AztecAssetType.ERC20),
-            AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
+            emptyAsset,
             AztecTypes.AztecAsset(1, tokens["LUSD"].addr, AztecTypes.AztecAssetType.ERC20),
-            AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
+            emptyAsset,
             lusdAmount,
             1,
             0,
@@ -167,7 +200,6 @@ contract StabilityPoolBridgeTest is TestUtil {
 
         // Withdraw LUSD from StabilityPool through the bridge
         vm.expectRevert(StabilityPoolBridge.SwapFailed.selector);
-        vm.prank(address(rollupProcessor));
         bridge.convert(
             AztecTypes.AztecAsset(2, address(bridge), AztecTypes.AztecAssetType.ERC20),
             AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
@@ -194,7 +226,6 @@ contract StabilityPoolBridgeTest is TestUtil {
 
         // Withdraw LUSD from StabilityPool through the bridge
         vm.expectRevert(StabilityPoolBridge.SwapFailed.selector);
-        vm.prank(address(rollupProcessor));
         bridge.convert(
             AztecTypes.AztecAsset(2, address(bridge), AztecTypes.AztecAssetType.ERC20),
             AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
@@ -209,28 +240,32 @@ contract StabilityPoolBridgeTest is TestUtil {
 
     function _deposit(uint256 _depositAmount) private {
         // 1. Mint the deposit amount of LUSD to the bridge
-        deal(tokens["LUSD"].addr, address(rollupProcessor), _depositAmount);
+        deal(tokens["LUSD"].addr, address(bridge), _depositAmount);
 
         // 2. Deposit LUSD to the StabilityPool contract through the bridge
-        rollupProcessor.convert(
-            address(bridge),
+        (uint256 outputValueA, , ) = bridge.convert(
             AztecTypes.AztecAsset(1, tokens["LUSD"].addr, AztecTypes.AztecAssetType.ERC20),
             AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
             AztecTypes.AztecAsset(2, address(bridge), AztecTypes.AztecAssetType.ERC20),
             AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
             _depositAmount,
             0,
-            0
+            0,
+            address(0)
         );
 
         // 3. Check the total supply of SPB token is equal to the amount of LUSD deposited
         assertEq(bridge.totalSupply(), _depositAmount);
 
-        // 4. Check the SPB balance of rollupProcessor is equal to the amount of LUSD deposited
-        assertEq(bridge.balanceOf(address(rollupProcessor)), _depositAmount);
+        // 4. Transfer SPB back to RollupProcessor
+        IERC20(address(bridge)).transferFrom(address(bridge), rollupProcessor, outputValueA);
 
-        // 5. Check the LUSD balance of the StabilityPoolBridge in the StabilityPool contract is equal to the amount
-        // of LUSD deposited
-        assertEq(bridge.STABILITY_POOL().getCompoundedLUSDDeposit(address(bridge)), _depositAmount);
+        // 5. Check the SPB balance of rollupProcessor is equal to the amount of LUSD deposited
+        assertEq(outputValueA, _depositAmount);
+        assertEq(bridge.balanceOf(rollupProcessor), _depositAmount);
+
+        // 6. Check the LUSD balance of the StabilityPoolBridge in the StabilityPool contract is greater than or equal
+        // to the amount of LUSD deposited
+        assertGe(bridge.STABILITY_POOL().getCompoundedLUSDDeposit(address(bridge)), _depositAmount);
     }
 }

--- a/src/test/bridges/liquity/StabilityPoolBridgeUnit.t.sol
+++ b/src/test/bridges/liquity/StabilityPoolBridgeUnit.t.sol
@@ -1,5 +1,5 @@
-// SPDX-License-Identifier: GPL-2.0-only
-// Copyright 2022 Spilsbury Holdings Ltd
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2022 Aztec.
 pragma solidity >=0.8.4;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
@@ -103,7 +103,7 @@ contract StabilityPoolBridgeUnitTest is TestUtil {
 
         while (i < numIters) {
             depositAmount = rand(depositAmount);
-            // 1. Mint deposit amount of LUSD to the directly to the bridge (to avoid transfer)
+            // 1. Mint deposit amount of LUSD directly to the bridge (to avoid transfer)
             deal(inputAssetA.erc20Address, address(bridge), depositAmount);
             // 2. Mint rewards to the bridge
             deal(tokens["LQTY"].addr, address(bridge), 1e20);
@@ -150,7 +150,7 @@ contract StabilityPoolBridgeUnitTest is TestUtil {
                 address(0)
             );
 
-            // 4. Transfer LUSD back to RollupProcessor
+            // 8. Transfer LUSD back to RollupProcessor
             IERC20(outputAssetA.erc20Address).transferFrom(address(bridge), rollupProcessor, outputValueA);
 
             i++;
@@ -186,7 +186,7 @@ contract StabilityPoolBridgeUnitTest is TestUtil {
         );
     }
 
-    function testUrgentModeOffSwap2Q() public {
+    function testUrgentModeOffSwap2() public {
         // I will deposit and withdraw 1 million LUSD
         uint256 lusdAmount = 1e24;
         _deposit(lusdAmount);
@@ -245,9 +245,9 @@ contract StabilityPoolBridgeUnitTest is TestUtil {
         // 2. Deposit LUSD to the StabilityPool contract through the bridge
         (uint256 outputValueA, , ) = bridge.convert(
             AztecTypes.AztecAsset(1, tokens["LUSD"].addr, AztecTypes.AztecAssetType.ERC20),
-            AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
+            emptyAsset,
             AztecTypes.AztecAsset(2, address(bridge), AztecTypes.AztecAssetType.ERC20),
-            AztecTypes.AztecAsset(0, address(0), AztecTypes.AztecAssetType.NOT_USED),
+            emptyAsset,
             _depositAmount,
             0,
             0,

--- a/src/test/bridges/liquity/StabilityPoolBridgeUnit.t.sol
+++ b/src/test/bridges/liquity/StabilityPoolBridgeUnit.t.sol
@@ -59,7 +59,7 @@ contract StabilityPoolBridgeUnitTest is TestUtil {
             AztecTypes.AztecAssetType.ERC20
         );
 
-        // Transfer SPB back to the bridge
+        // Transfer StabilityPoolBridge accounting token (SPB) back to the bridge
         IERC20(inputAssetA.erc20Address).transfer(address(bridge), inputValue);
 
         // Withdraw LUSD from StabilityPool through the bridge

--- a/src/test/bridges/liquity/StakingBridgeInternal.t.sol
+++ b/src/test/bridges/liquity/StakingBridgeInternal.t.sol
@@ -13,7 +13,7 @@ contract StakingBridgeTestInternal is TestUtil, StakingBridge(address(0)) {
     address public constant LQTY_ETH_POOL = 0xD1D5A4c0eA98971894772Dcd6D2f1dc71083C44E; // 3000 bps fee tier
 
     function setUp() public {
-        _aztecPreSetup();
+        rollupProcessor = address(this);
         setUpTokens();
 
         // solhint-disable-next-line

--- a/src/test/bridges/liquity/StakingBridgeUnit.t.sol
+++ b/src/test/bridges/liquity/StakingBridgeUnit.t.sol
@@ -19,7 +19,7 @@ contract StakingBridgeUnitTest is TestUtil {
         rollupProcessor = address(this);
         setUpTokens();
 
-        bridge = new StakingBridge(address(rollupProcessor));
+        bridge = new StakingBridge(rollupProcessor);
         bridge.setApprovals();
 
         // EIP-1087 optimization related mints

--- a/src/test/bridges/liquity/StakingBridgeUnit.t.sol
+++ b/src/test/bridges/liquity/StakingBridgeUnit.t.sol
@@ -74,7 +74,7 @@ contract StakingBridgeUnitTest is TestUtil {
             address(0)
         );
 
-        // Check the total supply of SPB token is 0
+        // Check the total supply of StakingBridge accounting token (SB) token is 0
         assertEq(bridge.totalSupply(), 0);
 
         // Transfer the funds back from the bridge to the rollup processor

--- a/src/test/bridges/liquity/TroveBridge.t.sol
+++ b/src/test/bridges/liquity/TroveBridge.t.sol
@@ -1,5 +1,5 @@
-// SPDX-License-Identifier: GPL-2.0-only
-// Copyright 2022 Spilsbury Holdings Ltd
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2022 Aztec.
 pragma solidity >=0.8.4;
 
 import {AztecTypes} from "../../../aztec/libraries/AztecTypes.sol";

--- a/src/test/bridges/liquity/TroveBridgeUnit.t.sol
+++ b/src/test/bridges/liquity/TroveBridgeUnit.t.sol
@@ -287,8 +287,11 @@ contract TroveBridgeUnitTest is TestUtil {
             AztecTypes.AztecAssetType.ERC20
         );
         AztecTypes.AztecAsset memory outputAssetA = AztecTypes.AztecAsset(3, address(0), AztecTypes.AztecAssetType.ETH);
-        AztecTypes.AztecAsset memory outputAssetB = AztecTypes.AztecAsset(1, tokens["LUSD"].addr, AztecTypes.AztecAssetType.ERC20);
-
+        AztecTypes.AztecAsset memory outputAssetB = AztecTypes.AztecAsset(
+            1,
+            tokens["LUSD"].addr,
+            AztecTypes.AztecAssetType.ERC20
+        );
 
         // inputValue is equal to rollupProcessor TB balance --> we want to repay the debt in full
         uint256 inputValue = bridge.balanceOf(rollupProcessor);
@@ -296,7 +299,7 @@ contract TroveBridgeUnitTest is TestUtil {
         IERC20(inputAssetA.erc20Address).transfer(address(bridge), inputValue);
 
         // Mint the debt amount of LUSD to the bridge
-        deal(inputAssetB.erc20Address, address(bridge), inputValue);
+        deal(inputAssetB.erc20Address, address(bridge), inputValue + bridge.DUST());
 
         (, uint256 outputValueB, ) = bridge.convert(
             inputAssetA,
@@ -714,7 +717,7 @@ contract TroveBridgeUnitTest is TestUtil {
         );
 
         // Borrow against ROLLUP_PROCESSOR_WEI_BALANCE
-        (uint256 outputValueA, uint256 outputValueB, ) = bridge.convert(
+        (uint256 outputValueA, uint256 outputValueB, ) = bridge.convert{value: depositAmount}(
             inputAssetA,
             emptyAsset,
             outputAssetA,

--- a/src/test/bridges/liquity/TroveBridgeUnit.t.sol
+++ b/src/test/bridges/liquity/TroveBridgeUnit.t.sol
@@ -24,6 +24,7 @@ contract TroveBridgeUnitTest is TestUtil {
 
     IHintHelpers private constant HINT_HELPERS = IHintHelpers(0xE84251b93D9524E0d2e621Ba7dc7cb3579F997C0);
     address private constant STABILITY_POOL = 0x66017D22b0f8556afDd19FC67041899Eb65a21bb;
+    address private constant LQTY_STAKING_CONTRACT = 0x4f9Fbb3f1E99B56e0Fe2892e623Ed36A76Fc605d;
     IBorrowerOperations public constant BORROWER_OPERATIONS =
         IBorrowerOperations(0x24179CD81c9e782A4096035f7eC97fB8B783e007);
     ITroveManager public constant TROVE_MANAGER = ITroveManager(0xA39739EF8b0231DbFA0DcdA07d7e29faAbCf4bb2);
@@ -65,7 +66,7 @@ contract TroveBridgeUnitTest is TestUtil {
         vm.label(address(bridge.USDC_ETH_POOL()), "USDC_ETH_POOL");
         vm.label(address(LIQUITY_PRICE_FEED), "LIQUITY_PRICE_FEED");
         vm.label(STABILITY_POOL, "STABILITY_POOL");
-        vm.label(0x4f9Fbb3f1E99B56e0Fe2892e623Ed36A76Fc605d, "LQTY_STAKING_CONTRACT");
+        vm.label(LQTY_STAKING_CONTRACT, "LQTY_STAKING_CONTRACT");
 
         // Set LUSD bridge balance to 1 WEI
         // Necessary for the optimization based on EIP-1087 to work!
@@ -293,7 +294,8 @@ contract TroveBridgeUnitTest is TestUtil {
             AztecTypes.AztecAssetType.ERC20
         );
 
-        // inputValue is equal to rollupProcessor TB balance --> we want to repay the debt in full
+        // inputValue is equal to rollupProcessor's TroveBridge accounting token (TB) balance --> we want to repay
+        // the debt in full
         uint256 inputValue = bridge.balanceOf(rollupProcessor);
         // Transfer TB to the bridge
         IERC20(inputAssetA.erc20Address).transfer(address(bridge), inputValue);

--- a/src/test/bridges/liquity/utils/MockPriceFeed.sol
+++ b/src/test/bridges/liquity/utils/MockPriceFeed.sol
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: GPL-2.0-only
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2022 Aztec.
 pragma solidity >=0.8.4;
 
 import {IPriceFeed} from "../../../../interfaces/liquity/IPriceFeed.sol";

--- a/src/test/bridges/liquity/utils/TestUtil.sol
+++ b/src/test/bridges/liquity/utils/TestUtil.sol
@@ -3,6 +3,7 @@
 pragma solidity >=0.8.4;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {AztecTypes} from "../../../../aztec/libraries/AztecTypes.sol";
 import {Test} from "forge-std/Test.sol";
 import {DefiBridgeProxy} from "../../../../aztec/DefiBridgeProxy.sol";
 import {RollupProcessor} from "../../../../aztec/RollupProcessor.sol";
@@ -20,7 +21,12 @@ contract TestUtil is Test {
 
     mapping(bytes32 => Token) internal tokens;
 
-    RollupProcessor internal rollupProcessor;
+    AztecTypes.AztecAsset internal emptyAsset;
+    address internal rollupProcessor;
+
+    // @dev This method exists on RollupProcessor.sol. It's defined here in order to be able to receive ETH like a real
+    //      rollup processor would.
+    function receiveEthFromBridge(uint256 _interactionNonce) external payable {}
 
     function setUpTokens() public {
         tokens["LUSD"].addr = 0x5f98805A4E8be255a32880FDeC7F6728C6568bA0;
@@ -49,9 +55,5 @@ contract TestUtil is Test {
     function rand(uint256 _seed) public pure returns (uint256) {
         // I want a number between 1 WAD and 10 million WAD
         return uint256(keccak256(abi.encodePacked(_seed))) % 10**25;
-    }
-
-    function _aztecPreSetup() internal {
-        rollupProcessor = new RollupProcessor(address(new DefiBridgeProxy()));
     }
 }

--- a/src/test/bridges/liquity/utils/TestUtil.sol
+++ b/src/test/bridges/liquity/utils/TestUtil.sol
@@ -1,5 +1,5 @@
-// SPDX-License-Identifier: GPL-2.0-only
-// Copyright 2022 Spilsbury Holdings Ltd
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2022 Aztec.
 pragma solidity >=0.8.4;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";


### PR DESCRIPTION
# Description

Updated tests to call bridge convert function directly. I plan on adding E2E tests in a separate PR. I created an issue for that https://github.com/AztecProtocol/aztec-connect-bridges/issues/152.

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] There are no unexpected formatting changes, or superfluous debug logs.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewers next convenience.
