### PR TITLE
Slippage protection in CurveStEthBridge

### DIFF
--- a/src/bridges/curve/CurveStEthBridge.sol
+++ b/src/bridges/curve/CurveStEthBridge.sol
@@ -60,7 +60,7 @@ contract CurveStEthBridge is BridgeBase {
      * @param _outputAssetA The output asset (eth or wstEth) opposite `_inputAssetB`
      * @param _inputValue The amount of token deposited
      * @param _interactionNonce The nonce of the DeFi interaction, used when swapping wstEth -> eth
-     * @param _auxData Minimum acceptable price per 1 unit of _inputAssetA multiplied by MIN_PRICE_SCALE
+    * @param _auxData For eth->wstEth, the minimum acceptable amount of stEth per 1 eth, for wstEth->eth, the minimum acceptable amount of eth per 1 wstEth. 
      * @return outputValueA The amount of `_outputAssetA` that the RollupProcessor should pull
      */
     function convert(

--- a/src/bridges/curve/CurveStEthBridge.sol
+++ b/src/bridges/curve/CurveStEthBridge.sol
@@ -102,7 +102,7 @@ contract CurveStEthBridge is BridgeBase {
      * @notice Swaps eth to stEth through curve and wrap the stEth into wstEth
      * @dev Reverts if `_outputAsset` is not wstEth
      * @param _inputValue The amount of token that is deposited
-     * @param _minDy Smallest acceptable dy
+     * @param _minDy Smallest acceptable dy (amount of stEth received from curve)
      * @param _outputAsset The asset that the DeFi interaction specify as output, must be wstEth
      * @return outputValue The amount of wstEth received from the interaction
      */
@@ -130,7 +130,7 @@ contract CurveStEthBridge is BridgeBase {
      * @dev Reverts if `_outputAsset` is not eth
      * @param _inputValue The amount of token that is deposited
      * @param _outputAsset The asset that the DeFi interaction specify as output, must be eth
-     * @param _minDy Smallest acceptable dy
+     * @param _minDy Smallest acceptable dy (amount of eth to receive from curve)
      * @return outputValue The amount of eth received from the interaction
      */
     function _unwrapETH(

--- a/src/bridges/curve/CurveStEthBridge.sol
+++ b/src/bridges/curve/CurveStEthBridge.sol
@@ -29,8 +29,7 @@ contract CurveStEthBridge is BridgeBase {
     IWstETH public constant WRAPPED_STETH = IWstETH(0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0);
     ICurvePool public constant CURVE_POOL = ICurvePool(0xDC24316b9AE028F1497c275EB9192a3Ea0f67022);
 
-    // Constant by which min price is scaled
-    uint256 public constant MIN_PRICE_SCALE = 1e18;
+    uint256 public constant PRECISION = 1e18;
 
     // Indexes of the assets in the curve pool
     int128 private constant CURVE_ETH_INDEX = 0;
@@ -60,7 +59,8 @@ contract CurveStEthBridge is BridgeBase {
      * @param _outputAssetA The output asset (eth or wstEth) opposite `_inputAssetB`
      * @param _inputValue The amount of token deposited
      * @param _interactionNonce The nonce of the DeFi interaction, used when swapping wstEth -> eth
-    * @param _auxData For eth->wstEth, the minimum acceptable amount of stEth per 1 eth, for wstEth->eth, the minimum acceptable amount of eth per 1 wstEth. 
+     * @param _auxData For eth->wstEth, the minimum acceptable amount of stEth per 1 eth, for wstEth->eth, the minimum
+     *                 acceptable amount of eth per 1 wstEth.
      * @return outputValueA The amount of `_outputAssetA` that the RollupProcessor should pull
      */
     function convert(
@@ -91,7 +91,7 @@ contract CurveStEthBridge is BridgeBase {
             revert ErrorLib.InvalidInputA();
         }
 
-        uint256 minDy = (_inputValue * _auxData) / MIN_PRICE_SCALE;
+        uint256 minDy = (_inputValue * _auxData) / PRECISION;
 
         outputValueA = isETHInput
             ? _wrapETH(_inputValue, _outputAssetA, minDy)

--- a/src/bridges/curve/CurveStEthBridge.sol
+++ b/src/bridges/curve/CurveStEthBridge.sol
@@ -29,6 +29,9 @@ contract CurveStEthBridge is BridgeBase {
     IWstETH public constant WRAPPED_STETH = IWstETH(0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0);
     ICurvePool public constant CURVE_POOL = ICurvePool(0xDC24316b9AE028F1497c275EB9192a3Ea0f67022);
 
+    // Constant by which min price is scaled
+    uint256 public constant MIN_PRICE_SCALE = 1e18;
+
     // Indexes of the assets in the curve pool
     int128 private constant CURVE_ETH_INDEX = 0;
     int128 private constant CURVE_STETH_INDEX = 1;
@@ -57,6 +60,7 @@ contract CurveStEthBridge is BridgeBase {
      * @param _outputAssetA The output asset (eth or wstEth) opposite `_inputAssetB`
      * @param _inputValue The amount of token deposited
      * @param _interactionNonce The nonce of the DeFi interaction, used when swapping wstEth -> eth
+     * @param _auxData Minimum acceptable price per 1 unit of _inputAssetA multiplied by MIN_PRICE_SCALE
      * @return outputValueA The amount of `_outputAssetA` that the RollupProcessor should pull
      */
     function convert(
@@ -66,7 +70,7 @@ contract CurveStEthBridge is BridgeBase {
         AztecTypes.AztecAsset calldata,
         uint256 _inputValue,
         uint256 _interactionNonce,
-        uint64,
+        uint64 _auxData,
         address
     )
         external
@@ -87,22 +91,26 @@ contract CurveStEthBridge is BridgeBase {
             revert ErrorLib.InvalidInputA();
         }
 
+        uint256 minDy = (_inputValue * _auxData) / MIN_PRICE_SCALE;
+
         outputValueA = isETHInput
-            ? _wrapETH(_inputValue, _outputAssetA)
-            : _unwrapETH(_inputValue, _outputAssetA, _interactionNonce);
+            ? _wrapETH(_inputValue, _outputAssetA, minDy)
+            : _unwrapETH(_inputValue, _outputAssetA, minDy, _interactionNonce);
     }
 
     /**
      * @notice Swaps eth to stEth through curve and wrap the stEth into wstEth
      * @dev Reverts if `_outputAsset` is not wstEth
      * @param _inputValue The amount of token that is deposited
+     * @param _minDy Smallest acceptable dy
      * @param _outputAsset The asset that the DeFi interaction specify as output, must be wstEth
      * @return outputValue The amount of wstEth received from the interaction
      */
-    function _wrapETH(uint256 _inputValue, AztecTypes.AztecAsset calldata _outputAsset)
-        private
-        returns (uint256 outputValue)
-    {
+    function _wrapETH(
+        uint256 _inputValue,
+        AztecTypes.AztecAsset calldata _outputAsset,
+        uint256 _minDy
+    ) private returns (uint256 outputValue) {
         if (
             _outputAsset.assetType != AztecTypes.AztecAssetType.ERC20 ||
             _outputAsset.erc20Address != address(WRAPPED_STETH)
@@ -111,7 +119,7 @@ contract CurveStEthBridge is BridgeBase {
         }
 
         // Swap eth -> stEth on curve
-        uint256 dy = CURVE_POOL.exchange{value: _inputValue}(CURVE_ETH_INDEX, CURVE_STETH_INDEX, _inputValue, 0);
+        uint256 dy = CURVE_POOL.exchange{value: _inputValue}(CURVE_ETH_INDEX, CURVE_STETH_INDEX, _inputValue, _minDy);
 
         // wrap stEth
         outputValue = WRAPPED_STETH.wrap(dy);
@@ -122,11 +130,13 @@ contract CurveStEthBridge is BridgeBase {
      * @dev Reverts if `_outputAsset` is not eth
      * @param _inputValue The amount of token that is deposited
      * @param _outputAsset The asset that the DeFi interaction specify as output, must be eth
+     * @param _minDy Smallest acceptable dy
      * @return outputValue The amount of eth received from the interaction
      */
     function _unwrapETH(
         uint256 _inputValue,
         AztecTypes.AztecAsset calldata _outputAsset,
+        uint256 _minDy,
         uint256 _interactionNonce
     ) private returns (uint256 outputValue) {
         if (_outputAsset.assetType != AztecTypes.AztecAssetType.ETH) {
@@ -137,7 +147,7 @@ contract CurveStEthBridge is BridgeBase {
         uint256 stETH = WRAPPED_STETH.unwrap(_inputValue);
 
         // Exchange stETH to ETH via curve
-        uint256 dy = CURVE_POOL.exchange(CURVE_STETH_INDEX, CURVE_ETH_INDEX, stETH, 0);
+        uint256 dy = CURVE_POOL.exchange(CURVE_STETH_INDEX, CURVE_ETH_INDEX, stETH, _minDy);
 
         outputValue = address(this).balance;
         if (outputValue < dy) {

--- a/src/test/bridges/curve/CurveStEthBridge.t.sol
+++ b/src/test/bridges/curve/CurveStEthBridge.t.sol
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2022 Aztec.
 pragma solidity >=0.8.4;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
@@ -112,7 +113,7 @@ contract CurveStEthBridgeTest is BridgeTestBase {
 
         // Making minDy bigger than expected minDy to cause the swap to fail
         uint256 minDy = _computeEthToWST(depositAmount) + 1e17;
-        uint64 minPrice = uint64((minDy * bridge.MIN_PRICE_SCALE()) / depositAmount);
+        uint64 minPrice = uint64((minDy * bridge.PRECISION()) / depositAmount);
 
         vm.prank(address(ROLLUP_PROCESSOR));
         vm.expectRevert("Exchange resulted in fewer coins than expected");
@@ -125,7 +126,7 @@ contract CurveStEthBridgeTest is BridgeTestBase {
 
         // Making minDy bigger than expected minDy to cause the swap to fail
         uint256 minDy = _computeWSTHToEth(depositAmount) + 1e17;
-        uint64 minPrice = uint64((minDy * bridge.MIN_PRICE_SCALE()) / depositAmount);
+        uint64 minPrice = uint64((minDy * bridge.PRECISION()) / depositAmount);
 
         vm.prank(address(ROLLUP_PROCESSOR));
         vm.expectRevert("Exchange resulted in fewer coins than expected");
@@ -157,7 +158,7 @@ contract CurveStEthBridgeTest is BridgeTestBase {
 
         uint256 wstEthIncrease = _computeEthToWST(_depositAmount);
         // Set minPrice in such a way that computed minDy is equal to wstEthIncrease
-        uint64 minPrice = uint64((wstEthIncrease * bridge.MIN_PRICE_SCALE()) / _depositAmount);
+        uint64 minPrice = uint64((wstEthIncrease * bridge.PRECISION()) / _depositAmount);
 
         uint256 bridgeId = encodeBridgeId(id, ethAsset, emptyAsset, wstETHAsset, emptyAsset, minPrice);
         vm.expectEmit(true, true, false, true);
@@ -180,14 +181,14 @@ contract CurveStEthBridgeTest is BridgeTestBase {
 
         uint256 expectedEth = _computeWSTHToEth(_depositAmount);
         // Set minPrice in such a way that computed minDy is equal to expectedEth
-        uint64 minPrice = uint64((expectedEth * bridge.MIN_PRICE_SCALE()) / _depositAmount);
+        uint64 minPrice = uint64((expectedEth * bridge.PRECISION()) / _depositAmount);
 
         uint256 bridgeId = encodeBridgeId(id, wstETHAsset, emptyAsset, ethAsset, emptyAsset, minPrice);
         vm.expectEmit(true, true, false, true);
         emit DefiBridgeProcessed(bridgeId, getNextNonce(), _depositAmount, expectedEth, 0, true, "");
         sendDefiRollup(bridgeId, _depositAmount);
 
-        assertEq(address(ROLLUP_PROCESSOR).balance, beforeETHBalance + expectedEth, "ETH balance not maching");
+        assertEq(address(ROLLUP_PROCESSOR).balance, beforeETHBalance + expectedEth, "ETH balance not matching");
         assertEq(
             WRAPPED_STETH.balanceOf(address(ROLLUP_PROCESSOR)),
             beforeWstEthBalance - _depositAmount,


### PR DESCRIPTION
# Description

Passing minPrice to CurveStEthBridge through _auxData in order to set slippage protection while not breaking aggregation.

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] There are no unexpected formatting changes, or superfluous debug logs.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewers next convenience.
