### PR TITLE
Make linter throw errors on everything to enforce it in CI

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -2,19 +2,21 @@
   "extends": "solhint:recommended",
   "rules": {
     "compiler-version": ["error", ">=0.8.4"],
-    "func-visibility": ["warn", { "ignoreConstructors": true }],
+    "func-visibility": ["error", { "ignoreConstructors": true }],
     "no-empty-blocks": "off",
+    "no-unused-vars": ["error"],
+    "state-visibility": ["error"],
     "not-rely-on-time": "off",
-    "const-name-snakecase": ["warn", { "treatImmutableVarAsConstant": true }],
-    "var-name-mixedcase": ["warn", { "treatImmutableVarAsConstant": true }],
-    "error-name-mixedcase": ["warn"],
-    "private-func-leading-underscore": ["warn"],
-    "private-vars-no-leading-underscore": ["warn"],
-    "func-param-name-leading-underscore": ["warn"],
-    "func-param-name-mixedcase": ["warn"],
-    "custom-error-over-require": ["warn"],
-    "strict-override": ["warn"],
-    "strict-import": ["warn"],
-    "ordering": ["warn"]
+    "const-name-snakecase": ["error", { "treatImmutableVarAsConstant": true }],
+    "var-name-mixedcase": ["error", { "treatImmutableVarAsConstant": true }],
+    "error-name-mixedcase": ["error"],
+    "private-func-leading-underscore": ["error"],
+    "private-vars-no-leading-underscore": ["error"],
+    "func-param-name-leading-underscore": ["error"],
+    "func-param-name-mixedcase": ["error"],
+    "custom-error-over-require": ["error"],
+    "strict-override": ["error"],
+    "strict-import": ["error"],
+    "ordering": ["error"]
   }
 }


### PR DESCRIPTION
# Description

I want grantees to fix linting errors/warnings without our feedback and I've just noticed that linter doesn't return exit code 1 on warnings. This is necessary for CI to fail. For this reason I changed warnings to be errors in the solhint config.

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] There are no unexpected formatting changes, or superfluous debug logs.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewers next convenience.
