### PR TITLE
handle virtual assets in encodeBridgeId helper

### DIFF
--- a/src/test/aztec/base/BridgeTestBase.sol
+++ b/src/test/aztec/base/BridgeTestBase.sol
@@ -205,10 +205,10 @@ abstract contract BridgeTestBase is Test {
         encodedId = _bridgeId & MASK_THIRTY_TWO_BITS;
 
         // Input assets
-        encodedId = encodedId | ((_inputAssetA.id & MASK_THIRTY_BITS) << INPUT_ASSET_ID_A_SHIFT);
-        encodedId = encodedId | ((_inputAssetB.id & MASK_THIRTY_BITS) << INPUT_ASSET_ID_B_SHIFT);
-        encodedId = encodedId | ((_outputAssetA.id & MASK_THIRTY_BITS) << OUTPUT_ASSET_ID_A_SHIFT);
-        encodedId = encodedId | ((_outputAssetB.id & MASK_THIRTY_BITS) << OUTPUT_ASSET_ID_B_SHIFT);
+        encodedId = encodedId | (_encodeAsset(_inputAssetA) << INPUT_ASSET_ID_A_SHIFT);
+        encodedId = encodedId | (_encodeAsset(_inputAssetB) << INPUT_ASSET_ID_B_SHIFT);
+        encodedId = encodedId | (_encodeAsset(_outputAssetA) << OUTPUT_ASSET_ID_A_SHIFT);
+        encodedId = encodedId | (_encodeAsset(_outputAssetB) << OUTPUT_ASSET_ID_B_SHIFT);
 
         // Aux data
         encodedId = encodedId | ((_auxData & MASK_SIXTY_FOUR_BITS) << AUX_DATA_SHIFT);
@@ -272,6 +272,13 @@ abstract contract BridgeTestBase is Test {
         );
 
         vm.mockCall(ROLLUP_PROCESSOR.verifier(), "", abi.encode(true));
+    }
+
+    function _encodeAsset(AztecTypes.AztecAsset memory _asset) private pure returns (uint256) {
+        if (_asset.assetType == AztecTypes.AztecAssetType.VIRTUAL) {
+            return (_asset.id & MASK_THIRTY_BITS) | VIRTUAL_ASSET_ID_FLAG;
+        }
+        return _asset.id & MASK_THIRTY_BITS;
     }
 
     /**

--- a/src/test/aztec/base/EncodeBridgeId.t.sol
+++ b/src/test/aztec/base/EncodeBridgeId.t.sol
@@ -2,6 +2,57 @@
 // Copyright 2022 Aztec.
 pragma solidity >=0.8.4;
 
+import {AztecTypes} from "./../../../aztec/libraries/AztecTypes.sol";
 import {BridgeTestBase} from "./BridgeTestBase.sol";
 
-contract EncodeBridgeIdTest is BridgeTestBase {}
+contract EncodeBridgeIdTest is BridgeTestBase {
+    uint256 private constant VIRTUAL_ASSET_ID_FLAG_SHIFT = 29;
+    uint256 private constant VIRTUAL_ASSET_ID_FLAG = 0x20000000; // 2 ** 29
+
+    function testVirtualAssetFlagApplied(uint32 _assetId) public {
+        uint256 assetId = bound(_assetId, 0, VIRTUAL_ASSET_ID_FLAG - 1);
+        uint256 virtualAsset = assetId + VIRTUAL_ASSET_ID_FLAG;
+
+        AztecTypes.AztecAsset memory decoded = _decodeAsset(virtualAsset);
+        assertEq(decoded.erc20Address, address(0), "Virtual asset has erc20 address");
+        assertEq(decoded.id, assetId, "Asset Id not matching");
+        assertTrue(decoded.assetType == AztecTypes.AztecAssetType.VIRTUAL, "Not virtual");
+    }
+
+    function testNonVirtual(uint32 _assetId) public {
+        uint256 assetId = bound(_assetId, 0, ROLLUP_PROCESSOR.getSupportedAssetsLength());
+
+        address assetAddress = ROLLUP_PROCESSOR.getSupportedAsset(assetId);
+
+        AztecTypes.AztecAsset memory decoded = _decodeAsset(assetId);
+
+        assertEq(decoded.erc20Address, assetAddress, "asset address not matching");
+        assertEq(decoded.id, assetId, "Asset Id not matching");
+        if (assetAddress == address(0)) {
+            assertTrue(decoded.assetType == AztecTypes.AztecAssetType.ETH, "Not eth");
+        } else {
+            assertTrue(decoded.assetType == AztecTypes.AztecAssetType.ERC20, "Not erc20");
+        }
+    }
+
+    function _decodeAsset(uint256 _assetId) internal view returns (AztecTypes.AztecAsset memory) {
+        if (_assetId >> VIRTUAL_ASSET_ID_FLAG_SHIFT == 1) {
+            return
+                AztecTypes.AztecAsset({
+                    id: _assetId - VIRTUAL_ASSET_ID_FLAG,
+                    erc20Address: address(0),
+                    assetType: AztecTypes.AztecAssetType.VIRTUAL
+                });
+        } else {
+            address erc20Address = ROLLUP_PROCESSOR.getSupportedAsset(_assetId);
+            return
+                AztecTypes.AztecAsset({
+                    id: _assetId,
+                    erc20Address: erc20Address,
+                    assetType: erc20Address == address(0)
+                        ? AztecTypes.AztecAssetType.ETH
+                        : AztecTypes.AztecAssetType.ERC20
+                });
+        }
+    }
+}


### PR DESCRIPTION
# Description

Closes #160 

Extends the `BridgeTestBase::encodeBridgeId` to better handle virtual assets without users having to manually account for it in the id.
Also adds tests for encoding virtual and non-virtual assets.

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] There are no unexpected formatting changes, or superfluous debug logs.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewers next convenience.
