### PR TITLE
refactor: using EthAddress type in AztecAsset

### DIFF
--- a/src/client/aave/aave-bridge-data.test.ts
+++ b/src/client/aave/aave-bridge-data.test.ts
@@ -57,17 +57,17 @@ describe("aave lending bridge data", () => {
     ethAsset = {
       id: 1n,
       assetType: AztecAssetType.ETH,
-      erc20Address: "0x0",
+      erc20Address: EthAddress.ZERO,
     };
     wethAsset = {
       id: 2n,
       assetType: AztecAssetType.ERC20,
-      erc20Address: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+      erc20Address: EthAddress.fromString("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"),
     };
     emptyAsset = {
       id: 0n,
       assetType: AztecAssetType.NOT_USED,
-      erc20Address: "0x0",
+      erc20Address: EthAddress.ZERO,
     };
   });
 
@@ -80,7 +80,7 @@ describe("aave lending bridge data", () => {
     const zkAsset = {
       id: 3n,
       assetType: AztecAssetType.ERC20,
-      erc20Address: EthAddress.random().toString(),
+      erc20Address: EthAddress.random(),
     };
 
     aaveLendingBridgeContract = {
@@ -110,12 +110,12 @@ describe("aave lending bridge data", () => {
     const zkAsset = {
       id: 3n,
       assetType: AztecAssetType.ERC20,
-      erc20Address: EthAddress.random().toString(),
+      erc20Address: EthAddress.random(),
     };
 
     aaveLendingBridgeContract = {
       ...aaveLendingBridgeContract,
-      underlyingToZkAToken: jest.fn().mockResolvedValue(zkAsset.erc20Address),
+      underlyingToZkAToken: jest.fn().mockResolvedValue(zkAsset.erc20Address.toString()),
     };
 
     lendingPoolContract = {
@@ -136,7 +136,7 @@ describe("aave lending bridge data", () => {
     const zkAsset = {
       id: 3n,
       assetType: AztecAssetType.ERC20,
-      erc20Address: EthAddress.random().toString(),
+      erc20Address: EthAddress.random(),
     };
 
     const rate = 3n * 10n ** 25n;
@@ -158,7 +158,7 @@ describe("aave lending bridge data", () => {
 
     aaveLendingBridgeContract = {
       ...aaveLendingBridgeContract,
-      underlyingToZkAToken: jest.fn().mockResolvedValue(zkAsset.erc20Address),
+      underlyingToZkAToken: jest.fn().mockResolvedValue(zkAsset.erc20Address.toString()),
     };
 
     lendingPoolContract = {
@@ -178,7 +178,7 @@ describe("aave lending bridge data", () => {
     const zkAsset = {
       id: 3n,
       assetType: AztecAssetType.ERC20,
-      erc20Address: EthAddress.random().toString(),
+      erc20Address: EthAddress.random(),
     };
 
     const rate = 3n * 10n ** 25n;
@@ -199,7 +199,7 @@ describe("aave lending bridge data", () => {
 
     aaveLendingBridgeContract = {
       ...aaveLendingBridgeContract,
-      underlyingToZkAToken: jest.fn().mockResolvedValue(zkAsset.erc20Address),
+      underlyingToZkAToken: jest.fn().mockResolvedValue(zkAsset.erc20Address.toString()),
     };
 
     lendingPoolContract = {
@@ -218,12 +218,12 @@ describe("aave lending bridge data", () => {
     const zkAsset = {
       id: 3n,
       assetType: AztecAssetType.ERC20,
-      erc20Address: EthAddress.random().toString(),
+      erc20Address: EthAddress.random(),
     };
 
     aaveLendingBridgeContract = {
       ...aaveLendingBridgeContract,
-      underlyingToZkAToken: jest.fn().mockResolvedValue(zkAsset.erc20Address),
+      underlyingToZkAToken: jest.fn().mockResolvedValue(zkAsset.erc20Address).toString(),
     };
 
     aaveBridgeData = createAaveBridgeData(lendingPoolContract as any, aaveLendingBridgeContract as any);

--- a/src/client/bridge-data.ts
+++ b/src/client/bridge-data.ts
@@ -1,3 +1,5 @@
+import { EthAddress } from "@aztec/barretenberg/address";
+
 export interface AssetValue {
   assetId: bigint; // the Aztec AssetId (this can be queried from the rollup contract)
   amount: bigint;
@@ -24,7 +26,7 @@ export enum SolidityType {
 export interface AztecAsset {
   id: bigint;
   assetType: AztecAssetType;
-  erc20Address: string;
+  erc20Address: EthAddress;
 }
 
 export interface AuxDataConfig {

--- a/src/client/compound/compound-bridge-data.test.ts
+++ b/src/client/compound/compound-bridge-data.test.ts
@@ -1,3 +1,4 @@
+import { EthAddress } from "@aztec/barretenberg/address";
 import { BigNumber } from "ethers";
 import {
   ICERC20,
@@ -36,33 +37,33 @@ describe("compound lending bridge data", () => {
     ethAsset = {
       id: 0n,
       assetType: AztecAssetType.ETH,
-      erc20Address: "0x0",
+      erc20Address: EthAddress.ZERO,
     };
     cethAsset = {
       id: 10n, // Asset has not yet been registered on RollupProcessor so this id is random
       assetType: AztecAssetType.ERC20,
-      erc20Address: "0x4Ddc2D193948926D02f9B1fE9e1daa0718270ED5",
+      erc20Address: EthAddress.fromString("0x4Ddc2D193948926D02f9B1fE9e1daa0718270ED5"),
     };
     daiAsset = {
       id: 1n,
       assetType: AztecAssetType.ERC20,
-      erc20Address: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+      erc20Address: EthAddress.fromString("0x6B175474E89094C44Da98b954EedeAC495271d0F"),
     };
     cdaiAsset = {
       id: 11n, // Asset has not yet been registered on RollupProcessor so this id is random
       assetType: AztecAssetType.ERC20,
-      erc20Address: "0x5d3a536E4D6DbD6114cc1Ead35777bAB948E3643",
+      erc20Address: EthAddress.fromString("0x5d3a536E4D6DbD6114cc1Ead35777bAB948E3643"),
     };
     emptyAsset = {
       id: 0n,
       assetType: AztecAssetType.NOT_USED,
-      erc20Address: "0x0",
+      erc20Address: EthAddress.ZERO,
     };
   });
 
   it("should correctly fetch auxData when minting", async () => {
     // Setup mocks
-    const allMarkets = [cethAsset.erc20Address];
+    const allMarkets = [cethAsset.erc20Address.toString()];
     comptrollerContract = {
       ...comptrollerContract,
       getAllMarkets: jest.fn().mockResolvedValue(allMarkets),
@@ -71,7 +72,7 @@ describe("compound lending bridge data", () => {
 
     rollupProcessorContract = {
       ...rollupProcessorContract,
-      getSupportedAsset: jest.fn().mockResolvedValue(cethAsset.erc20Address),
+      getSupportedAsset: jest.fn().mockResolvedValue(cethAsset.erc20Address.toString()),
     };
     IRollupProcessor__factory.connect = () => rollupProcessorContract as any;
 
@@ -84,7 +85,7 @@ describe("compound lending bridge data", () => {
 
   it("should correctly fetch auxData when redeeming", async () => {
     // Setup mocks
-    const allMarkets = [cethAsset.erc20Address];
+    const allMarkets = [cethAsset.erc20Address.toString()];
     comptrollerContract = {
       ...comptrollerContract,
       getAllMarkets: jest.fn().mockResolvedValue(allMarkets),
@@ -93,7 +94,7 @@ describe("compound lending bridge data", () => {
 
     rollupProcessorContract = {
       ...rollupProcessorContract,
-      getSupportedAsset: jest.fn().mockResolvedValue(cethAsset.erc20Address),
+      getSupportedAsset: jest.fn().mockResolvedValue(cethAsset.erc20Address.toString()),
     };
     IRollupProcessor__factory.connect = () => rollupProcessorContract as any;
 
@@ -106,7 +107,7 @@ describe("compound lending bridge data", () => {
 
   it("should throw when getting auxData for unsupported inputAssetA", async () => {
     // Setup mocks
-    const allMarkets = [cethAsset.erc20Address];
+    const allMarkets = [cethAsset.erc20Address.toString()];
     comptrollerContract = {
       ...comptrollerContract,
       getAllMarkets: jest.fn().mockResolvedValue(allMarkets),
@@ -115,7 +116,7 @@ describe("compound lending bridge data", () => {
 
     rollupProcessorContract = {
       ...rollupProcessorContract,
-      getSupportedAsset: jest.fn().mockResolvedValue("0xdAC17F958D2ee523a2206206994597C13D831ec7"), // random address
+      getSupportedAsset: jest.fn().mockResolvedValue(EthAddress.random().toString()),
     };
     IRollupProcessor__factory.connect = () => rollupProcessorContract as any;
 
@@ -129,7 +130,7 @@ describe("compound lending bridge data", () => {
 
   it("should throw when getting auxData for unsupported outputAssetA", async () => {
     // Setup mocks
-    const allMarkets = [cethAsset.erc20Address];
+    const allMarkets = [cethAsset.erc20Address.toString()];
     comptrollerContract = {
       ...comptrollerContract,
       getAllMarkets: jest.fn().mockResolvedValue(allMarkets),
@@ -138,7 +139,7 @@ describe("compound lending bridge data", () => {
 
     rollupProcessorContract = {
       ...rollupProcessorContract,
-      getSupportedAsset: jest.fn().mockResolvedValue("0xdAC17F958D2ee523a2206206994597C13D831ec7"), // random address
+      getSupportedAsset: jest.fn().mockResolvedValue(EthAddress.random().toString()),
     };
     IRollupProcessor__factory.connect = () => rollupProcessorContract as any;
 

--- a/src/client/curve/curve-steth/curve-bridge-data.test.ts
+++ b/src/client/curve/curve-steth/curve-bridge-data.test.ts
@@ -44,17 +44,17 @@ describe("curve steth bridge data", () => {
     ethAsset = {
       id: 1n,
       assetType: AztecAssetType.ETH,
-      erc20Address: "0x0",
+      erc20Address: EthAddress.ZERO,
     };
     wstETHAsset = {
       id: 2n,
       assetType: AztecAssetType.ERC20,
-      erc20Address: "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
+      erc20Address: EthAddress.fromString("0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0"),
     };
     emptyAsset = {
       id: 0n,
       assetType: AztecAssetType.NOT_USED,
-      erc20Address: "0x0",
+      erc20Address: EthAddress.ZERO,
     };
   });
 

--- a/src/client/element/element-bridge-data.test.ts
+++ b/src/client/element/element-bridge-data.test.ts
@@ -21,8 +21,6 @@ type Mockify<T> = {
   [P in keyof T]: jest.Mock;
 };
 
-const randomAddress = () => `0x${randomBytes(20).toString("hex")}`;
-
 const tranche1DeploymentBlockNumber = 45n;
 const tranche2DeploymentBlockNumber = 87n;
 
@@ -54,6 +52,7 @@ describe("element bridge data", () => {
   const bridge1 = new BridgeId(1, 4, 4, undefined, undefined, Number(expiration1));
   const bridge2 = new BridgeId(1, 5, 5, undefined, undefined, Number(expiration2));
   const outputValue = 10n * 10n ** 18n;
+  const testAddress = EthAddress.random();
 
   const defiEvents = [
     { bridgeId: bridge1.toBigInt(), nonce: 56, totalInputValue: 56n * 10n ** 16n, blockNumber: 59 } as DefiEvent,
@@ -257,22 +256,22 @@ describe("element bridge data", () => {
     const output = await elementBridgeData.getExpectedYield(
       {
         assetType: AztecAssetType.ERC20,
-        erc20Address: "test",
+        erc20Address: testAddress,
         id: 1n,
       },
       {
         assetType: AztecAssetType.NOT_USED,
-        erc20Address: EthAddress.ZERO.toString(),
+        erc20Address: EthAddress.ZERO,
         id: 0n,
       },
       {
         assetType: AztecAssetType.ERC20,
-        erc20Address: "test",
+        erc20Address: testAddress,
         id: 1n,
       },
       {
         assetType: AztecAssetType.NOT_USED,
-        erc20Address: EthAddress.ZERO.toString(),
+        erc20Address: EthAddress.ZERO,
         id: 0n,
       },
       expiry,
@@ -291,7 +290,7 @@ describe("element bridge data", () => {
 
   it("should return the correct market size for a given tranche", async () => {
     const expiry = BigInt(Date.now() + 86400 * 30);
-    const tokenAddress = randomAddress();
+    const tokenAddress = EthAddress.random().toString();
     const poolId = "0x90ca5cef5b29342b229fb8ae2db5d8f4f894d6520002000000000000000000b5";
     const tokenBalance = 10e18,
       elementBridge = {
@@ -316,22 +315,22 @@ describe("element bridge data", () => {
     const marketSize = await elementBridgeData.getMarketSize(
       {
         assetType: AztecAssetType.ERC20,
-        erc20Address: "test",
+        erc20Address: EthAddress.random(),
         id: 1n,
       },
       {
         assetType: AztecAssetType.NOT_USED,
-        erc20Address: EthAddress.ZERO.toString(),
+        erc20Address: EthAddress.ZERO,
         id: 0n,
       },
       {
         assetType: AztecAssetType.ERC20,
-        erc20Address: "test",
+        erc20Address: testAddress,
         id: 1n,
       },
       {
         assetType: AztecAssetType.NOT_USED,
-        erc20Address: EthAddress.ZERO.toString(),
+        erc20Address: EthAddress.ZERO,
         id: 0n,
       },
       expiry,

--- a/src/client/element/element-bridge-data.ts
+++ b/src/client/element/element-bridge-data.ts
@@ -242,7 +242,7 @@ export class ElementBridgeData implements BridgeDataFieldGetters {
     outputAssetA: AztecAsset,
     outputAssetB: AztecAsset,
   ): Promise<bigint[]> {
-    const assetExpiries = await this.elementBridgeContract.getAssetExpiries(inputAssetA.erc20Address);
+    const assetExpiries = await this.elementBridgeContract.getAssetExpiries(inputAssetA.erc20Address.toString());
     if (assetExpiries && assetExpiries.length) {
       return assetExpiries.map(a => a.toBigInt());
     }
@@ -278,7 +278,10 @@ export class ElementBridgeData implements BridgeDataFieldGetters {
     auxData: bigint,
     precision: bigint,
   ): Promise<number[]> {
-    const assetExpiryHash = await this.elementBridgeContract.hashAssetAndExpiry(inputAssetA.erc20Address, auxData);
+    const assetExpiryHash = await this.elementBridgeContract.hashAssetAndExpiry(
+      inputAssetA.erc20Address.toString(),
+      auxData,
+    );
     const pool = await this.elementBridgeContract.pools(assetExpiryHash);
     const poolId = pool.poolId;
     const trancheAddress = pool.trancheAddress;
@@ -301,7 +304,7 @@ export class ElementBridgeData implements BridgeDataFieldGetters {
     const deltas = await this.balancerContract.queryBatchSwap(
       SwapType.SwapExactIn,
       [step],
-      [inputAssetA.erc20Address, trancheAddress],
+      [inputAssetA.erc20Address.toString(), trancheAddress],
       funds,
     );
 
@@ -328,7 +331,10 @@ export class ElementBridgeData implements BridgeDataFieldGetters {
     outputAssetB: AztecAsset,
     auxData: bigint,
   ): Promise<AssetValue[]> {
-    const assetExpiryHash = await this.elementBridgeContract.hashAssetAndExpiry(inputAssetA.erc20Address, auxData);
+    const assetExpiryHash = await this.elementBridgeContract.hashAssetAndExpiry(
+      inputAssetA.erc20Address.toString(),
+      auxData,
+    );
     const pool = await this.elementBridgeContract.pools(assetExpiryHash);
     const poolId = pool.poolId;
     const tokenBalances = await this.balancerContract.getPoolTokens(poolId);

--- a/src/client/lido/lido-bridge-data.test.ts
+++ b/src/client/lido/lido-bridge-data.test.ts
@@ -44,17 +44,17 @@ describe("lido bridge data", () => {
     ethAsset = {
       id: 1n,
       assetType: AztecAssetType.ETH,
-      erc20Address: "0x0",
+      erc20Address: EthAddress.ZERO,
     };
     wstETHAsset = {
       id: 2n,
       assetType: AztecAssetType.ERC20,
-      erc20Address: "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
+      erc20Address: EthAddress.fromString("0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0"),
     };
     emptyAsset = {
       id: 0n,
       assetType: AztecAssetType.NOT_USED,
-      erc20Address: "0x0",
+      erc20Address: EthAddress.ZERO,
     };
   });
 


### PR DESCRIPTION
# Description

I refactored clients so that `EthAddress` type is used in `AztecAsset`. This makes a lot of sense because clients are used in the internal codebase and there the use of `EthAddress` type is the default.

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] There are no unexpected formatting changes, or superfluous debug logs.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewers next convenience.
