### PR TITLE
feat: add `getUnderlyingAmount` to curve-bridge-data

### DIFF
--- a/src/client/bridge-data.ts
+++ b/src/client/bridge-data.ts
@@ -5,6 +5,14 @@ export interface AssetValue {
   amount: bigint;
 }
 
+export interface UnderlyingAsset {
+  address: EthAddress;
+  name: string;
+  symbol: string;
+  decimals: number;
+  amount: bigint;
+}
+
 export enum AztecAssetType {
   ETH,
   ERC20,
@@ -37,22 +45,22 @@ export interface AuxDataConfig {
 }
 
 export interface BridgeDataFieldGetters {
-  /*
-  @dev This function should be implemented for stateful bridges
-  @param interactionNonce A globally unique identifier of a given DeFi interaction
-  @param inputValue User's input value
-  @return The value of the user's share of a given interaction
-  */
+  /**
+   * @dev This function should be implemented for stateful bridges
+   * @param interactionNonce A globally unique identifier of a given DeFi interaction
+   * @param inputValue User's input value
+   * @return The value of the user's share of a given interaction
+   */
   getInteractionPresentValue?(interactionNonce: bigint, inputValue: bigint): Promise<AssetValue[]>;
 
-  /*
-  @dev This function should be implemented for all bridges that use auxData which require on-chain data
-  @param inputAssetA A struct detailing the first input asset
-  @param inputAssetB A struct detailing the second input asset
-  @param outputAssetA A struct detailing the first output asset
-  @param outputAssetB A struct detailing the second output asset
-  @return The set of possible auxData values that they can use for a given set of input and output assets
-  */
+  /**
+   * @dev This function should be implemented for all bridges that use auxData which require on-chain data
+   * @param inputAssetA A struct detailing the first input asset
+   * @param inputAssetB A struct detailing the second input asset
+   * @param outputAssetA A struct detailing the first output asset
+   * @param outputAssetB A struct detailing the second output asset
+   * @return The set of possible auxData values that they can use for a given set of input and output assets
+   */
   getAuxData?(
     inputAssetA: AztecAsset,
     inputAssetB: AztecAsset,
@@ -60,21 +68,21 @@ export interface BridgeDataFieldGetters {
     outputAssetB: AztecAsset,
   ): Promise<bigint[]>;
 
-  /*
-  @dev This public variable defines the structure of the auxData
-  */
+  /**
+   * @dev This public variable defines the structure of the auxData
+   */
   auxDataConfig: AuxDataConfig[];
 
-  /*
-  @dev This function should be implemented for all bridges
-  @param inputAssetA A struct detailing the first input asset
-  @param inputAssetB A struct detailing the second input asset
-  @param outputAssetA A struct detailing the first output asset
-  @param outputAssetB A struct detailing the second output asset
-  @param auxData Arbitrary data to be passed into the bridge contract (slippage / nftID etc)
-  @param inputValue Amount of inputAssetA (and inputAssetB if used) provided on input
-  @return The expected return amounts of outputAssetA and outputAssetB
-  */
+  /**
+   * @dev This function should be implemented for all bridges
+   * @param inputAssetA A struct detailing the first input asset
+   * @param inputAssetB A struct detailing the second input asset
+   * @param outputAssetA A struct detailing the first output asset
+   * @param outputAssetB A struct detailing the second output asset
+   * @param auxData Arbitrary data to be passed into the bridge contract (slippage / nftID etc)
+   * @param inputValue Amount of inputAssetA (and inputAssetB if used) provided on input
+   * @return The expected return amounts of outputAssetA and outputAssetB
+   */
   getExpectedOutput(
     inputAssetA: AztecAsset,
     inputAssetB: AztecAsset,
@@ -84,30 +92,30 @@ export interface BridgeDataFieldGetters {
     inputValue: bigint,
   ): Promise<bigint[]>;
 
-  /*
-  @dev This function should be implemented for async bridges
-  @param interactionNonce A globally unique identifier of a given DeFi interaction
-  @return The date at which the bridge is expected to be finalised (for limit orders this should be the expiration)
-  */
+  /**
+   * @dev This function should be implemented for async bridges
+   * @param interactionNonce A globally unique identifier of a given DeFi interaction
+   * @return The date at which the bridge is expected to be finalised (for limit orders this should be the expiration)
+   */
   getExpiration?(interactionNonce: bigint): Promise<bigint>;
 
-  /*
-  @dev This function should be implemented for async bridges
-  @param interactionNonce A globally unique identifier of a given DeFi interaction
-  @return A boolean indicating whether the interaction has been finilised
-  */
+  /**
+   * @dev This function should be implemented for async bridges
+   * @param interactionNonce A globally unique identifier of a given DeFi interaction
+   * @return A boolean indicating whether the interaction has been finilised
+   */
   hasFinalised?(interactionNonce: bigint): Promise<boolean>;
 
-  /*
-  @notice This function computes annual percentage return (APR) for given assets, auxData and inputValue
-  @dev This function should be implemented for all bridges that are stateful
-  @param inputAssetA A struct detailing the first input asset
-  @param inputAssetB A struct detailing the second input asset
-  @param outputAssetA A struct detailing the first output asset
-  @param outputAssetB A struct detailing the second output asset
-  @param auxData Arbitrary data to be passed into the bridge contract (slippage / nftID etc)
-  @param inputValue Amount of inputAssetA (and inputAssetB if used) provided on input
-  @return The expected APR of outputAssetA and outputAssetB if used (e.g. for Lido the return value would currently
+  /**
+  * @notice This function computes annual percentage return (APR) for given assets, auxData and inputValue
+  * @dev This function should be implemented for all bridges that are stateful
+  * @param inputAssetA A struct detailing the first input asset
+  * @param inputAssetB A struct detailing the second input asset
+  * @param outputAssetA A struct detailing the first output asset
+  * @param outputAssetB A struct detailing the second output asset
+  * @param auxData Arbitrary data to be passed into the bridge contract (slippage / nftID etc)
+  * @param inputValue Amount of inputAssetA (and inputAssetB if used) provided on input
+  * @return The expected APR of outputAssetA and outputAssetB if used (e.g. for Lido the return value would currently
           be [3.9])
   */
   getAPR?(
@@ -119,14 +127,14 @@ export interface BridgeDataFieldGetters {
     inputValue: bigint,
   ): Promise<number[]>;
 
-  /*
-  @dev This function should be implemented for all bridges dealing with L1 liquidity
-  @param inputAssetA A struct detailing the first input asset
-  @param inputAssetB A struct detailing the second input asset
-  @param outputAssetA A struct detailing the first output asset
-  @param outputAssetB A struct detailing the second output asset
-  @param auxData Arbitrary data to be passed into the bridge contract (slippage / nftID etc)
-  @return L1 liquidity this bridge call will be interacting with (e.g. the liquidity of the underlying yield pool
+  /** 
+  * @dev This function should be implemented for all bridges dealing with L1 liquidity
+  * @param inputAssetA A struct detailing the first input asset
+  * @param inputAssetB A struct detailing the second input asset
+  * @param outputAssetA A struct detailing the first output asset
+  * @param outputAssetB A struct detailing the second output asset
+  * @param auxData Arbitrary data to be passed into the bridge contract (slippage / nftID etc)
+  * @return L1 liquidity this bridge call will be interacting with (e.g. the liquidity of the underlying yield pool
           or AMM)
   */
   getMarketSize?(
@@ -137,11 +145,19 @@ export interface BridgeDataFieldGetters {
     auxData: bigint,
   ): Promise<AssetValue[]>;
 
-  /*
-  @notice This function computes annual percentage return (APR) for a given interaction
-  @dev This function should be implemented for all async yield bridges
-  @param interactionNonce A globally unique identifier of a given DeFi interaction
-  @return APR based on the information of a given interaction (e.g. token amounts after finalisation etc.)
-  */
+  /**
+   * @notice This function computes annual percentage return (APR) for a given interaction
+   * @dev This function should be implemented for all async yield bridges
+   * @param interactionNonce A globally unique identifier of a given DeFi interaction
+   * @return APR based on the information of a given interaction (e.g. token amounts after finalisation etc.)
+   */
   getInteractionAPR?(interactionNonce: bigint): Promise<number[]>;
+
+  /**
+   * @notice This function gets the underlying amount for wrapped assets or shares
+   * @param asset The wrapped asset
+   * @param amount The amount of wrapped asset
+   * @return The assetValue for the underlying
+   */
+  getUnderlyingAmount?(asset: AztecAsset, amount: bigint): Promise<UnderlyingAsset>;
 }

--- a/src/client/bridge-data.ts
+++ b/src/client/bridge-data.ts
@@ -157,7 +157,7 @@ export interface BridgeDataFieldGetters {
    * @notice This function gets the underlying amount for wrapped assets or shares
    * @param asset The wrapped asset
    * @param amount The amount of wrapped asset
-   * @return The assetValue for the underlying
+   * @return The underlying asset (address, name, symbol, decimals, amount)
    */
   getUnderlyingAmount?(asset: AztecAsset, amount: bigint): Promise<UnderlyingAsset>;
 }

--- a/src/client/curve/curve-steth/curve-bridge-data.test.ts
+++ b/src/client/curve/curve-steth/curve-bridge-data.test.ts
@@ -105,6 +105,7 @@ describe("curve steth bridge data", () => {
     wstethContract = {
       ...wstethContract,
       getWstETHByStETH: jest.fn().mockResolvedValue(BigNumber.from(wstEthAmount)),
+      getStETHByWstETH: jest.fn().mockResolvedValue(BigNumber.from(stEthAmountOut)),
     };
 
     curveBridgeData = createCurveStethBridgeData(
@@ -122,6 +123,9 @@ describe("curve steth bridge data", () => {
       depositAmount,
     );
     expect(expectedOutput == output[0]).toBeTruthy();
+
+    const underlying = await curveBridgeData.getUnderlyingAmount(wstETHAsset, expectedOutput);
+    expect(underlying.amount == stEthAmountOut).toBeTruthy();
   });
   it("should exit to ETH when deposit WstETH", async () => {
     const depositAmount = BigInt(100e18);

--- a/src/client/curve/curve-steth/curve-bridge-data.ts
+++ b/src/client/curve/curve-steth/curve-bridge-data.ts
@@ -1,5 +1,6 @@
 import {
   AssetValue,
+  UnderlyingAsset,
   AuxDataConfig,
   AztecAsset,
   SolidityType,
@@ -125,5 +126,19 @@ export class CurveStethBridgeData implements BridgeDataFieldGetters {
         amount: postTotalPooledEther.toBigInt(),
       },
     ];
+  }
+
+  async getUnderlyingAmount(asset: AztecAsset, amount: bigint): Promise<UnderlyingAsset> {
+    if (!asset.erc20Address.equals(EthAddress.fromString("0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0"))) {
+      throw new Error("Eth have no underlying");
+    }
+    const stETHBalance = await this.wstETHContract.getStETHByWstETH(amount);
+    return {
+      address: EthAddress.fromString("0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84"),
+      name: "Liquid staked Ether 2.0 ",
+      symbol: "stETH",
+      decimals: 18,
+      amount: stETHBalance.toBigInt(),
+    };
   }
 }

--- a/src/client/lido/lido-bridge-data.test.ts
+++ b/src/client/lido/lido-bridge-data.test.ts
@@ -88,6 +88,7 @@ describe("lido bridge data", () => {
     wstethContract = {
       ...wstethContract,
       getWstETHByStETH: jest.fn().mockResolvedValue(BigNumber.from(wstEthAmount)),
+      getStETHByWstETH: jest.fn().mockResolvedValue(BigNumber.from(depositAmount)),
     };
 
     lidoBridgeData = createLidoBridgeData(wstethContract as any, curvePoolContract as any, lidoOracleContract as any);
@@ -101,6 +102,8 @@ describe("lido bridge data", () => {
       depositAmount,
     );
     expect(expectedOutput == output[0]).toBeTruthy();
+    const underlying = await lidoBridgeData.getUnderlyingAmount(wstETHAsset, expectedOutput);
+    expect(underlying.amount == depositAmount).toBeTruthy();
   });
   it("should exit to ETH when deposit WstETH", async () => {
     const depositAmount = BigInt(100e18);

--- a/src/client/lido/lido-bridge-data.ts
+++ b/src/client/lido/lido-bridge-data.ts
@@ -5,6 +5,7 @@ import {
   SolidityType,
   AztecAssetType,
   BridgeDataFieldGetters,
+  UnderlyingAsset,
 } from "../bridge-data";
 
 import {
@@ -125,5 +126,19 @@ export class LidoBridgeData implements BridgeDataFieldGetters {
         amount: postTotalPooledEther.toBigInt(),
       },
     ];
+  }
+
+  async getUnderlyingAmount(asset: AztecAsset, amount: bigint): Promise<UnderlyingAsset> {
+    if (!asset.erc20Address.equals(EthAddress.fromString("0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0"))) {
+      throw new Error("Eth have no underlying");
+    }
+    const stETHBalance = await this.wstETHContract.getStETHByWstETH(amount);
+    return {
+      address: EthAddress.fromString("0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84"),
+      name: "Liquid staked Ether 2.0 ",
+      symbol: "stETH",
+      decimals: 18,
+      amount: stETHBalance.toBigInt(),
+    };
   }
 }


### PR DESCRIPTION
# Description

Extends the bridge data class with a `getUnderlyingAmount()` function that can be used by the frontend for valuing wrapped assets. For `wstEth` this will return the `stEth` amount that it can be unwrapped to, which might help the frontend to simplify explanations for users.

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] There are no unexpected formatting changes, or superfluous debug logs.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewers next convenience.
- [x] NatSpec documentation of all the non-test functions is present and is complete.
- [x] Continuous integration (CI) passes.
