### PR TITLE
Lh/subsidy base bridge

### DIFF
--- a/src/bridges/base/BridgeBase.sol
+++ b/src/bridges/base/BridgeBase.sol
@@ -71,4 +71,19 @@ abstract contract BridgeBase is IDefiBridge {
     {
         revert ErrorLib.AsyncDisabled();
     }
+
+    /**
+     * @notice Computes the criteria that is passed on to the subsidy contract when claiming
+     * @dev Should be overridden by bridge implementation if intended to limit subsidy.
+     * @return The criteria to be passed along
+     */
+    function computeCriteria(
+        AztecTypes.AztecAsset calldata,
+        AztecTypes.AztecAsset calldata,
+        AztecTypes.AztecAsset calldata,
+        AztecTypes.AztecAsset calldata,
+        uint64
+    ) public view virtual returns (uint256) {
+        return 0;
+    }
 }

--- a/src/test/bridges/example/ExampleE2E.t.sol
+++ b/src/test/bridges/example/ExampleE2E.t.sol
@@ -55,7 +55,8 @@ contract ExampleE2ETest is BridgeTestBase {
         id = ROLLUP_PROCESSOR.getSupportedBridgesLength();
 
         // Subsidize the bridge when used with USDC and register a beneficiary
-        uint256 criteria = bridge.computeCriteria(USDC, USDC);
+        AztecTypes.AztecAsset memory usdcAsset = getRealAztecAsset(USDC);
+        uint256 criteria = bridge.computeCriteria(usdcAsset, emptyAsset, usdcAsset, emptyAsset, 0);
         uint32 gasPerMinute = 200;
         subsidy.subsidize{value: 1 ether}(address(bridge), criteria, gasPerMinute);
 

--- a/src/test/bridges/example/ExampleUnit.t.sol
+++ b/src/test/bridges/example/ExampleUnit.t.sol
@@ -2,7 +2,7 @@
 // Copyright 2022 Aztec.
 pragma solidity >=0.8.4;
 
-import {Test} from "forge-std/Test.sol";
+import {BridgeTestBase} from "./../../aztec/base/BridgeTestBase.sol";
 import {AztecTypes} from "../../../aztec/libraries/AztecTypes.sol";
 
 // Example-specific imports
@@ -12,11 +12,10 @@ import {ErrorLib} from "../../../bridges/base/ErrorLib.sol";
 import {ISubsidy, Subsidy} from "../../../aztec/Subsidy.sol";
 
 // @notice The purpose of this test is to directly test convert functionality of the bridge.
-contract ExampleUnitTest is Test {
+contract ExampleUnitTest is BridgeTestBase {
     address private constant DAI = 0x6B175474E89094C44Da98b954EedeAC495271d0F;
     address private constant BENEFICIARY = address(11);
 
-    AztecTypes.AztecAsset private emptyAsset;
     address private rollupProcessor;
     ISubsidy private subsidy;
     // The reference to the example bridge
@@ -43,7 +42,8 @@ contract ExampleUnitTest is Test {
         vm.label(address(bridge), "Example Bridge");
 
         // Subsidize the bridge when used with Dai and register a beneficiary
-        uint256 criteria = bridge.computeCriteria(DAI, DAI);
+        AztecTypes.AztecAsset memory daiAsset = getRealAztecAsset(DAI);
+        uint256 criteria = bridge.computeCriteria(daiAsset, emptyAsset, daiAsset, emptyAsset, 0);
         uint32 gasPerMinute = 200;
         subsidy.subsidize{value: 1 ether}(address(bridge), criteria, gasPerMinute);
 

--- a/src/test/bridges/example/ExampleUnit.t.sol
+++ b/src/test/bridges/example/ExampleUnit.t.sol
@@ -63,6 +63,16 @@ contract ExampleUnitTest is BridgeTestBase {
         bridge.convert(emptyAsset, emptyAsset, emptyAsset, emptyAsset, 0, 0, 0, address(0));
     }
 
+    function testInvalidOutputAssetType() public {
+        AztecTypes.AztecAsset memory inputAssetA = AztecTypes.AztecAsset({
+            id: 1,
+            erc20Address: DAI,
+            assetType: AztecTypes.AztecAssetType.ERC20
+        });
+        vm.expectRevert(ErrorLib.InvalidOutputA.selector);
+        bridge.convert(inputAssetA, emptyAsset, emptyAsset, emptyAsset, 0, 0, 0, address(0));
+    }
+
     function testExampleBridgeUnitTestFixed() public {
         testExampleBridgeUnitTest(10 ether);
     }


### PR DESCRIPTION
# Description

Extending the BridgeBase with a `computeCriteria` to be used for bridges that supports subsidies. Can be left as is if no restrictions on subsidies or no subsidies are provided.

Extends the example bridge tests with a single test.

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] There are no unexpected formatting changes, or superfluous debug logs.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewers next convenience.
- [x] NatSpec documentation of all the non-test functions is present and is complete.
- [x] Continuous integration (CI) passes.
- [x] Command `forge coverage --match-contract MyContract` returns 100% line coverage.
- [x] All the possible reverts are tested.
