### PR TITLE
Subsidy audit feedback implementation

### DIFF
--- a/src/aztec/Subsidy.sol
+++ b/src/aztec/Subsidy.sol
@@ -52,8 +52,8 @@ contract Subsidy is ISubsidy {
      * @notice Container for Subsidy related information
      * @member available Amount of ETH remaining to be paid out
      * @member gasUsage Amount of gas the interaction consumes (used to define max possible payout)
-     * @member minGasPerMinute Minimum amount of gas per second the subsidizer has to subsidize
-     * @member gasPerMinute Amount of gas per second the subsidizer is willing to subsidize
+     * @member minGasPerMinute Minimum amount of gas per minute the subsidizer has to subsidize
+     * @member gasPerMinute Amount of gas per minute the subsidizer is willing to subsidize
      * @member lastUpdated Last time subsidy was paid out or funded (if not subsidy was yet claimed after funding)
      */
     struct Subsidy {

--- a/src/aztec/Subsidy.sol
+++ b/src/aztec/Subsidy.sol
@@ -263,7 +263,7 @@ contract Subsidy is ISubsidy {
      * @notice Gets current accumulated subsidy amount for a given `_bridge` and `_criteria`
      * @param _bridge Address of the subsidized bridge
      * @param _criteria A value defining a specific bridge call
-     * @return - Accumulated subsidy amount (would paid out if the bridge called `claimSubsidy(_criteria, ...)`)
+     * @return - Accumulated subsidy amount (amount paid out if the bridge called `claimSubsidy(_criteria, ...)`)
      */
     function getAccumulatedSubsidyAmount(address _bridge, uint256 _criteria) external view returns (uint256) {
         Subsidy memory sub = subsidies[_bridge][_criteria];
@@ -283,7 +283,7 @@ contract Subsidy is ISubsidy {
         uint32 _minGasPerMinute
     ) public override(ISubsidy) {
         // Loading `sub` first in order to not overwrite `sub.available` in case this function was already called
-        // before and subsidy was set. This should not be needed for well written bridges.
+        // and a subsidy was set. 
         Subsidy memory sub = subsidies[msg.sender][_criteria];
 
         sub.gasUsage = _gasUsage;
@@ -295,7 +295,7 @@ contract Subsidy is ISubsidy {
     /**
      * @notice Computes accumulated subsidy amount based on Subsidy struct and current block
      * @param _subsidy Subsidy based on which to compute accumulated subsidy amount
-     * @return - Accumulated subsidy amount
+     * @return - Accumulated subsidy amount (amount paid out if the bridge called `claimSubsidy(_criteria, ...)`)
      */
     function _computeAccumulatedSubsidyAmount(Subsidy memory _subsidy) private view returns (uint256) {
         uint256 subsidyAmount;

--- a/src/aztec/interfaces/ISubsidy.sol
+++ b/src/aztec/interfaces/ISubsidy.sol
@@ -4,17 +4,21 @@ pragma solidity >=0.8.4;
 
 // @dev documentation of this interface is in its implementation (Subsidy contract)
 interface ISubsidy {
-    function subsidies(address _bridge, uint256 _criteria)
-        external
-        returns (
-            uint128,
-            uint32,
-            uint32,
-            uint32,
-            uint32
-        );
-
-    function claimableAmount(address _beneficiary) external returns (uint256);
+    /**
+     * @notice Container for Subsidy related information
+     * @member available Amount of ETH remaining to be paid out
+     * @member gasUsage Amount of gas the interaction consumes (used to define max possible payout)
+     * @member minGasPerMinute Minimum amount of gas per minute the subsidizer has to subsidize
+     * @member gasPerMinute Amount of gas per minute the subsidizer is willing to subsidize
+     * @member lastUpdated Last time subsidy was paid out or funded (if not subsidy was yet claimed after funding)
+     */
+    struct Subsidy {
+        uint128 available;
+        uint32 gasUsage;
+        uint32 minGasPerMinute;
+        uint32 gasPerMinute;
+        uint32 lastUpdated;
+    }
 
     function setGasUsageAndMinGasPerMinute(
         uint256 _criteria,
@@ -41,4 +45,13 @@ interface ISubsidy {
     function claimSubsidy(uint256 _criteria, address _beneficiary) external returns (uint256);
 
     function withdraw(address _beneficiary) external returns (uint256);
+
+    // solhint-disable-next-line
+    function MIN_SUBSIDY_VALUE() external view returns (uint256);
+
+    function claimableAmount(address _beneficiary) external view returns (uint256);
+
+    function isRegistered(address _beneficiary) external view returns (bool);
+
+    function getSubsidy(address _bridge, uint256 _criteria) external view returns (Subsidy memory);
 }

--- a/src/aztec/interfaces/ISubsidy.sol
+++ b/src/aztec/interfaces/ISubsidy.sol
@@ -36,6 +36,8 @@ interface ISubsidy {
         uint32 _gasPerMinute
     ) external payable;
 
+    function topUp(address _bridge, uint256 _criteria) external payable;
+
     function claimSubsidy(uint256 _criteria, address _beneficiary) external returns (uint256);
 
     function withdraw(address _beneficiary) external returns (uint256);

--- a/src/aztec/interfaces/ISubsidy.sol
+++ b/src/aztec/interfaces/ISubsidy.sol
@@ -54,4 +54,6 @@ interface ISubsidy {
     function isRegistered(address _beneficiary) external view returns (bool);
 
     function getSubsidy(address _bridge, uint256 _criteria) external view returns (Subsidy memory);
+
+    function getAccumulatedSubsidyAmount(address _bridge, uint256 _criteria) external view returns (uint256);
 }

--- a/src/test/aztec/subsidy/Subsidy.t.sol
+++ b/src/test/aztec/subsidy/Subsidy.t.sol
@@ -25,6 +25,25 @@ contract SubsidyTest is Test {
         vm.deal(BENEFICIARY, 0);
     }
 
+    function testSettingGasUsageAndMinGasPerMinuteDoesntOverwriteAvailable() public {
+        uint256 criteria = 1;
+        uint32 gasUsage = 5e4;
+        uint32 minGasPerMinute = 100;
+        vm.prank(BRIDGE);
+        subsidy.setGasUsageAndMinGasPerMinute(criteria, gasUsage, minGasPerMinute);
+
+        subsidy.subsidize{value: 1 ether}(BRIDGE, criteria, minGasPerMinute);
+
+        Subsidy.Subsidy memory sub = subsidy.getSubsidy(BRIDGE, 1);
+        assertEq(sub.available, 1 ether, "available incorrectly set");
+
+        vm.prank(BRIDGE);
+        subsidy.setGasUsageAndMinGasPerMinute(criteria, gasUsage, minGasPerMinute);
+
+        sub = subsidy.getSubsidy(BRIDGE, 1);
+        assertEq(sub.available, 1 ether, "available got reset to 0");
+    }
+
     function testArrayLengthsDontMatchError() public {
         // First set min gas per second values for different criteria
         uint256[] memory criteria = new uint256[](1);

--- a/src/test/aztec/subsidy/Subsidy.t.sol
+++ b/src/test/aztec/subsidy/Subsidy.t.sol
@@ -156,6 +156,30 @@ contract SubsidyTest is Test {
         assertEq(sub.available, 1 ether, "available incorrectly set in refill");
     }
 
+    function testGetAccumulatedSubsidyAmount() public {
+        // Set huge gasUsage and gasPerMinute so that everything can be claimed in 1 call
+        uint256 criteria = 1;
+        uint32 gasUsage = type(uint32).max;
+        vm.prank(BRIDGE);
+        subsidy.setGasUsageAndMinGasPerMinute(criteria, gasUsage, 100);
+
+        subsidy.subsidize{value: 1 ether}(BRIDGE, criteria, 100000);
+
+        vm.warp(block.timestamp + 7 days);
+
+        subsidy.registerBeneficiary(BENEFICIARY);
+
+        uint256 accumulatedSubsidyAmount = subsidy.getAccumulatedSubsidyAmount(BRIDGE, criteria);
+
+        vm.prank(BRIDGE);
+        uint256 referenceAccumulatedSubsidyAmount = subsidy.claimSubsidy(criteria, BENEFICIARY);
+        assertEq(
+            accumulatedSubsidyAmount,
+            referenceAccumulatedSubsidyAmount,
+            "getAccumulatedSubsidyAmount(...) and claimSubsidy(...) returned different amounts"
+        );
+    }
+
     function testTopUpWorks(uint96 _value1, uint96 _value2) public {
         // Set huge gasUsage and gasPerMinute so that everything can be claimed in 1 call
         uint32 gasUsage = type(uint32).max;

--- a/src/test/aztec/subsidy/Subsidy.t.sol
+++ b/src/test/aztec/subsidy/Subsidy.t.sol
@@ -3,13 +3,13 @@
 pragma solidity >=0.8.4;
 
 import {Test} from "forge-std/Test.sol";
-import {Subsidy} from "../../../aztec/Subsidy.sol";
+import {ISubsidy, Subsidy} from "../../../aztec/Subsidy.sol";
 
 contract SubsidyTest is Test {
     address private constant BRIDGE = address(10);
     address private constant BENEFICIARY = address(11);
 
-    Subsidy private subsidy;
+    ISubsidy private subsidy;
 
     event Subsidized(address indexed bridge, uint256 indexed criteria, uint128 available, uint32 gasPerMinute);
     event BeneficiaryRegistered(address indexed beneficiary);


### PR DESCRIPTION
# Description

### 1. Reset of `setGasUsageAndMinGasPerMinute(...)` can result in lost ETH
Addressed in 28a760d7e4c41b3201cc3564644ea9f09b9edc1e
### 2. Dust or tiny leftover amounts in sub.available
Addressed in a0855c8286af2913255ea32eec90cda47d1afaaf
### 3. `MIN_SUBSIDY_VALUE` might not be enough for expensive bridge interaction
This is not that big of a deal since the intention of subsidy is to simply incentivize rollup provider to include a bridge call with low amount of aggregated users, or more clearly said, low amount of overall fees to be collected. The goal is not to cover `gasUsage` in full. For this reason we've decided to not address this. This issue also gets alleviated by implementing the `topUp(...)` function.
### 4. It is not possible to change gasPerMinute of active subsidy
We decided to not address this as well because it would require us to track owner of a Subsidy. Allowing this doesn't seem to be worth the added complexity. Preferable approach is to initially fund subsidy with small ETH amount and let it run out if it's considered that `gasPerMinute` was set incorrectly.
### 5. Subsidizer needs to trust the bridge completely
We also didn't address this because we consider the bridge to be trusted. It's a job of the entity funding the Subsidy to decide whether the bridge is worthy of a Subsidy. They can always simple not fund a potentially malicious bridge.
### 6. No withdraw or update/topUp for an active subsidy criteria.
Top up was addressed in a0855c8286af2913255ea32eec90cda47d1afaaf.
Subsidy withdrawal doesn't seem to be worth it for the same reason as what I wrote in response to Note 4 - tracking owners is impractical.
### 7.1. Adding a public view function to get the current subsidy for a given block.timestamp
Addressed in 43de7a5c0f6a4e5a60ac07f70c5adcc7ebdf1e84.
### 7.2. The contract and the struct have the same name in Solidity
We didn't come up with a better name so we left it as it is.
### 7.3 Consider a ratePerSec instead of ratePerMinute to avoid conversion or convert only once in setGasUsageAndMinGasPerMinute
Doing this would not be practical because it would effectively mean that the minimum amount of subsidized gas would be the amount of seconds in the day which is ~86k gas. We've considered this value to be too high for a minimum value.


# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] There are no unexpected formatting changes, or superfluous debug logs.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewers next convenience.
- [x] NatSpec documentation of all the non-test functions is present and is complete.
- [x] Continuous integration (CI) passes.
- [x] Command `forge coverage --match-contract MyContract` returns 100% line coverage.
- [x] All the possible reverts are tested.
