### PR TITLE
refactor: simplified APR function + unifying AssetValue with internal repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test:contracts:block": "forge test --fork-block-number",
     "cast": "cast",
     "test:contracts": "forge test --no-match-contract 'Element|AceOfZk|StabilityPoolBridge' --no-match-test 'testRedistribution' && yarn test:pinned",
-    "build": "yarn clean && yarn compile:typechain && yarn compile:client-dest",
+    "build": "yarn clean && yarn compile:client-dest",
     "formatting": "yarn prettier --write .",
     "formatting:check": "prettier --check .",
     "lint": "yarn lint:contracts && yarn lint:clients",

--- a/src/client/aave/aave-bridge-data.test.ts
+++ b/src/client/aave/aave-bridge-data.test.ts
@@ -131,8 +131,7 @@ describe("aave lending bridge data", () => {
     expect(output[0]).toBeGreaterThan(depositAmount);
   });
 
-  it("should return the expected yield when entering", async () => {
-    const depositAmount = 10n ** 18n;
+  it("should return the expected APR when entering", async () => {
     const zkAsset = {
       id: 3n,
       assetType: AztecAssetType.ERC20,
@@ -168,13 +167,12 @@ describe("aave lending bridge data", () => {
 
     aaveBridgeData = createAaveBridgeData(lendingPoolContract as any, aaveLendingBridgeContract as any);
 
-    const output = await aaveBridgeData.getAPR(ethAsset, emptyAsset, zkAsset, emptyAsset, 0n, depositAmount);
+    const APR = await aaveBridgeData.getAPR(ethAsset, zkAsset);
 
-    expect(output[0]).toBe(3);
+    expect(APR).toBe(3);
   });
 
-  it("should return the expected yield when exiting", async () => {
-    const depositAmount = 10n ** 18n;
+  it("should return 0 expected APR when exiting", async () => {
     const zkAsset = {
       id: 3n,
       assetType: AztecAssetType.ERC20,
@@ -209,9 +207,9 @@ describe("aave lending bridge data", () => {
 
     aaveBridgeData = createAaveBridgeData(lendingPoolContract as any, aaveLendingBridgeContract as any);
 
-    const output = await aaveBridgeData.getAPR(zkAsset, emptyAsset, ethAsset, emptyAsset, 0n, depositAmount);
+    const APR = await aaveBridgeData.getAPR(zkAsset, ethAsset);
 
-    expect(output[0]).toBe(0);
+    expect(APR).toBe(0);
   });
 
   it.skip("should return the market size", async () => {

--- a/src/client/aave/aave-bridge-data.test.ts
+++ b/src/client/aave/aave-bridge-data.test.ts
@@ -131,7 +131,7 @@ describe("aave lending bridge data", () => {
     expect(output[0]).toBeGreaterThan(depositAmount);
   });
 
-  it("should return the expected APR when entering", async () => {
+  it("returns correct APR", async () => {
     const zkAsset = {
       id: 3n,
       assetType: AztecAssetType.ERC20,
@@ -167,49 +167,9 @@ describe("aave lending bridge data", () => {
 
     aaveBridgeData = createAaveBridgeData(lendingPoolContract as any, aaveLendingBridgeContract as any);
 
-    const APR = await aaveBridgeData.getAPR(ethAsset, zkAsset);
+    const APR = await aaveBridgeData.getAPR(zkAsset);
 
     expect(APR).toBe(3);
-  });
-
-  it("should return 0 expected APR when exiting", async () => {
-    const zkAsset = {
-      id: 3n,
-      assetType: AztecAssetType.ERC20,
-      erc20Address: EthAddress.random(),
-    };
-
-    const rate = 3n * 10n ** 25n;
-    const reserveData: ReserveDataStruct = {
-      configuration: { data: 0 },
-      liquidityIndex: 0,
-      variableBorrowIndex: 0,
-      currentLiquidityRate: BigNumber.from(rate),
-      currentVariableBorrowRate: 0,
-      currentStableBorrowRate: 0,
-      lastUpdateTimestamp: 0,
-      aTokenAddress: EthAddress.random().toString(),
-      stableDebtTokenAddress: EthAddress.random().toString(),
-      variableDebtTokenAddress: EthAddress.random().toString(),
-      interestRateStrategyAddress: EthAddress.random().toString(),
-      id: 0,
-    };
-
-    aaveLendingBridgeContract = {
-      ...aaveLendingBridgeContract,
-      underlyingToZkAToken: jest.fn().mockResolvedValue(zkAsset.erc20Address.toString()),
-    };
-
-    lendingPoolContract = {
-      ...lendingPoolContract,
-      getReserveData: jest.fn().mockResolvedValue(reserveData),
-    };
-
-    aaveBridgeData = createAaveBridgeData(lendingPoolContract as any, aaveLendingBridgeContract as any);
-
-    const APR = await aaveBridgeData.getAPR(zkAsset, ethAsset);
-
-    expect(APR).toBe(0);
   });
 
   it.skip("should return the market size", async () => {

--- a/src/client/aave/aave-bridge-data.test.ts
+++ b/src/client/aave/aave-bridge-data.test.ts
@@ -89,7 +89,7 @@ describe("aave lending bridge data", () => {
 
     aaveBridgeData = createAaveBridgeData(lendingPoolContract as any, aaveLendingBridgeContract as any);
 
-    const output = await aaveBridgeData.getExpectedOutput(ethAsset, emptyAsset, zkAsset, emptyAsset, 0n, depositAmount);
+    const output = await aaveBridgeData.getExpectedOutput(ethAsset, emptyAsset, zkAsset, emptyAsset, 0, depositAmount);
 
     expect(expectedOutput).toBe(output[0]);
     expect(output[0]).toBeLessThan(depositAmount);
@@ -119,7 +119,7 @@ describe("aave lending bridge data", () => {
 
     aaveBridgeData = createAaveBridgeData(lendingPoolContract as any, aaveLendingBridgeContract as any);
 
-    const output = await aaveBridgeData.getExpectedOutput(zkAsset, emptyAsset, ethAsset, emptyAsset, 0n, depositAmount);
+    const output = await aaveBridgeData.getExpectedOutput(zkAsset, emptyAsset, ethAsset, emptyAsset, 0, depositAmount);
 
     expect(expectedOutput).toBe(output[0]);
     expect(output[0]).toBeGreaterThan(depositAmount);

--- a/src/client/aave/aave-bridge-data.test.ts
+++ b/src/client/aave/aave-bridge-data.test.ts
@@ -24,7 +24,6 @@ describe("aave lending bridge data", () => {
   let aaveLendingBridgeContract: Mockify<IAaveLendingBridge>;
 
   let ethAsset: AztecAsset;
-  let wethAsset: AztecAsset;
   let emptyAsset: AztecAsset;
 
   const createAaveBridgeData = (
@@ -55,17 +54,12 @@ describe("aave lending bridge data", () => {
 
   beforeAll(() => {
     ethAsset = {
-      id: 1n,
+      id: 1,
       assetType: AztecAssetType.ETH,
       erc20Address: EthAddress.ZERO,
     };
-    wethAsset = {
-      id: 2n,
-      assetType: AztecAssetType.ERC20,
-      erc20Address: EthAddress.fromString("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"),
-    };
     emptyAsset = {
-      id: 0n,
+      id: 0,
       assetType: AztecAssetType.NOT_USED,
       erc20Address: EthAddress.ZERO,
     };
@@ -78,7 +72,7 @@ describe("aave lending bridge data", () => {
     const expectedOutput = (depositAmount * precision) / normalizer;
 
     const zkAsset = {
-      id: 3n,
+      id: 3,
       assetType: AztecAssetType.ERC20,
       erc20Address: EthAddress.random(),
     };
@@ -108,7 +102,7 @@ describe("aave lending bridge data", () => {
     const expectedOutput = (depositAmount * normalizer) / precision;
 
     const zkAsset = {
-      id: 3n,
+      id: 3,
       assetType: AztecAssetType.ERC20,
       erc20Address: EthAddress.random(),
     };
@@ -133,7 +127,7 @@ describe("aave lending bridge data", () => {
 
   it("returns correct APR", async () => {
     const zkAsset = {
-      id: 3n,
+      id: 3,
       assetType: AztecAssetType.ERC20,
       erc20Address: EthAddress.random(),
     };
@@ -174,7 +168,7 @@ describe("aave lending bridge data", () => {
 
   it.skip("should return the market size", async () => {
     const zkAsset = {
-      id: 3n,
+      id: 3,
       assetType: AztecAssetType.ERC20,
       erc20Address: EthAddress.random(),
     };

--- a/src/client/aave/aave-bridge-data.ts
+++ b/src/client/aave/aave-bridge-data.ts
@@ -1,23 +1,16 @@
-import {
-  AssetValue,
-  AuxDataConfig,
-  AztecAsset,
-  SolidityType,
-  AztecAssetType,
-  BridgeDataFieldGetters,
-} from "../bridge-data";
+import { AuxDataConfig, AztecAsset, AztecAssetType, BridgeDataFieldGetters, SolidityType } from "../bridge-data";
 
+import { EthAddress } from "@aztec/barretenberg/address";
+import { EthereumProvider } from "@aztec/barretenberg/blockchain";
 import {
   IAaveLendingBridge,
   IAaveLendingBridge__factory,
-  IERC20,
   IERC20__factory,
   ILendingPool,
   ILendingPool__factory,
 } from "../../../typechain-types";
-import { EthereumProvider } from "@aztec/barretenberg/blockchain";
 import { createWeb3Provider } from "../aztec/provider";
-import { EthAddress } from "@aztec/barretenberg/address";
+import { AssetValue } from "@aztec/barretenberg/asset";
 
 export class AaveBridgeData implements BridgeDataFieldGetters {
   public scalingFactor: bigint = 1n * 10n ** 18n;

--- a/src/client/aave/aave-bridge-data.ts
+++ b/src/client/aave/aave-bridge-data.ts
@@ -38,7 +38,7 @@ export class AaveBridgeData implements BridgeDataFieldGetters {
   ];
 
   // Unused
-  async getInteractionPresentValue(interactionNonce: bigint): Promise<AssetValue[]> {
+  async getInteractionPresentValue(interactionNonce: number): Promise<AssetValue[]> {
     return [];
   }
 

--- a/src/client/aave/aave-bridge-data.ts
+++ b/src/client/aave/aave-bridge-data.ts
@@ -126,15 +126,9 @@ export class AaveBridgeData implements BridgeDataFieldGetters {
     }
   }
 
-  async getAPR(inputAssetA: AztecAsset, outputAssetA: AztecAsset): Promise<number> {
-    const { entering, underlyingAsset } = await this.getUnderlyingAndEntering(inputAssetA, outputAssetA);
-
-    if (!entering) {
-      return 0;
-    }
-
+  async getAPR(yieldAsset: AztecAsset): Promise<number> {
     // Not taking into account how the deposited funds will change the yield
-    const reserveData = await this.lendingPoolContract.getReserveData(underlyingAsset.toString());
+    const reserveData = await this.lendingPoolContract.getReserveData(yieldAsset.toString());
     const rate = reserveData.currentLiquidityRate.toBigInt();
     return Number(rate / 10n ** 25n);
   }

--- a/src/client/aave/aave-bridge-data.ts
+++ b/src/client/aave/aave-bridge-data.ts
@@ -153,7 +153,7 @@ export class AaveBridgeData implements BridgeDataFieldGetters {
     return [
       {
         assetId: inputAssetA.id,
-        amount: (await token.totalSupply()).toBigInt(),
+        value: (await token.totalSupply()).toBigInt(),
       },
     ];
   }

--- a/src/client/aave/aave-bridge-data.ts
+++ b/src/client/aave/aave-bridge-data.ts
@@ -126,26 +126,17 @@ export class AaveBridgeData implements BridgeDataFieldGetters {
     }
   }
 
-  async getAPR(
-    inputAssetA: AztecAsset,
-    inputAssetB: AztecAsset,
-    outputAssetA: AztecAsset,
-    outputAssetB: AztecAsset,
-    auxData: bigint,
-    inputValue: bigint,
-  ): Promise<number[]> {
-    const YEAR = 60n * 60n * 24n * 365n;
-
+  async getAPR(inputAssetA: AztecAsset, outputAssetA: AztecAsset): Promise<number> {
     const { entering, underlyingAsset } = await this.getUnderlyingAndEntering(inputAssetA, outputAssetA);
 
     if (!entering) {
-      return [0];
+      return 0;
     }
 
     // Not taking into account how the deposited funds will change the yield
     const reserveData = await this.lendingPoolContract.getReserveData(underlyingAsset.toString());
     const rate = reserveData.currentLiquidityRate.toBigInt();
-    return [Number(rate / 10n ** 25n)];
+    return Number(rate / 10n ** 25n);
   }
 
   async getMarketSize(

--- a/src/client/aave/aave-bridge-data.ts
+++ b/src/client/aave/aave-bridge-data.ts
@@ -100,7 +100,7 @@ export class AaveBridgeData implements BridgeDataFieldGetters {
     inputAssetB: AztecAsset,
     outputAssetA: AztecAsset,
     outputAssetB: AztecAsset,
-    auxData: bigint,
+    auxData: number,
     inputValue: bigint,
   ): Promise<bigint[]> {
     const { entering, underlyingAsset } = await this.getUnderlyingAndEntering(inputAssetA, outputAssetA);
@@ -131,7 +131,7 @@ export class AaveBridgeData implements BridgeDataFieldGetters {
     inputAssetB: AztecAsset,
     outputAssetA: AztecAsset,
     outputAssetB: AztecAsset,
-    auxData: bigint,
+    auxData: number,
   ): Promise<AssetValue[]> {
     const { underlyingAsset } = await this.getUnderlyingAndEntering(inputAssetA, outputAssetA);
     const reserveData = await this.lendingPoolContract.getReserveData(underlyingAsset.toString());

--- a/src/client/bridge-data.ts
+++ b/src/client/bridge-data.ts
@@ -1,9 +1,5 @@
 import { EthAddress } from "@aztec/barretenberg/address";
-
-export interface AssetValue {
-  assetId: number; // ID used in `RollupProcessor.getSupportedAsset(assetId)`
-  value: bigint;
-}
+import { AssetValue } from "@aztec/barretenberg/asset";
 
 export interface UnderlyingAsset {
   address: EthAddress;

--- a/src/client/bridge-data.ts
+++ b/src/client/bridge-data.ts
@@ -107,25 +107,13 @@ export interface BridgeDataFieldGetters {
   hasFinalised?(interactionNonce: bigint): Promise<boolean>;
 
   /**
-  * @notice This function computes annual percentage return (APR) for given assets, auxData and inputValue
-  * @dev This function should be implemented for all bridges that are stateful
-  * @param inputAssetA A struct detailing the first input asset
-  * @param inputAssetB A struct detailing the second input asset
-  * @param outputAssetA A struct detailing the first output asset
-  * @param outputAssetB A struct detailing the second output asset
-  * @param auxData Arbitrary data to be passed into the bridge contract (slippage / nftID etc)
-  * @param inputValue Amount of inputAssetA (and inputAssetB if used) provided on input
-  * @return The expected APR of outputAssetA and outputAssetB if used (e.g. for Lido the return value would currently
-          be [3.9])
-  */
-  getAPR?(
-    inputAssetA: AztecAsset,
-    inputAssetB: AztecAsset,
-    outputAssetA: AztecAsset,
-    outputAssetB: AztecAsset,
-    auxData: bigint,
-    inputValue: bigint,
-  ): Promise<number[]>;
+   * @notice This function computes annual percentage return (APR) for a given asset
+   * @dev This function should be implemented for all bridges which work with yield-bearing assets
+   * @param inputAssetA A struct detailing the input asset
+   * @param outputAssetA A struct detailing the output asset
+   * @return The expected APR (e.g. for Lido the return value would currently be 3.9)
+   */
+  getAPR?(inputAssetA: AztecAsset, outputAssetA: AztecAsset): Promise<number>;
 
   /** 
   * @dev This function should be implemented for all bridges dealing with L1 liquidity

--- a/src/client/bridge-data.ts
+++ b/src/client/bridge-data.ts
@@ -43,8 +43,8 @@ export interface AuxDataConfig {
 export interface BridgeDataFieldGetters {
   /**
    * @dev This function should be implemented for stateful bridges
-   * @param inputValue User's input value
    * @param interactionNonce A globally unique identifier of a given DeFi interaction
+   * @param inputValue User's input value
    * @return The value of the user's share of a given interaction
    */
   getInteractionPresentValue?(interactionNonce: number, inputValue: bigint): Promise<AssetValue[]>;
@@ -110,16 +110,17 @@ export interface BridgeDataFieldGetters {
    */
   getAPR?(yieldAsset: AztecAsset): Promise<number>;
 
-  /** 
-  * @dev This function should be implemented for all bridges dealing with L1 liquidity
-  * @param inputAssetA A struct detailing the first input asset
-  * @param inputAssetB A struct detailing the second input asset
-  * @param outputAssetA A struct detailing the first output asset
-  * @param outputAssetB A struct detailing the second output asset
-  * @param auxData Arbitrary data to be passed into the bridge contract (slippage / nftID etc)
-  * @return L1 liquidity this bridge call will be interacting with (e.g. the liquidity of the underlying yield pool
-          or AMM)
-  */
+  /**
+   * @notice This function computes market size
+   * @dev Should be implemented for all bridges dealing with L1 liquidity
+   * @param inputAssetA A struct detailing the first input asset
+   * @param inputAssetB A struct detailing the second input asset
+   * @param outputAssetA A struct detailing the first output asset
+   * @param outputAssetB A struct detailing the second output asset
+   * @param auxData Arbitrary data to be passed into the bridge contract (slippage / nftID etc)
+   * @return L1 liquidity this bridge call will be interacting with (e.g. the liquidity of the underlying yield pool
+   *       or AMM, amount of ETH staked in Lido etc.)
+   */
   getMarketSize?(
     inputAssetA: AztecAsset,
     inputAssetB: AztecAsset,

--- a/src/client/bridge-data.ts
+++ b/src/client/bridge-data.ts
@@ -109,11 +109,10 @@ export interface BridgeDataFieldGetters {
   /**
    * @notice This function computes annual percentage return (APR) for a given asset
    * @dev This function should be implemented for all bridges which work with yield-bearing assets
-   * @param inputAssetA A struct detailing the input asset
-   * @param outputAssetA A struct detailing the output asset
+   * @param yieldAsset A struct detailing the yield asset (e.g. cToken, wstETH, aETH, ...)
    * @return The expected APR (e.g. for Lido the return value would currently be 3.9)
    */
-  getAPR?(inputAssetA: AztecAsset, outputAssetA: AztecAsset): Promise<number>;
+  getAPR?(yieldAsset: AztecAsset): Promise<number>;
 
   /** 
   * @dev This function should be implemented for all bridges dealing with L1 liquidity

--- a/src/client/bridge-data.ts
+++ b/src/client/bridge-data.ts
@@ -43,11 +43,11 @@ export interface AuxDataConfig {
 export interface BridgeDataFieldGetters {
   /**
    * @dev This function should be implemented for stateful bridges
-   * @param interactionNonce A globally unique identifier of a given DeFi interaction
    * @param inputValue User's input value
+   * @param interactionNonce A globally unique identifier of a given DeFi interaction
    * @return The value of the user's share of a given interaction
    */
-  getInteractionPresentValue?(interactionNonce: bigint, inputValue: bigint): Promise<AssetValue[]>;
+  getInteractionPresentValue?(interactionNonce: number, inputValue: bigint): Promise<AssetValue[]>;
 
   /**
    * @dev This function should be implemented for all bridges that use auxData which require on-chain data
@@ -93,14 +93,14 @@ export interface BridgeDataFieldGetters {
    * @param interactionNonce A globally unique identifier of a given DeFi interaction
    * @return The date at which the bridge is expected to be finalised (for limit orders this should be the expiration)
    */
-  getExpiration?(interactionNonce: bigint): Promise<bigint>;
+  getExpiration?(interactionNonce: number): Promise<bigint>;
 
   /**
    * @dev This function should be implemented for async bridges
    * @param interactionNonce A globally unique identifier of a given DeFi interaction
    * @return A boolean indicating whether the interaction has been finilised
    */
-  hasFinalised?(interactionNonce: bigint): Promise<boolean>;
+  hasFinalised?(interactionNonce: number): Promise<boolean>;
 
   /**
    * @notice This function computes annual percentage return (APR) for a given asset
@@ -134,7 +134,7 @@ export interface BridgeDataFieldGetters {
    * @param interactionNonce A globally unique identifier of a given DeFi interaction
    * @return APR based on the information of a given interaction (e.g. token amounts after finalisation etc.)
    */
-  getInteractionAPR?(interactionNonce: bigint): Promise<number[]>;
+  getInteractionAPR?(interactionNonce: number): Promise<number[]>;
 
   /**
    * @notice This function gets the underlying amount for wrapped assets or shares

--- a/src/client/bridge-data.ts
+++ b/src/client/bridge-data.ts
@@ -2,7 +2,7 @@ import { EthAddress } from "@aztec/barretenberg/address";
 
 export interface AssetValue {
   assetId: bigint; // ID used in `RollupProcessor.getSupportedAsset(assetId)`
-  amount: bigint;
+  value: bigint;
 }
 
 export interface UnderlyingAsset {

--- a/src/client/bridge-data.ts
+++ b/src/client/bridge-data.ts
@@ -1,7 +1,7 @@
 import { EthAddress } from "@aztec/barretenberg/address";
 
 export interface AssetValue {
-  assetId: bigint; // ID used in `RollupProcessor.getSupportedAsset(assetId)`
+  assetId: number; // ID used in `RollupProcessor.getSupportedAsset(assetId)`
   value: bigint;
 }
 
@@ -32,7 +32,7 @@ export enum SolidityType {
 }
 
 export interface AztecAsset {
-  id: bigint;
+  id: number;
   assetType: AztecAssetType;
   erc20Address: EthAddress;
 }

--- a/src/client/bridge-data.ts
+++ b/src/client/bridge-data.ts
@@ -84,7 +84,7 @@ export interface BridgeDataFieldGetters {
     inputAssetB: AztecAsset,
     outputAssetA: AztecAsset,
     outputAssetB: AztecAsset,
-    auxData: bigint,
+    auxData: number,
     inputValue: bigint,
   ): Promise<bigint[]>;
 
@@ -125,7 +125,7 @@ export interface BridgeDataFieldGetters {
     inputAssetB: AztecAsset,
     outputAssetA: AztecAsset,
     outputAssetB: AztecAsset,
-    auxData: bigint,
+    auxData: number,
   ): Promise<AssetValue[]>;
 
   /**

--- a/src/client/compound/compound-bridge-data.test.ts
+++ b/src/client/compound/compound-bridge-data.test.ts
@@ -162,7 +162,7 @@ describe("compound lending bridge data", () => {
 
     // Test the code using mocked controller
     const expectedOutput = (
-      await compoundBridgeData.getExpectedOutput(ethAsset, emptyAsset, cethAsset, emptyAsset, 0n, 10n ** 18n)
+      await compoundBridgeData.getExpectedOutput(ethAsset, emptyAsset, cethAsset, emptyAsset, 0, 10n ** 18n)
     )[0];
     expect(expectedOutput).toBe(4983773038n);
   });
@@ -178,7 +178,7 @@ describe("compound lending bridge data", () => {
 
     // Test the code using mocked controller
     const expectedOutput = (
-      await compoundBridgeData.getExpectedOutput(cethAsset, emptyAsset, ethAsset, emptyAsset, 1n, 4983783707n)
+      await compoundBridgeData.getExpectedOutput(cethAsset, emptyAsset, ethAsset, emptyAsset, 1, 4983783707n)
     )[0];
     expect(expectedOutput).toBe(1000002140628525162n);
   });
@@ -207,9 +207,9 @@ describe("compound lending bridge data", () => {
     const compoundBridgeData = CompoundBridgeData.create({} as any);
 
     // Test the code using mocked controller
-    const marketSizeMint = (await compoundBridgeData.getMarketSize(daiAsset, emptyAsset, cdaiAsset, emptyAsset, 0n))[0];
+    const marketSizeMint = (await compoundBridgeData.getMarketSize(daiAsset, emptyAsset, cdaiAsset, emptyAsset, 0))[0];
     const marketSizeRedeem = (
-      await compoundBridgeData.getMarketSize(cdaiAsset, emptyAsset, daiAsset, emptyAsset, 1n)
+      await compoundBridgeData.getMarketSize(cdaiAsset, emptyAsset, daiAsset, emptyAsset, 1)
     )[0];
     expect(marketSizeMint.value).toBe(marketSizeRedeem.value);
     expect(marketSizeMint.value).toBe(368442895892448315882277748n);

--- a/src/client/compound/compound-bridge-data.test.ts
+++ b/src/client/compound/compound-bridge-data.test.ts
@@ -201,7 +201,9 @@ describe("compound lending bridge data", () => {
     // Setup mocks
     cerc20Contract = {
       ...cerc20Contract,
-      supplyRatePerBlock: jest.fn().mockResolvedValue(undefined),
+      supplyRatePerBlock: jest.fn().mockImplementation(() => {
+        throw new Error();
+      }),
     };
     ICERC20__factory.connect = () => cerc20Contract as any;
     const compoundBridgeData = CompoundBridgeData.create({} as any);

--- a/src/client/compound/compound-bridge-data.test.ts
+++ b/src/client/compound/compound-bridge-data.test.ts
@@ -183,7 +183,7 @@ describe("compound lending bridge data", () => {
     expect(expectedOutput).toBe(1000002140628525162n);
   });
 
-  it("should correctly compute expected yield when minting", async () => {
+  it("should correctly compute expected APR when minting", async () => {
     // Setup mocks
     cerc20Contract = {
       ...cerc20Contract,
@@ -193,21 +193,21 @@ describe("compound lending bridge data", () => {
     const compoundBridgeData = CompoundBridgeData.create({} as any);
 
     // Test the code using mocked controller
-    const expectedYield = (await compoundBridgeData.getAPR(ethAsset, emptyAsset, cethAsset, emptyAsset, 0n, 0n))[0];
-    expect(expectedYield).toBe(0.0710926465392);
+    const APR = await compoundBridgeData.getAPR(ethAsset, cethAsset);
+    expect(APR).toBe(0.0710926465392);
   });
 
-  it("should compute expected yield to be 0 when redeeming", async () => {
+  it("should compute expected APR to be 0 when redeeming", async () => {
     // Setup mocks
     cerc20Contract = {
       ...cerc20Contract,
-      supplyRatePerBlock: jest.fn().mockResolvedValue(BigNumber.from("338149955")),
+      supplyRatePerBlock: jest.fn().mockResolvedValue(undefined),
     };
     ICERC20__factory.connect = () => cerc20Contract as any;
     const compoundBridgeData = CompoundBridgeData.create({} as any);
 
     // Test the code using mocked controller
-    const expectedYield = (await compoundBridgeData.getAPR(cethAsset, emptyAsset, ethAsset, emptyAsset, 1n, 0n))[0];
+    const expectedYield = await compoundBridgeData.getAPR(cethAsset, ethAsset);
     expect(expectedYield).toBe(0);
   });
 

--- a/src/client/compound/compound-bridge-data.test.ts
+++ b/src/client/compound/compound-bridge-data.test.ts
@@ -183,7 +183,7 @@ describe("compound lending bridge data", () => {
     expect(expectedOutput).toBe(1000002140628525162n);
   });
 
-  it("should correctly compute expected APR when minting", async () => {
+  it("should correctly compute expected APR", async () => {
     // Setup mocks
     cerc20Contract = {
       ...cerc20Contract,
@@ -193,24 +193,8 @@ describe("compound lending bridge data", () => {
     const compoundBridgeData = CompoundBridgeData.create({} as any);
 
     // Test the code using mocked controller
-    const APR = await compoundBridgeData.getAPR(ethAsset, cethAsset);
+    const APR = await compoundBridgeData.getAPR(cethAsset);
     expect(APR).toBe(0.0710926465392);
-  });
-
-  it("should compute expected APR to be 0 when redeeming", async () => {
-    // Setup mocks
-    cerc20Contract = {
-      ...cerc20Contract,
-      supplyRatePerBlock: jest.fn().mockImplementation(() => {
-        throw new Error();
-      }),
-    };
-    ICERC20__factory.connect = () => cerc20Contract as any;
-    const compoundBridgeData = CompoundBridgeData.create({} as any);
-
-    // Test the code using mocked controller
-    const expectedYield = await compoundBridgeData.getAPR(cethAsset, ethAsset);
-    expect(expectedYield).toBe(0);
   });
 
   it("should correctly compute market size", async () => {

--- a/src/client/compound/compound-bridge-data.test.ts
+++ b/src/client/compound/compound-bridge-data.test.ts
@@ -227,7 +227,7 @@ describe("compound lending bridge data", () => {
     const marketSizeRedeem = (
       await compoundBridgeData.getMarketSize(cdaiAsset, emptyAsset, daiAsset, emptyAsset, 1n)
     )[0];
-    expect(marketSizeMint.amount).toBe(marketSizeRedeem.amount);
-    expect(marketSizeMint.amount).toBe(368442895892448315882277748n);
+    expect(marketSizeMint.value).toBe(marketSizeRedeem.value);
+    expect(marketSizeMint.value).toBe(368442895892448315882277748n);
   });
 });

--- a/src/client/compound/compound-bridge-data.test.ts
+++ b/src/client/compound/compound-bridge-data.test.ts
@@ -35,27 +35,27 @@ describe("compound lending bridge data", () => {
 
   beforeAll(() => {
     ethAsset = {
-      id: 0n,
+      id: 0,
       assetType: AztecAssetType.ETH,
       erc20Address: EthAddress.ZERO,
     };
     cethAsset = {
-      id: 10n, // Asset has not yet been registered on RollupProcessor so this id is random
+      id: 10, // Asset has not yet been registered on RollupProcessor so this id is random
       assetType: AztecAssetType.ERC20,
       erc20Address: EthAddress.fromString("0x4Ddc2D193948926D02f9B1fE9e1daa0718270ED5"),
     };
     daiAsset = {
-      id: 1n,
+      id: 1,
       assetType: AztecAssetType.ERC20,
       erc20Address: EthAddress.fromString("0x6B175474E89094C44Da98b954EedeAC495271d0F"),
     };
     cdaiAsset = {
-      id: 11n, // Asset has not yet been registered on RollupProcessor so this id is random
+      id: 11, // Asset has not yet been registered on RollupProcessor so this id is random
       assetType: AztecAssetType.ERC20,
       erc20Address: EthAddress.fromString("0x5d3a536E4D6DbD6114cc1Ead35777bAB948E3643"),
     };
     emptyAsset = {
-      id: 0n,
+      id: 0,
       assetType: AztecAssetType.NOT_USED,
       erc20Address: EthAddress.ZERO,
     };

--- a/src/client/compound/compound-bridge-data.ts
+++ b/src/client/compound/compound-bridge-data.ts
@@ -11,14 +11,8 @@ import {
   IRollupProcessor__factory,
 } from "../../../typechain-types";
 import { createWeb3Provider } from "../aztec/provider";
-import {
-  AssetValue,
-  AuxDataConfig,
-  AztecAsset,
-  AztecAssetType,
-  BridgeDataFieldGetters,
-  SolidityType,
-} from "../bridge-data";
+import { AuxDataConfig, AztecAsset, AztecAssetType, BridgeDataFieldGetters, SolidityType } from "../bridge-data";
+import { AssetValue } from "@aztec/barretenberg/asset";
 
 export class CompoundBridgeData implements BridgeDataFieldGetters {
   readonly expScale = 10n ** 18n;

--- a/src/client/compound/compound-bridge-data.ts
+++ b/src/client/compound/compound-bridge-data.ts
@@ -96,19 +96,15 @@ export class CompoundBridgeData implements BridgeDataFieldGetters {
     }
   }
 
-  async getAPR(inputAssetA: AztecAsset, outputAssetA: AztecAsset): Promise<number> {
+  async getAPR(yieldAsset: AztecAsset): Promise<number> {
     // Not taking into account how the deposited funds will change the yield
     // The approximate number of blocks per year that is assumed by the interest rate model
 
     const blocksPerYear = 2102400;
-    const cToken = ICERC20__factory.connect(outputAssetA.erc20Address.toString(), this.ethersProvider);
+    const cToken = ICERC20__factory.connect(yieldAsset.erc20Address.toString(), this.ethersProvider);
 
-    try {
-      const supplyRatePerBlock = await cToken.supplyRatePerBlock();
-      return supplyRatePerBlock.mul(blocksPerYear).toNumber() / 10 ** 16;
-    } catch {
-      return 0;
-    }
+    const supplyRatePerBlock = await cToken.supplyRatePerBlock();
+    return supplyRatePerBlock.mul(blocksPerYear).toNumber() / 10 ** 16;
   }
 
   async getMarketSize(

--- a/src/client/compound/compound-bridge-data.ts
+++ b/src/client/compound/compound-bridge-data.ts
@@ -144,7 +144,7 @@ export class CompoundBridgeData implements BridgeDataFieldGetters {
     return [
       {
         assetId: underlyingAsset.id,
-        amount: marketSize.toBigInt(),
+        value: marketSize.toBigInt(),
       },
     ];
   }

--- a/src/client/compound/compound-bridge-data.ts
+++ b/src/client/compound/compound-bridge-data.ts
@@ -72,15 +72,15 @@ export class CompoundBridgeData implements BridgeDataFieldGetters {
     inputAssetB: AztecAsset,
     outputAssetA: AztecAsset,
     outputAssetB: AztecAsset,
-    auxData: bigint,
+    auxData: number,
     inputValue: bigint,
   ): Promise<bigint[]> {
-    if (auxData === 0n) {
+    if (auxData === 0) {
       // Minting
       const cToken = ICERC20__factory.connect(outputAssetA.erc20Address.toString(), this.ethersProvider);
       const exchangeRateStored = await cToken.exchangeRateStored();
       return [BigNumber.from(inputValue).mul(this.expScale).div(exchangeRateStored).toBigInt()];
-    } else if (auxData === 1n) {
+    } else if (auxData === 1) {
       // Redeeming
       const cToken = ICERC20__factory.connect(inputAssetA.erc20Address.toString(), this.ethersProvider);
       const exchangeRateStored = await cToken.exchangeRateStored();
@@ -106,15 +106,15 @@ export class CompoundBridgeData implements BridgeDataFieldGetters {
     inputAssetB: AztecAsset,
     outputAssetA: AztecAsset,
     outputAssetB: AztecAsset,
-    auxData: bigint,
+    auxData: number,
   ): Promise<AssetValue[]> {
     let cTokenAddress;
     let underlyingAsset;
-    if (auxData === 0n) {
+    if (auxData === 0) {
       // Minting
       cTokenAddress = outputAssetA.erc20Address;
       underlyingAsset = inputAssetA;
-    } else if (auxData === 1n) {
+    } else if (auxData === 1) {
       // Redeeming
       cTokenAddress = inputAssetA.erc20Address;
       underlyingAsset = outputAssetA;

--- a/src/client/compound/compound-bridge-data.ts
+++ b/src/client/compound/compound-bridge-data.ts
@@ -96,30 +96,19 @@ export class CompoundBridgeData implements BridgeDataFieldGetters {
     }
   }
 
-  async getAPR(
-    inputAssetA: AztecAsset,
-    inputAssetB: AztecAsset,
-    outputAssetA: AztecAsset,
-    outputAssetB: AztecAsset,
-    auxData: bigint,
-    inputValue: bigint,
-  ): Promise<number[]> {
+  async getAPR(inputAssetA: AztecAsset, outputAssetA: AztecAsset): Promise<number> {
     // Not taking into account how the deposited funds will change the yield
-    if (auxData === 0n) {
-      // Minting
-      // The approximate number of blocks per year that is assumed by the interest rate model
-      const blocksPerYear = 2102400;
-      const supplyRatePerBlock = await ICERC20__factory.connect(
-        outputAssetA.erc20Address.toString(),
-        this.ethersProvider,
-      ).supplyRatePerBlock();
-      return [supplyRatePerBlock.mul(blocksPerYear).toNumber() / 10 ** 16];
-    } else if (auxData === 1n) {
-      // Redeeming
-      return [0];
-    } else {
-      throw "Invalid auxData";
+    // Minting
+    // The approximate number of blocks per year that is assumed by the interest rate model
+    const blocksPerYear = 2102400;
+    const cToken = ICERC20__factory.connect(outputAssetA.erc20Address.toString(), this.ethersProvider);
+    const supplyRatePerBlock = await cToken.supplyRatePerBlock();
+
+    if (supplyRatePerBlock === undefined) {
+      return 0;
     }
+
+    return supplyRatePerBlock.mul(blocksPerYear).toNumber() / 10 ** 16;
   }
 
   async getMarketSize(

--- a/src/client/compound/compound-bridge-data.ts
+++ b/src/client/compound/compound-bridge-data.ts
@@ -8,7 +8,7 @@ import {
   IComptroller__factory,
   IERC20__factory,
   IRollupProcessor,
-  IRollupProcessor__factory
+  IRollupProcessor__factory,
 } from "../../../typechain-types";
 import { createWeb3Provider } from "../aztec/provider";
 import {
@@ -17,7 +17,7 @@ import {
   AztecAsset,
   AztecAssetType,
   BridgeDataFieldGetters,
-  SolidityType
+  SolidityType,
 } from "../bridge-data";
 
 export class CompoundBridgeData implements BridgeDataFieldGetters {

--- a/src/client/compound/compound-bridge-data.ts
+++ b/src/client/compound/compound-bridge-data.ts
@@ -8,7 +8,7 @@ import {
   IComptroller__factory,
   IERC20__factory,
   IRollupProcessor,
-  IRollupProcessor__factory,
+  IRollupProcessor__factory
 } from "../../../typechain-types";
 import { createWeb3Provider } from "../aztec/provider";
 import {
@@ -17,7 +17,7 @@ import {
   AztecAsset,
   AztecAssetType,
   BridgeDataFieldGetters,
-  SolidityType,
+  SolidityType
 } from "../bridge-data";
 
 export class CompoundBridgeData implements BridgeDataFieldGetters {
@@ -98,17 +98,17 @@ export class CompoundBridgeData implements BridgeDataFieldGetters {
 
   async getAPR(inputAssetA: AztecAsset, outputAssetA: AztecAsset): Promise<number> {
     // Not taking into account how the deposited funds will change the yield
-    // Minting
     // The approximate number of blocks per year that is assumed by the interest rate model
+
     const blocksPerYear = 2102400;
     const cToken = ICERC20__factory.connect(outputAssetA.erc20Address.toString(), this.ethersProvider);
-    const supplyRatePerBlock = await cToken.supplyRatePerBlock();
 
-    if (supplyRatePerBlock === undefined) {
+    try {
+      const supplyRatePerBlock = await cToken.supplyRatePerBlock();
+      return supplyRatePerBlock.mul(blocksPerYear).toNumber() / 10 ** 16;
+    } catch {
       return 0;
     }
-
-    return supplyRatePerBlock.mul(blocksPerYear).toNumber() / 10 ** 16;
   }
 
   async getMarketSize(

--- a/src/client/curve/curve-steth/curve-bridge-data.test.ts
+++ b/src/client/curve/curve-steth/curve-bridge-data.test.ts
@@ -194,7 +194,7 @@ describe("curve steth bridge data", () => {
       lidoOracleContract as any,
     );
 
-    const APR = await curveBridgeData.getAPR(wstETHAsset, ethAsset);
+    const APR = await curveBridgeData.getAPR(wstETHAsset);
     expect(APR).toBe(expectedAPR);
   });
 });

--- a/src/client/curve/curve-steth/curve-bridge-data.test.ts
+++ b/src/client/curve/curve-steth/curve-bridge-data.test.ts
@@ -42,17 +42,17 @@ describe("curve steth bridge data", () => {
 
   beforeAll(() => {
     ethAsset = {
-      id: 1n,
+      id: 1,
       assetType: AztecAssetType.ETH,
       erc20Address: EthAddress.ZERO,
     };
     wstETHAsset = {
-      id: 2n,
+      id: 2,
       assetType: AztecAssetType.ERC20,
       erc20Address: EthAddress.fromString("0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0"),
     };
     emptyAsset = {
-      id: 0n,
+      id: 0,
       assetType: AztecAssetType.NOT_USED,
       erc20Address: EthAddress.ZERO,
     };

--- a/src/client/curve/curve-steth/curve-bridge-data.test.ts
+++ b/src/client/curve/curve-steth/curve-bridge-data.test.ts
@@ -160,9 +160,8 @@ describe("curve steth bridge data", () => {
     expect(expectedOutput == output[0]).toBeTruthy();
   });
 
-  it("should correctly return the expectedYearlyOutput", async () => {
-    const depositAmount = BigInt(1 * 10e18);
-    const expectedOutput = 4.32;
+  it("should correctly return the expected APR", async () => {
+    const expectedAPR = 4.32;
 
     wstethContract = {
       ...wstethContract,
@@ -195,7 +194,7 @@ describe("curve steth bridge data", () => {
       lidoOracleContract as any,
     );
 
-    const output = await curveBridgeData.getAPR(wstETHAsset, emptyAsset, ethAsset, emptyAsset, 0n, depositAmount);
-    expect(expectedOutput).toBe(output[0]);
+    const APR = await curveBridgeData.getAPR(wstETHAsset, ethAsset);
+    expect(APR).toBe(expectedAPR);
   });
 });

--- a/src/client/curve/curve-steth/curve-bridge-data.test.ts
+++ b/src/client/curve/curve-steth/curve-bridge-data.test.ts
@@ -85,7 +85,7 @@ describe("curve steth bridge data", () => {
       emptyAsset,
       wstETHAsset,
       emptyAsset,
-      0n,
+      0,
       depositAmount,
     );
     expect(expectedOutput == output[0]).toBeTruthy();
@@ -119,7 +119,7 @@ describe("curve steth bridge data", () => {
       emptyAsset,
       wstETHAsset,
       emptyAsset,
-      0n,
+      0,
       depositAmount,
     );
     expect(expectedOutput == output[0]).toBeTruthy();
@@ -153,7 +153,7 @@ describe("curve steth bridge data", () => {
       emptyAsset,
       ethAsset,
       emptyAsset,
-      0n,
+      0,
       depositAmount,
     );
 

--- a/src/client/curve/curve-steth/curve-bridge-data.ts
+++ b/src/client/curve/curve-steth/curve-bridge-data.ts
@@ -90,14 +90,7 @@ export class CurveStethBridgeData implements BridgeDataFieldGetters {
     }
     return [0n];
   }
-  async getAPR(
-    inputAssetA: AztecAsset,
-    inputAssetB: AztecAsset,
-    outputAssetA: AztecAsset,
-    outputAssetB: AztecAsset,
-    auxData: bigint,
-    inputValue: bigint,
-  ): Promise<number[]> {
+  async getAPR(inputAssetA: AztecAsset, outputAssetA: AztecAsset): Promise<number> {
     const YEAR = 60n * 60n * 24n * 365n;
     if (outputAssetA.assetType === AztecAssetType.ETH) {
       const { postTotalPooledEther, preTotalPooledEther, timeElapsed } =
@@ -107,9 +100,9 @@ export class CurveStethBridgeData implements BridgeDataFieldGetters {
         ((postTotalPooledEther.toBigInt() - preTotalPooledEther.toBigInt()) * YEAR * this.scalingFactor) /
         (preTotalPooledEther.toBigInt() * timeElapsed.toBigInt());
 
-      return [Number(scaledAPR / (this.scalingFactor / 10000n)) / 100];
+      return Number(scaledAPR / (this.scalingFactor / 10000n)) / 100;
     }
-    return [0];
+    return 0;
   }
 
   async getMarketSize(

--- a/src/client/curve/curve-steth/curve-bridge-data.ts
+++ b/src/client/curve/curve-steth/curve-bridge-data.ts
@@ -116,7 +116,7 @@ export class CurveStethBridgeData implements BridgeDataFieldGetters {
     return [
       {
         assetId: inputAssetA.id,
-        amount: postTotalPooledEther.toBigInt(),
+        value: postTotalPooledEther.toBigInt(),
       },
     ];
   }

--- a/src/client/curve/curve-steth/curve-bridge-data.ts
+++ b/src/client/curve/curve-steth/curve-bridge-data.ts
@@ -90,19 +90,16 @@ export class CurveStethBridgeData implements BridgeDataFieldGetters {
     }
     return [0n];
   }
-  async getAPR(inputAssetA: AztecAsset, outputAssetA: AztecAsset): Promise<number> {
+  async getAPR(yieldAsset: AztecAsset): Promise<number> {
     const YEAR = 60n * 60n * 24n * 365n;
-    if (outputAssetA.assetType === AztecAssetType.ETH) {
-      const { postTotalPooledEther, preTotalPooledEther, timeElapsed } =
-        await this.lidoOracleContract.getLastCompletedReportDelta();
+    const { postTotalPooledEther, preTotalPooledEther, timeElapsed } =
+      await this.lidoOracleContract.getLastCompletedReportDelta();
 
-      const scaledAPR =
-        ((postTotalPooledEther.toBigInt() - preTotalPooledEther.toBigInt()) * YEAR * this.scalingFactor) /
-        (preTotalPooledEther.toBigInt() * timeElapsed.toBigInt());
+    const scaledAPR =
+      ((postTotalPooledEther.toBigInt() - preTotalPooledEther.toBigInt()) * YEAR * this.scalingFactor) /
+      (preTotalPooledEther.toBigInt() * timeElapsed.toBigInt());
 
-      return Number(scaledAPR / (this.scalingFactor / 10000n)) / 100;
-    }
-    return 0;
+    return Number(scaledAPR / (this.scalingFactor / 10000n)) / 100;
   }
 
   async getMarketSize(

--- a/src/client/curve/curve-steth/curve-bridge-data.ts
+++ b/src/client/curve/curve-steth/curve-bridge-data.ts
@@ -1,5 +1,4 @@
 import {
-  AssetValue,
   UnderlyingAsset,
   AuxDataConfig,
   AztecAsset,
@@ -19,6 +18,7 @@ import {
 import { EthereumProvider } from "@aztec/barretenberg/blockchain";
 import { createWeb3Provider } from "../../aztec/provider";
 import { EthAddress } from "@aztec/barretenberg/address";
+import { AssetValue } from "@aztec/barretenberg/asset";
 
 export class CurveStethBridgeData implements BridgeDataFieldGetters {
   public scalingFactor: bigint = 1n * 10n ** 18n;

--- a/src/client/curve/curve-steth/curve-bridge-data.ts
+++ b/src/client/curve/curve-steth/curve-bridge-data.ts
@@ -53,7 +53,7 @@ export class CurveStethBridgeData implements BridgeDataFieldGetters {
   ];
 
   // Lido bridge contract is stateless
-  async getInteractionPresentValue(interactionNonce: bigint): Promise<AssetValue[]> {
+  async getInteractionPresentValue(interactionNonce: number): Promise<AssetValue[]> {
     return [];
   }
 

--- a/src/client/curve/curve-steth/curve-bridge-data.ts
+++ b/src/client/curve/curve-steth/curve-bridge-data.ts
@@ -72,7 +72,7 @@ export class CurveStethBridgeData implements BridgeDataFieldGetters {
     inputAssetB: AztecAsset,
     outputAssetA: AztecAsset,
     outputAssetB: AztecAsset,
-    auxData: bigint,
+    auxData: number,
     inputValue: bigint,
   ): Promise<bigint[]> {
     // ETH -> wstETH
@@ -107,7 +107,7 @@ export class CurveStethBridgeData implements BridgeDataFieldGetters {
     inputAssetB: AztecAsset,
     outputAssetA: AztecAsset,
     outputAssetB: AztecAsset,
-    auxData: bigint,
+    auxData: number,
   ): Promise<AssetValue[]> {
     const { postTotalPooledEther } = await this.lidoOracleContract.getLastCompletedReportDelta();
     return [

--- a/src/client/donation/donation-bridge-data.ts
+++ b/src/client/donation/donation-bridge-data.ts
@@ -74,7 +74,7 @@ export class DonationBridgeData implements BridgeDataFieldGetters {
     return [
       {
         assetId: inputAssetA.id,
-        amount: 0n,
+        value: 0n,
       },
     ];
   }

--- a/src/client/donation/donation-bridge-data.ts
+++ b/src/client/donation/donation-bridge-data.ts
@@ -60,15 +60,8 @@ export class DonationBridgeData implements BridgeDataFieldGetters {
     }
   }
 
-  async getAPR(
-    inputAssetA: AztecAsset,
-    inputAssetB: AztecAsset,
-    outputAssetA: AztecAsset,
-    outputAssetB: AztecAsset,
-    auxData: bigint,
-    inputValue: bigint,
-  ): Promise<number[]> {
-    return [0];
+  async getAPR(inputAssetA: AztecAsset, outputAssetA: AztecAsset): Promise<number> {
+    return 0;
   }
 
   async getMarketSize(

--- a/src/client/donation/donation-bridge-data.ts
+++ b/src/client/donation/donation-bridge-data.ts
@@ -1,16 +1,9 @@
-import { EthAddress } from "@aztec/barretenberg/address";
+import { AssetValue } from "@aztec/barretenberg/asset";
 import { EthereumProvider } from "@aztec/barretenberg/blockchain";
 import { Web3Provider } from "@ethersproject/providers";
 import { IRollupProcessor, IRollupProcessor__factory } from "../../../typechain-types";
 import { createWeb3Provider } from "../aztec/provider";
-import {
-  AssetValue,
-  AuxDataConfig,
-  AztecAsset,
-  AztecAssetType,
-  BridgeDataFieldGetters,
-  SolidityType,
-} from "../bridge-data";
+import { AuxDataConfig, AztecAsset, AztecAssetType, BridgeDataFieldGetters, SolidityType } from "../bridge-data";
 
 export class DonationBridgeData implements BridgeDataFieldGetters {
   private constructor(private ethersProvider: Web3Provider, private rollupProcessor: IRollupProcessor) {}

--- a/src/client/donation/donation-bridge-data.ts
+++ b/src/client/donation/donation-bridge-data.ts
@@ -60,7 +60,7 @@ export class DonationBridgeData implements BridgeDataFieldGetters {
     }
   }
 
-  async getAPR(inputAssetA: AztecAsset, outputAssetA: AztecAsset): Promise<number> {
+  async getAPR(yieldAsset: AztecAsset): Promise<number> {
     return 0;
   }
 

--- a/src/client/donation/donation-bridge-data.ts
+++ b/src/client/donation/donation-bridge-data.ts
@@ -40,7 +40,7 @@ export class DonationBridgeData implements BridgeDataFieldGetters {
     inputAssetB: AztecAsset,
     outputAssetA: AztecAsset,
     outputAssetB: AztecAsset,
-    auxData: bigint,
+    auxData: number,
     inputValue: bigint,
   ): Promise<bigint[]> {
     if (
@@ -62,7 +62,7 @@ export class DonationBridgeData implements BridgeDataFieldGetters {
     inputAssetB: AztecAsset,
     outputAssetA: AztecAsset,
     outputAssetB: AztecAsset,
-    auxData: bigint,
+    auxData: number,
   ): Promise<AssetValue[]> {
     return [
       {

--- a/src/client/element/element-bridge-data.test.ts
+++ b/src/client/element/element-bridge-data.test.ts
@@ -270,7 +270,7 @@ describe("element bridge data", () => {
 
   it("should return the correct yield of the tranche", async () => {
     const now = Math.floor(Date.now() / 1000);
-    const expiry = BigInt(now + 86400 * 30);
+    const expiry = now + 86400 * 30;
     const trancheAddress = "0x90ca5cef5b29342b229fb8ae2db5d8f4f894d652";
     const poolId = "0x90ca5cef5b29342b229fb8ae2db5d8f4f894d6520002000000000000000000b5";
     const interest = BigInt(1e16);
@@ -321,7 +321,7 @@ describe("element bridge data", () => {
       BigInt(inputValue),
     );
     const YEAR = 60 * 60 * 24 * 365;
-    const timeToExpiration = expiry - BigInt(now);
+    const timeToExpiration = BigInt(expiry - now);
     const scaledOut = (BigInt(interest) * elementBridgeData.scalingFactor) / timeToExpiration;
     const yearlyOut = (scaledOut * BigInt(YEAR)) / elementBridgeData.scalingFactor;
     const scaledPercentage = (yearlyOut * elementBridgeData.scalingFactor) / inputValue;

--- a/src/client/element/element-bridge-data.test.ts
+++ b/src/client/element/element-bridge-data.test.ts
@@ -1,17 +1,16 @@
-import { ChainProperties, ElementBridgeData } from "./element-bridge-data";
+import { EthAddress } from "@aztec/barretenberg/address";
+import { BridgeCallData } from "@aztec/barretenberg/bridge_call_data";
 import { BigNumber } from "ethers";
-import { randomBytes } from "crypto";
 import {
-  IRollupProcessor,
   ElementBridge,
-  IVault,
   ElementBridge__factory,
+  IRollupProcessor,
   IRollupProcessor__factory,
+  IVault,
   IVault__factory,
 } from "../../../typechain-types";
-import { BridgeCallData } from "@aztec/barretenberg/bridge_call_data";
 import { AztecAssetType } from "../bridge-data";
-import { EthAddress } from "@aztec/barretenberg/address";
+import { ChainProperties, ElementBridgeData } from "./element-bridge-data";
 
 jest.mock("../aztec/provider", () => ({
   createWeb3Provider: jest.fn(),
@@ -301,22 +300,22 @@ describe("element bridge data", () => {
       {
         assetType: AztecAssetType.ERC20,
         erc20Address: testAddress,
-        id: 1n,
+        id: 1,
       },
       {
         assetType: AztecAssetType.NOT_USED,
         erc20Address: EthAddress.ZERO,
-        id: 0n,
+        id: 0,
       },
       {
         assetType: AztecAssetType.ERC20,
         erc20Address: testAddress,
-        id: 1n,
+        id: 1,
       },
       {
         assetType: AztecAssetType.NOT_USED,
         erc20Address: EthAddress.ZERO,
-        id: 0n,
+        id: 0,
       },
       expiry,
       BigInt(inputValue),
@@ -330,57 +329,5 @@ describe("element bridge data", () => {
     const percent = Number(percentage2sf) / 100;
 
     expect(output[0]).toBe(percent);
-  });
-
-  it("should return the correct market size for a given tranche", async () => {
-    const expiry = BigInt(Date.now() + 86400 * 30);
-    const tokenAddress = EthAddress.random().toString();
-    const poolId = "0x90ca5cef5b29342b229fb8ae2db5d8f4f894d6520002000000000000000000b5";
-    const tokenBalance = 10e18,
-      elementBridge = {
-        hashAssetAndExpiry: jest.fn().mockResolvedValue("0xa"),
-        pools: jest.fn().mockResolvedValue([tokenAddress, "", poolId]),
-        provider: {
-          getBlockNumber: jest.fn().mockResolvedValue(200),
-          getBlock: jest.fn().mockResolvedValue({ timestamp: +now.toString(), number: 200 }),
-        },
-      };
-
-    balancerContract = {
-      ...balancerContract,
-      getPoolTokens: jest.fn().mockResolvedValue([[tokenAddress], [BigNumber.from(BigInt(tokenBalance))]]),
-    };
-
-    const elementBridgeData = createElementBridgeData(
-      elementBridge as any,
-      balancerContract as any,
-      rollupContract as any,
-    );
-    const marketSize = await elementBridgeData.getMarketSize(
-      {
-        assetType: AztecAssetType.ERC20,
-        erc20Address: EthAddress.random(),
-        id: 1n,
-      },
-      {
-        assetType: AztecAssetType.NOT_USED,
-        erc20Address: EthAddress.ZERO,
-        id: 0n,
-      },
-      {
-        assetType: AztecAssetType.ERC20,
-        erc20Address: testAddress,
-        id: 1n,
-      },
-      {
-        assetType: AztecAssetType.NOT_USED,
-        erc20Address: EthAddress.ZERO,
-        id: 0n,
-      },
-      expiry,
-    );
-    expect(marketSize[0].assetId).toBe(BigInt(tokenAddress));
-    expect(marketSize[0].value).toBe(BigInt(tokenBalance));
-    expect(marketSize.length).toBe(1);
   });
 });

--- a/src/client/element/element-bridge-data.test.ts
+++ b/src/client/element/element-bridge-data.test.ts
@@ -199,7 +199,7 @@ describe("element bridge data", () => {
     const fullTime = expiration1 - startDate;
     const out = defiEvent.totalInputValue + (delta * timeElapsed) / fullTime;
 
-    expect(daiValue.amount).toStrictEqual(out / userShareDivisor);
+    expect(daiValue.value).toStrictEqual(out / userShareDivisor);
     expect(Number(daiValue.assetId)).toStrictEqual(bridgeCallData1.inputAssetIdA);
   });
 
@@ -226,7 +226,7 @@ describe("element bridge data", () => {
       const timeElapsed = BigInt(now) - startDate;
       const fullTime = BigInt(bridgeCallData.auxData) - startDate;
       const out = defiEvent.totalInputValue + (delta * timeElapsed) / fullTime;
-      expect(daiValue.amount).toStrictEqual(out / userShareDivisor);
+      expect(daiValue.value).toStrictEqual(out / userShareDivisor);
       expect(Number(daiValue.assetId)).toStrictEqual(bridgeCallData.inputAssetIdA);
     };
     await testInteraction(56);
@@ -380,7 +380,7 @@ describe("element bridge data", () => {
       expiry,
     );
     expect(marketSize[0].assetId).toBe(BigInt(tokenAddress));
-    expect(marketSize[0].amount).toBe(BigInt(tokenBalance));
+    expect(marketSize[0].value).toBe(BigInt(tokenBalance));
     expect(marketSize.length).toBe(1);
   });
 });

--- a/src/client/element/element-bridge-data.ts
+++ b/src/client/element/element-bridge-data.ts
@@ -205,7 +205,7 @@ export class ElementBridgeData {
     return [
       {
         assetId: BigInt(BridgeCallData.fromBigInt(defiEvent.encodedBridgeCallData).inputAssetIdA),
-        amount: userPresentValue,
+        value: userPresentValue,
       },
     ];
   }
@@ -343,7 +343,7 @@ export class ElementBridgeData {
     return tokenBalances[0].map((address, index) => {
       return {
         assetId: BigInt(address), // todo fetch via the sdk @Leila
-        amount: tokenBalances[1][index].toBigInt(),
+        value: tokenBalances[1][index].toBigInt(),
       };
     });
   }

--- a/src/client/element/element-bridge-data.ts
+++ b/src/client/element/element-bridge-data.ts
@@ -204,7 +204,7 @@ export class ElementBridgeData {
 
     return [
       {
-        assetId: BigInt(BridgeCallData.fromBigInt(defiEvent.encodedBridgeCallData).inputAssetIdA),
+        assetId: BridgeCallData.fromBigInt(defiEvent.encodedBridgeCallData).inputAssetIdA,
         value: userPresentValue,
       },
     ];
@@ -322,30 +322,6 @@ export class ElementBridgeData {
     const percentage2sf = (percentageScaled * 10000n) / this.scalingFactor;
 
     return [Number(percentage2sf) / 100];
-  }
-
-  async getMarketSize(
-    inputAssetA: AztecAsset,
-    inputAssetB: AztecAsset,
-    outputAssetA: AztecAsset,
-    outputAssetB: AztecAsset,
-    auxData: bigint,
-  ): Promise<AssetValue[]> {
-    const assetExpiryHash = await this.elementBridgeContract.hashAssetAndExpiry(
-      inputAssetA.erc20Address.toString(),
-      auxData,
-    );
-    const pool = await this.elementBridgeContract.pools(assetExpiryHash);
-    const poolId = pool.poolId;
-    const tokenBalances = await this.balancerContract.getPoolTokens(poolId);
-
-    // todo return the correct aztec assetIds
-    return tokenBalances[0].map((address, index) => {
-      return {
-        assetId: BigInt(address), // todo fetch via the sdk @Leila
-        value: tokenBalances[1][index].toBigInt(),
-      };
-    });
   }
 
   async getExpiration(interactionNonce: bigint): Promise<bigint> {

--- a/src/client/element/element-bridge-data.ts
+++ b/src/client/element/element-bridge-data.ts
@@ -264,7 +264,7 @@ export class ElementBridgeData {
     inputAssetB: AztecAsset,
     outputAssetA: AztecAsset,
     outputAssetB: AztecAsset,
-    auxData: bigint,
+    auxData: number,
     inputValue: bigint,
   ): Promise<bigint[]> {
     // bridge is async the third parameter represents this
@@ -276,7 +276,7 @@ export class ElementBridgeData {
     inputAssetB: AztecAsset,
     outputAssetA: AztecAsset,
     outputAssetB: AztecAsset,
-    auxData: bigint,
+    auxData: number,
     inputValue: bigint,
   ): Promise<number[]> {
     const assetExpiryHash = await this.elementBridgeContract.hashAssetAndExpiry(
@@ -313,7 +313,7 @@ export class ElementBridgeData {
 
     const outputAssetAValue = deltas[1];
 
-    const timeToExpiration = auxData - BigInt(latestBlock.timestamp);
+    const timeToExpiration = BigInt(auxData - latestBlock.timestamp);
 
     const YEAR = 60n * 60n * 24n * 365n;
     const interest = -outputAssetAValue.toBigInt() - inputValue;

--- a/src/client/element/element-bridge-data.ts
+++ b/src/client/element/element-bridge-data.ts
@@ -1,17 +1,18 @@
-import { AssetValue, BridgeDataFieldGetters, AuxDataConfig, AztecAsset, SolidityType } from "../bridge-data";
+import { EthAddress } from "@aztec/barretenberg/address";
+import { AssetValue } from "@aztec/barretenberg/asset";
+import { EthereumProvider } from "@aztec/barretenberg/blockchain";
+import { BridgeCallData } from "@aztec/barretenberg/bridge_call_data";
 import {
   ElementBridge,
-  IVault,
-  IRollupProcessor,
   ElementBridge__factory,
-  IVault__factory,
+  IRollupProcessor,
   IRollupProcessor__factory,
+  IVault,
+  IVault__factory,
 } from "../../../typechain-types";
 import { AsyncDefiBridgeProcessedEvent } from "../../../typechain-types/IRollupProcessor";
-import { EthereumProvider } from "@aztec/barretenberg/blockchain";
 import { createWeb3Provider } from "../aztec/provider";
-import { EthAddress } from "@aztec/barretenberg/address";
-import { BridgeCallData } from "@aztec/barretenberg/bridge_call_data";
+import { AuxDataConfig, AztecAsset, SolidityType } from "../bridge-data";
 
 export type BatchSwapStep = {
   poolId: string;

--- a/src/client/element/element-bridge-data.ts
+++ b/src/client/element/element-bridge-data.ts
@@ -68,7 +68,7 @@ const decodeEvent = async (event: AsyncDefiBridgeProcessedEvent): Promise<EventB
   return newEventBlock;
 };
 
-export class ElementBridgeData implements BridgeDataFieldGetters {
+export class ElementBridgeData {
   public scalingFactor = BigInt(1n * 10n ** 18n);
   private interactionBlockNumbers: Array<EventBlock> = [];
 

--- a/src/client/erc4626/erc4626-bridge-data.test.ts
+++ b/src/client/erc4626/erc4626-bridge-data.test.ts
@@ -13,7 +13,6 @@ type Mockify<T> = {
 };
 
 describe("ERC4626 bridge data", () => {
-  let erc20Contract: Mockify<IERC20>;
   let erc4626Contract: Mockify<IERC4626>;
 
   let ethAsset: AztecAsset;
@@ -23,22 +22,22 @@ describe("ERC4626 bridge data", () => {
 
   beforeAll(() => {
     ethAsset = {
-      id: 0n,
+      id: 0,
       assetType: AztecAssetType.ETH,
       erc20Address: EthAddress.ZERO,
     };
     mplAsset = {
-      id: 10n, // Asset has not yet been registered on RollupProcessor so this id is random
+      id: 10, // Asset has not yet been registered on RollupProcessor so this id is random
       assetType: AztecAssetType.ERC20,
       erc20Address: EthAddress.fromString("0x33349B282065b0284d756F0577FB39c158F935e6"),
     };
     xmplAsset = {
-      id: 1n,
+      id: 1,
       assetType: AztecAssetType.ERC20,
       erc20Address: EthAddress.fromString("0x4937A209D4cDbD3ecD48857277cfd4dA4D82914c"),
     };
     emptyAsset = {
-      id: 0n,
+      id: 0,
       assetType: AztecAssetType.NOT_USED,
       erc20Address: EthAddress.ZERO,
     };

--- a/src/client/erc4626/erc4626-bridge-data.test.ts
+++ b/src/client/erc4626/erc4626-bridge-data.test.ts
@@ -1,6 +1,6 @@
 import { EthAddress } from "@aztec/barretenberg/address";
 import { BigNumber } from "ethers";
-import { IERC20, IERC20__factory, IERC4626, IERC4626__factory } from "../../../typechain-types";
+import { IERC4626, IERC4626__factory } from "../../../typechain-types";
 import { AztecAsset, AztecAssetType } from "../bridge-data";
 import { ERC4626BridgeData } from "./erc4626-bridge-data";
 
@@ -85,7 +85,7 @@ describe("ERC4626 bridge data", () => {
 
     // Test the code using mocked controller
     const expectedOutput = (
-      await erc4626BridgeData.getExpectedOutput(mplAsset, emptyAsset, xmplAsset, emptyAsset, 0n, 10n ** 18n)
+      await erc4626BridgeData.getExpectedOutput(mplAsset, emptyAsset, xmplAsset, emptyAsset, 0, 10n ** 18n)
     )[0];
     expect(expectedOutput).toBe(111111n);
   });
@@ -102,7 +102,7 @@ describe("ERC4626 bridge data", () => {
 
     // Test the code using mocked controller
     const expectedOutput = (
-      await erc4626BridgeData.getExpectedOutput(xmplAsset, emptyAsset, mplAsset, emptyAsset, 1n, 10n ** 18n)
+      await erc4626BridgeData.getExpectedOutput(xmplAsset, emptyAsset, mplAsset, emptyAsset, 1, 10n ** 18n)
     )[0];
     expect(expectedOutput).toBe(111111n);
   });

--- a/src/client/erc4626/erc4626-bridge-data.ts
+++ b/src/client/erc4626/erc4626-bridge-data.ts
@@ -1,16 +1,10 @@
 import { EthAddress } from "@aztec/barretenberg/address";
 import { EthereumProvider } from "@aztec/barretenberg/blockchain";
 import { Web3Provider } from "@ethersproject/providers";
-import { IERC20__factory, IERC4626__factory } from "../../../typechain-types";
+import { IERC4626__factory } from "../../../typechain-types";
 import { createWeb3Provider } from "../aztec/provider";
-import {
-  AssetValue,
-  AuxDataConfig,
-  AztecAsset,
-  AztecAssetType,
-  BridgeDataFieldGetters,
-  SolidityType,
-} from "../bridge-data";
+import { AuxDataConfig, AztecAsset, BridgeDataFieldGetters, SolidityType } from "../bridge-data";
+import { AssetValue } from "@aztec/barretenberg/asset";
 
 export class ERC4626BridgeData implements BridgeDataFieldGetters {
   readonly WETH = EthAddress.fromString("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2");

--- a/src/client/erc4626/erc4626-bridge-data.ts
+++ b/src/client/erc4626/erc4626-bridge-data.ts
@@ -4,7 +4,6 @@ import { Web3Provider } from "@ethersproject/providers";
 import { IERC4626__factory } from "../../../typechain-types";
 import { createWeb3Provider } from "../aztec/provider";
 import { AuxDataConfig, AztecAsset, BridgeDataFieldGetters, SolidityType } from "../bridge-data";
-import { AssetValue } from "@aztec/barretenberg/asset";
 
 export class ERC4626BridgeData implements BridgeDataFieldGetters {
   readonly WETH = EthAddress.fromString("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2");
@@ -63,16 +62,16 @@ export class ERC4626BridgeData implements BridgeDataFieldGetters {
     inputAssetB: AztecAsset,
     outputAssetA: AztecAsset,
     outputAssetB: AztecAsset,
-    auxData: bigint,
+    auxData: number,
     inputValue: bigint,
   ): Promise<bigint[]> {
-    if (auxData === 0n) {
+    if (auxData === 0) {
       // Issuing
       const shareAddress = outputAssetA.erc20Address;
       const vault = IERC4626__factory.connect(shareAddress.toString(), this.ethersProvider);
       const amountOut = await vault.previewDeposit(inputValue);
       return [amountOut.toBigInt()];
-    } else if (auxData === 1n) {
+    } else if (auxData === 1) {
       // Redeeming
       const shareAddress = inputAssetA.erc20Address;
       const vault = IERC4626__factory.connect(shareAddress.toString(), this.ethersProvider);

--- a/src/client/example/example-bridge-data.ts
+++ b/src/client/example/example-bridge-data.ts
@@ -6,9 +6,9 @@ export class ExampleBridgeData implements BridgeDataFieldGetters {
 
   // @dev This function should be implemented for stateful bridges. It should return an array of AssetValue's
   // @dev which define how much a given interaction is worth in terms of Aztec asset ids.
-  // @param bigint interactionNonce the interaction nonce to return the value for
+  // @param interactionNonce the nonce to return the value for
 
-  async getInteractionPresentValue(interactionNonce: bigint): Promise<AssetValue[]> {
+  async getInteractionPresentValue(interactionNonce: number): Promise<AssetValue[]> {
     return [
       {
         assetId: 1,

--- a/src/client/example/example-bridge-data.ts
+++ b/src/client/example/example-bridge-data.ts
@@ -11,7 +11,7 @@ export class ExampleBridgeData implements BridgeDataFieldGetters {
     return [
       {
         assetId: 1n,
-        amount: 1000n,
+        value: 1000n,
       },
     ];
   }
@@ -52,6 +52,6 @@ export class ExampleBridgeData implements BridgeDataFieldGetters {
     outputAssetB: AztecAsset,
     auxData: bigint,
   ): Promise<AssetValue[]> {
-    return [{ assetId: 0n, amount: 100n }];
+    return [{ assetId: 0n, value: 100n }];
   }
 }

--- a/src/client/example/example-bridge-data.ts
+++ b/src/client/example/example-bridge-data.ts
@@ -1,4 +1,5 @@
-import { AssetValue, AuxDataConfig, AztecAsset, BridgeDataFieldGetters, SolidityType } from "../bridge-data";
+import { AuxDataConfig, AztecAsset, BridgeDataFieldGetters, SolidityType } from "../bridge-data";
+import { AssetValue } from "@aztec/barretenberg/asset";
 
 export class ExampleBridgeData implements BridgeDataFieldGetters {
   constructor() {}

--- a/src/client/example/example-bridge-data.ts
+++ b/src/client/example/example-bridge-data.ts
@@ -10,7 +10,7 @@ export class ExampleBridgeData implements BridgeDataFieldGetters {
   async getInteractionPresentValue(interactionNonce: bigint): Promise<AssetValue[]> {
     return [
       {
-        assetId: 1n,
+        assetId: 1,
         value: 1000n,
       },
     ];
@@ -52,6 +52,6 @@ export class ExampleBridgeData implements BridgeDataFieldGetters {
     outputAssetB: AztecAsset,
     auxData: bigint,
   ): Promise<AssetValue[]> {
-    return [{ assetId: 0n, value: 100n }];
+    return [{ assetId: 0, value: 100n }];
   }
 }

--- a/src/client/example/example-bridge-data.ts
+++ b/src/client/example/example-bridge-data.ts
@@ -40,7 +40,7 @@ export class ExampleBridgeData implements BridgeDataFieldGetters {
     inputAssetB: AztecAsset,
     outputAssetA: AztecAsset,
     outputAssetB: AztecAsset,
-    auxData: bigint,
+    auxData: number,
     inputValue: bigint,
   ): Promise<bigint[]> {
     return [100n, 0n];
@@ -51,7 +51,7 @@ export class ExampleBridgeData implements BridgeDataFieldGetters {
     inputAssetB: AztecAsset,
     outputAssetA: AztecAsset,
     outputAssetB: AztecAsset,
-    auxData: bigint,
+    auxData: number,
   ): Promise<AssetValue[]> {
     return [{ assetId: 0, value: 100n }];
   }

--- a/src/client/lido/lido-bridge-data.test.ts
+++ b/src/client/lido/lido-bridge-data.test.ts
@@ -164,7 +164,7 @@ describe("lido bridge data", () => {
 
     lidoBridgeData = createLidoBridgeData(wstethContract as any, curvePoolContract as any, lidoOracleContract as any);
 
-    const apr = await lidoBridgeData.getAPR(ethAsset, wstETHAsset);
+    const apr = await lidoBridgeData.getAPR(wstETHAsset);
     expect(apr).toBe(expectedAPR);
   });
 });

--- a/src/client/lido/lido-bridge-data.test.ts
+++ b/src/client/lido/lido-bridge-data.test.ts
@@ -75,7 +75,7 @@ describe("lido bridge data", () => {
       emptyAsset,
       wstETHAsset,
       emptyAsset,
-      0n,
+      0,
       depositAmount,
     );
     expect(expectedOutput == output[0]).toBeTruthy();
@@ -98,7 +98,7 @@ describe("lido bridge data", () => {
       emptyAsset,
       wstETHAsset,
       emptyAsset,
-      0n,
+      0,
       depositAmount,
     );
     expect(expectedOutput == output[0]).toBeTruthy();
@@ -127,7 +127,7 @@ describe("lido bridge data", () => {
       emptyAsset,
       ethAsset,
       emptyAsset,
-      0n,
+      0,
       depositAmount,
     );
 

--- a/src/client/lido/lido-bridge-data.test.ts
+++ b/src/client/lido/lido-bridge-data.test.ts
@@ -134,9 +134,8 @@ describe("lido bridge data", () => {
     expect(expectedOutput == output[0]).toBeTruthy();
   });
 
-  it("should correctly return the expectedYearlyOutput", async () => {
-    const depositAmount = BigInt(1 * 10e18);
-    const expectedOutput = 4.32;
+  it("should correctly return APR", async () => {
+    const expectedAPR = 4.32;
 
     wstethContract = {
       ...wstethContract,
@@ -165,7 +164,7 @@ describe("lido bridge data", () => {
 
     lidoBridgeData = createLidoBridgeData(wstethContract as any, curvePoolContract as any, lidoOracleContract as any);
 
-    const output = await lidoBridgeData.getAPR(wstETHAsset, emptyAsset, ethAsset, emptyAsset, 0n, depositAmount);
-    expect(expectedOutput).toBe(output[0]);
+    const apr = await lidoBridgeData.getAPR(ethAsset, wstETHAsset);
+    expect(apr).toBe(expectedAPR);
   });
 });

--- a/src/client/lido/lido-bridge-data.test.ts
+++ b/src/client/lido/lido-bridge-data.test.ts
@@ -42,17 +42,17 @@ describe("lido bridge data", () => {
 
   beforeAll(() => {
     ethAsset = {
-      id: 1n,
+      id: 1,
       assetType: AztecAssetType.ETH,
       erc20Address: EthAddress.ZERO,
     };
     wstETHAsset = {
-      id: 2n,
+      id: 2,
       assetType: AztecAssetType.ERC20,
       erc20Address: EthAddress.fromString("0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0"),
     };
     emptyAsset = {
-      id: 0n,
+      id: 0,
       assetType: AztecAssetType.NOT_USED,
       erc20Address: EthAddress.ZERO,
     };

--- a/src/client/lido/lido-bridge-data.ts
+++ b/src/client/lido/lido-bridge-data.ts
@@ -1,5 +1,4 @@
 import {
-  AssetValue,
   AuxDataConfig,
   AztecAsset,
   SolidityType,
@@ -19,6 +18,7 @@ import {
 import { EthereumProvider } from "@aztec/barretenberg/blockchain";
 import { createWeb3Provider } from "../aztec/provider";
 import { EthAddress } from "@aztec/barretenberg/address";
+import { AssetValue } from "@aztec/barretenberg/asset";
 
 export class LidoBridgeData implements BridgeDataFieldGetters {
   public scalingFactor: bigint = 1n * 10n ** 18n;

--- a/src/client/lido/lido-bridge-data.ts
+++ b/src/client/lido/lido-bridge-data.ts
@@ -53,7 +53,7 @@ export class LidoBridgeData implements BridgeDataFieldGetters {
   ];
 
   // Lido bridge contract is stateless
-  async getInteractionPresentValue(interactionNonce: bigint): Promise<AssetValue[]> {
+  async getInteractionPresentValue(interactionNonce: number): Promise<AssetValue[]> {
     return [];
   }
 

--- a/src/client/lido/lido-bridge-data.ts
+++ b/src/client/lido/lido-bridge-data.ts
@@ -116,7 +116,7 @@ export class LidoBridgeData implements BridgeDataFieldGetters {
     return [
       {
         assetId: inputAssetA.id,
-        amount: postTotalPooledEther.toBigInt(),
+        value: postTotalPooledEther.toBigInt(),
       },
     ];
   }

--- a/src/client/lido/lido-bridge-data.ts
+++ b/src/client/lido/lido-bridge-data.ts
@@ -90,19 +90,16 @@ export class LidoBridgeData implements BridgeDataFieldGetters {
     }
     return [0n];
   }
-  async getAPR(inputAssetA: AztecAsset, outputAssetA: AztecAsset): Promise<number> {
+  async getAPR(yieldAsset: AztecAsset): Promise<number> {
     const YEAR = 60n * 60n * 24n * 365n;
-    if (inputAssetA.assetType === AztecAssetType.ETH) {
-      const { postTotalPooledEther, preTotalPooledEther, timeElapsed } =
-        await this.lidoOracleContract.getLastCompletedReportDelta();
+    const { postTotalPooledEther, preTotalPooledEther, timeElapsed } =
+      await this.lidoOracleContract.getLastCompletedReportDelta();
 
-      const scaledAPR =
-        ((postTotalPooledEther.toBigInt() - preTotalPooledEther.toBigInt()) * YEAR * this.scalingFactor) /
-        (preTotalPooledEther.toBigInt() * timeElapsed.toBigInt());
+    const scaledAPR =
+      ((postTotalPooledEther.toBigInt() - preTotalPooledEther.toBigInt()) * YEAR * this.scalingFactor) /
+      (preTotalPooledEther.toBigInt() * timeElapsed.toBigInt());
 
-      return Number(scaledAPR / (this.scalingFactor / 10000n)) / 100;
-    }
-    return 0;
+    return Number(scaledAPR / (this.scalingFactor / 10000n)) / 100;
   }
 
   async getMarketSize(

--- a/src/client/lido/lido-bridge-data.ts
+++ b/src/client/lido/lido-bridge-data.ts
@@ -90,16 +90,9 @@ export class LidoBridgeData implements BridgeDataFieldGetters {
     }
     return [0n];
   }
-  async getAPR(
-    inputAssetA: AztecAsset,
-    inputAssetB: AztecAsset,
-    outputAssetA: AztecAsset,
-    outputAssetB: AztecAsset,
-    auxData: bigint,
-    inputValue: bigint,
-  ): Promise<number[]> {
+  async getAPR(inputAssetA: AztecAsset, outputAssetA: AztecAsset): Promise<number> {
     const YEAR = 60n * 60n * 24n * 365n;
-    if (outputAssetA.assetType === AztecAssetType.ETH) {
+    if (inputAssetA.assetType === AztecAssetType.ETH) {
       const { postTotalPooledEther, preTotalPooledEther, timeElapsed } =
         await this.lidoOracleContract.getLastCompletedReportDelta();
 
@@ -107,9 +100,9 @@ export class LidoBridgeData implements BridgeDataFieldGetters {
         ((postTotalPooledEther.toBigInt() - preTotalPooledEther.toBigInt()) * YEAR * this.scalingFactor) /
         (preTotalPooledEther.toBigInt() * timeElapsed.toBigInt());
 
-      return [Number(scaledAPR / (this.scalingFactor / 10000n)) / 100];
+      return Number(scaledAPR / (this.scalingFactor / 10000n)) / 100;
     }
-    return [0];
+    return 0;
   }
 
   async getMarketSize(

--- a/src/client/lido/lido-bridge-data.ts
+++ b/src/client/lido/lido-bridge-data.ts
@@ -72,7 +72,7 @@ export class LidoBridgeData implements BridgeDataFieldGetters {
     inputAssetB: AztecAsset,
     outputAssetA: AztecAsset,
     outputAssetB: AztecAsset,
-    auxData: bigint,
+    auxData: number,
     inputValue: bigint,
   ): Promise<bigint[]> {
     // ETH -> wstETH
@@ -107,7 +107,7 @@ export class LidoBridgeData implements BridgeDataFieldGetters {
     inputAssetB: AztecAsset,
     outputAssetA: AztecAsset,
     outputAssetB: AztecAsset,
-    auxData: bigint,
+    auxData: number,
   ): Promise<AssetValue[]> {
     const { postTotalPooledEther } = await this.lidoOracleContract.getLastCompletedReportDelta();
     return [

--- a/src/client/yearn/yearn-bridge-data.test.ts
+++ b/src/client/yearn/yearn-bridge-data.test.ts
@@ -32,37 +32,37 @@ describe("Testing Yearn auxData", () => {
 
   beforeAll(() => {
     ethAsset = {
-      id: 0n,
+      id: 0,
       assetType: AztecAssetType.ETH,
       erc20Address: EthAddress.ZERO,
     };
     daiAsset = {
-      id: 1n,
+      id: 1,
       assetType: AztecAssetType.ERC20,
       erc20Address: EthAddress.fromString("0x6B175474E89094C44Da98b954EedeAC495271d0F"),
     };
     yvDaiAsset = {
-      id: 2n,
+      id: 2,
       assetType: AztecAssetType.ERC20,
       erc20Address: EthAddress.fromString("0xdA816459F1AB5631232FE5e97a05BBBb94970c95"),
     };
     yvEthAsset = {
-      id: 3n,
+      id: 3,
       assetType: AztecAssetType.ERC20,
       erc20Address: EthAddress.fromString("0xa258c4606ca8206d8aa700ce2143d7db854d168c"),
     };
     wethAsset = {
-      id: 4n,
+      id: 4,
       assetType: AztecAssetType.ERC20,
       erc20Address: EthAddress.fromString("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"),
     };
     yvUSDCAsset = {
-      id: 5n,
+      id: 5,
       assetType: AztecAssetType.ERC20,
       erc20Address: EthAddress.fromString("0xa354F35829Ae975e850e23e9615b11Da1B3dC4DE"),
     };
     emptyAsset = {
-      id: 100n,
+      id: 100,
       assetType: AztecAssetType.NOT_USED,
       erc20Address: EthAddress.ZERO,
     };
@@ -88,14 +88,14 @@ describe("Testing Yearn auxData", () => {
 
     rollupProcessorContract = {
       ...rollupProcessorContract,
-      getSupportedAsset: jest.fn((id: bigint) => {
-        if (id === 1n) {
+      getSupportedAsset: jest.fn((id: number) => {
+        if (id === 1) {
           return daiAsset.erc20Address.toString();
-        } else if (id === 2n) {
+        } else if (id === 2) {
           return yvDaiAsset.erc20Address.toString();
-        } else if (id === 3n) {
+        } else if (id === 3) {
           return yvEthAsset.erc20Address.toString();
-        } else if (id === 4n) {
+        } else if (id === 4) {
           return wethAsset.erc20Address.toString();
         }
       }),
@@ -129,14 +129,14 @@ describe("Testing Yearn auxData", () => {
 
     rollupProcessorContract = {
       ...rollupProcessorContract,
-      getSupportedAsset: jest.fn((id: bigint) => {
-        if (id === 1n) {
+      getSupportedAsset: jest.fn((id: number) => {
+        if (id === 1) {
           return daiAsset.erc20Address.toString();
-        } else if (id === 2n) {
+        } else if (id === 2) {
           return yvDaiAsset.erc20Address.toString();
-        } else if (id === 3n) {
+        } else if (id === 3) {
           return yvEthAsset.erc20Address.toString();
-        } else if (id === 4n) {
+        } else if (id === 4) {
           return wethAsset.erc20Address.toString();
         }
       }),
@@ -234,16 +234,16 @@ describe("Testing Yearn auxData", () => {
 
     rollupProcessorContract = {
       ...rollupProcessorContract,
-      getSupportedAsset: jest.fn((id: bigint) => {
-        if (id === 1n) {
+      getSupportedAsset: jest.fn((id: number) => {
+        if (id === 1) {
           return daiAsset.erc20Address.toString();
-        } else if (id === 2n) {
+        } else if (id === 2) {
           return yvDaiAsset.erc20Address.toString();
-        } else if (id === 3n) {
+        } else if (id === 3) {
           return yvEthAsset.erc20Address.toString();
-        } else if (id === 4n) {
+        } else if (id === 4) {
           return wethAsset.erc20Address.toString();
-        } else if (id === 5n) {
+        } else if (id === 5) {
           return yvUSDCAsset.erc20Address.toString();
         }
       }),
@@ -291,27 +291,27 @@ describe("Testing Yearn expectedOutput", () => {
 
   beforeAll(() => {
     ethAsset = {
-      id: 0n,
+      id: 0,
       assetType: AztecAssetType.ETH,
       erc20Address: EthAddress.ZERO,
     };
     daiAsset = {
-      id: 1n,
+      id: 1,
       assetType: AztecAssetType.ERC20,
       erc20Address: EthAddress.fromString("0x6B175474E89094C44Da98b954EedeAC495271d0F"),
     };
     yvDaiAsset = {
-      id: 2n,
+      id: 2,
       assetType: AztecAssetType.ERC20,
       erc20Address: EthAddress.fromString("0xdA816459F1AB5631232FE5e97a05BBBb94970c95"),
     };
     yvEthAsset = {
-      id: 3n,
+      id: 3,
       assetType: AztecAssetType.ERC20,
       erc20Address: EthAddress.fromString("0xa258c4606ca8206d8aa700ce2143d7db854d168c"),
     };
     emptyAsset = {
-      id: 100n,
+      id: 100,
       assetType: AztecAssetType.NOT_USED,
       erc20Address: EthAddress.ZERO,
     };
@@ -418,27 +418,27 @@ describe("Testing Yearn getExpectedYield", () => {
 
   beforeAll(() => {
     ethAsset = {
-      id: 0n,
+      id: 0,
       assetType: AztecAssetType.ETH,
       erc20Address: EthAddress.ZERO,
     };
     daiAsset = {
-      id: 1n,
+      id: 1,
       assetType: AztecAssetType.ERC20,
       erc20Address: EthAddress.fromString("0x6B175474E89094C44Da98b954EedeAC495271d0F"),
     };
     yvDaiAsset = {
-      id: 2n,
+      id: 2,
       assetType: AztecAssetType.ERC20,
       erc20Address: EthAddress.fromString("0xdA816459F1AB5631232FE5e97a05BBBb94970c95"),
     };
     wethAsset = {
-      id: 4n,
+      id: 4,
       assetType: AztecAssetType.ERC20,
       erc20Address: EthAddress.fromString("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"),
     };
     emptyAsset = {
-      id: 100n,
+      id: 100,
       assetType: AztecAssetType.NOT_USED,
       erc20Address: EthAddress.ZERO,
     };

--- a/src/client/yearn/yearn-bridge-data.test.ts
+++ b/src/client/yearn/yearn-bridge-data.test.ts
@@ -333,7 +333,7 @@ describe("Testing Yearn expectedOutput", () => {
       emptyAsset,
       yvDaiAsset,
       emptyAsset,
-      0n,
+      0,
       10n ** 18n,
     );
     expect(expectedOutputERC20[0]).toBe(989902989507028311n);
@@ -344,7 +344,7 @@ describe("Testing Yearn expectedOutput", () => {
       emptyAsset,
       yvEthAsset,
       emptyAsset,
-      0n,
+      0,
       10n ** 18n,
     );
     expect(expectedOutputETH[0]).toBe(989902989507028311n);
@@ -367,7 +367,7 @@ describe("Testing Yearn expectedOutput", () => {
       emptyAsset,
       daiAsset,
       emptyAsset,
-      1n,
+      1,
       10n ** 18n,
     );
     expect(expectedOutputERC20[0]).toBe(1110200000000000000n);
@@ -378,7 +378,7 @@ describe("Testing Yearn expectedOutput", () => {
       emptyAsset,
       ethAsset,
       emptyAsset,
-      1n,
+      1,
       10n ** 18n,
     );
     expect(expectedOutputETH[0]).toBe(1110200000000000000n);
@@ -398,13 +398,13 @@ describe("Testing Yearn expectedOutput", () => {
 
     expect.assertions(3);
     await expect(
-      yearnBridgeData.getExpectedOutput(yvDaiAsset, emptyAsset, daiAsset, emptyAsset, 0n, 10n ** 18n),
+      yearnBridgeData.getExpectedOutput(yvDaiAsset, emptyAsset, daiAsset, emptyAsset, 0, 10n ** 18n),
     ).rejects.toEqual(new Error("Token not found"));
     await expect(
-      yearnBridgeData.getExpectedOutput(daiAsset, emptyAsset, yvDaiAsset, emptyAsset, 1n, 10n ** 18n),
+      yearnBridgeData.getExpectedOutput(daiAsset, emptyAsset, yvDaiAsset, emptyAsset, 1, 10n ** 18n),
     ).rejects.toEqual(new Error("Token not found"));
     await expect(
-      yearnBridgeData.getExpectedOutput(yvDaiAsset, emptyAsset, daiAsset, emptyAsset, 3n, 10n ** 18n),
+      yearnBridgeData.getExpectedOutput(yvDaiAsset, emptyAsset, daiAsset, emptyAsset, 3, 10n ** 18n),
     ).rejects.toEqual("Invalid auxData");
   });
 });
@@ -451,7 +451,7 @@ describe("Testing Yearn getExpectedYield", () => {
       emptyAsset,
       emptyAsset,
       emptyAsset,
-      0n,
+      0,
       0n,
     );
     expect(expectedOutputDAI).not.toBeUndefined();
@@ -462,7 +462,7 @@ describe("Testing Yearn getExpectedYield", () => {
       emptyAsset,
       emptyAsset,
       emptyAsset,
-      0n,
+      0,
       0n,
     );
     expect(expectedOutputWETH).not.toBeUndefined();
@@ -473,7 +473,7 @@ describe("Testing Yearn getExpectedYield", () => {
       emptyAsset,
       emptyAsset,
       emptyAsset,
-      0n,
+      0,
       0n,
     );
     expect(expectedOutputETH).not.toBeUndefined();
@@ -481,10 +481,10 @@ describe("Testing Yearn getExpectedYield", () => {
     expect((expectedOutputWETH as [number, number])[0]).toBe((expectedOutputETH as [number, number])[0]);
 
     await expect(
-      yearnBridgeData.getExpectedOutput(emptyAsset, emptyAsset, emptyAsset, emptyAsset, 0n, 0n),
+      yearnBridgeData.getExpectedOutput(emptyAsset, emptyAsset, emptyAsset, emptyAsset, 0, 0n),
     ).rejects.toEqual(new Error("Token not found"));
     await expect(
-      yearnBridgeData.getExpectedOutput(yvDaiAsset, emptyAsset, emptyAsset, emptyAsset, 0n, 0n),
+      yearnBridgeData.getExpectedOutput(yvDaiAsset, emptyAsset, emptyAsset, emptyAsset, 0, 0n),
     ).rejects.toEqual(new Error("Token not found"));
   });
 });

--- a/src/client/yearn/yearn-bridge-data.ts
+++ b/src/client/yearn/yearn-bridge-data.ts
@@ -102,10 +102,10 @@ export class YearnBridgeData implements BridgeDataFieldGetters {
     inputAssetB: AztecAsset,
     outputAssetA: AztecAsset,
     outputAssetB: AztecAsset,
-    auxData: bigint,
+    auxData: number,
     inputValue: bigint,
   ): Promise<bigint[]> {
-    if (auxData === 0n) {
+    if (auxData === 0) {
       let tokenAddress = inputAssetA.erc20Address.toString();
       if (inputAssetA.assetType == AztecAssetType.ETH) {
         // Deposit via zap
@@ -120,7 +120,7 @@ export class YearnBridgeData implements BridgeDataFieldGetters {
       const expectedShares = BigNumber.from(inputValue).mul(BigNumber.from(10).pow(decimals)).div(pricePerShare);
       return [expectedShares.toBigInt(), 0n];
     }
-    if (auxData === 1n) {
+    if (auxData === 1) {
       let tokenAddress = outputAssetA.erc20Address.toString();
       if (outputAssetA.assetType == AztecAssetType.ETH) {
         // Withdraw via zap
@@ -143,7 +143,7 @@ export class YearnBridgeData implements BridgeDataFieldGetters {
     inputAssetB: AztecAsset,
     outputAssetA: AztecAsset,
     outputAssetB: AztecAsset,
-    auxData: bigint,
+    auxData: number,
     inputValue: bigint,
   ): Promise<number[]> {
     type TminVaultStruct = {

--- a/src/client/yearn/yearn-bridge-data.ts
+++ b/src/client/yearn/yearn-bridge-data.ts
@@ -3,6 +3,7 @@ import { EthereumProvider } from "@aztec/barretenberg/blockchain";
 import { Web3Provider } from "@ethersproject/providers";
 import { createWeb3Provider } from "../aztec/provider";
 import { BigNumber } from "ethers";
+
 import "isomorphic-fetch";
 
 import { AuxDataConfig, AztecAsset, AztecAssetType, BridgeDataFieldGetters, SolidityType } from "../bridge-data";


### PR DESCRIPTION
# Description

1. Simplified `getAPR` function,
2. changed `assetId` type to number,
3. changed `auxData` type to number,
4. importing `AssetValue` from internal repo and doing the related changes,
5. removed `getMarketSize` from element because it was returning non-sense which makes me thing it was not used anyway,
6. changed `interactionNonce` type to number,
7. updated `yarn build` command to not compile typechain twice,
8. removed unused imports and variables from a few places.

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] There are no unexpected formatting changes, or superfluous debug logs.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewers next convenience.
