### PR TITLE
refactor: Element inheriting from BridgeDataFieldGetters

### DIFF
--- a/src/client/bridge-data.ts
+++ b/src/client/bridge-data.ts
@@ -144,4 +144,7 @@ export interface BridgeDataFieldGetters {
    * @return The underlying asset (address, name, symbol, decimals, amount)
    */
   getUnderlyingAmount?(asset: AztecAsset, amount: bigint): Promise<UnderlyingAsset>;
+
+  // Used only in Element, TODO: remove once clients get refactored to not share 1 class
+  getTermAPR?(underlying: AztecAsset, auxData: number, inputValue: bigint): Promise<number>;
 }

--- a/src/client/element/element-bridge-data.test.ts
+++ b/src/client/element/element-bridge-data.test.ts
@@ -192,7 +192,7 @@ describe("element bridge data", () => {
     const totalInput = defiEvents.find(x => x.nonce === 56)!.totalInputValue;
     const userShareDivisor = 2n;
     const defiEvent = getDefiEvent(56)!;
-    const [daiValue] = await elementBridgeData.getInteractionPresentValue(56n, totalInput / userShareDivisor);
+    const [daiValue] = await elementBridgeData.getInteractionPresentValue(56, totalInput / userShareDivisor);
     const delta = outputValue - defiEvent.totalInputValue;
     const timeElapsed = BigInt(now) - startDate;
     const fullTime = expiration1 - startDate;
@@ -217,10 +217,7 @@ describe("element bridge data", () => {
       const totalInput = defiEvents.find(x => x.nonce === nonce)!.totalInputValue;
       const userShareDivisor = 2n;
 
-      const [daiValue] = await elementBridgeData.getInteractionPresentValue(
-        BigInt(nonce),
-        totalInput / userShareDivisor,
-      );
+      const [daiValue] = await elementBridgeData.getInteractionPresentValue(nonce, totalInput / userShareDivisor);
       const delta = interactions[nonce].quantityPT.toBigInt() - defiEvent.totalInputValue;
       const timeElapsed = BigInt(now) - startDate;
       const fullTime = BigInt(bridgeCallData.auxData) - startDate;
@@ -240,7 +237,7 @@ describe("element bridge data", () => {
 
   it("requesting the present value of an unknown interaction should return empty values", async () => {
     const elementBridgeData = createElementBridgeData();
-    const values = await elementBridgeData.getInteractionPresentValue(57n, 0n);
+    const values = await elementBridgeData.getInteractionPresentValue(57, 0n);
     expect(values).toStrictEqual([]);
   });
 
@@ -263,7 +260,7 @@ describe("element bridge data", () => {
     } as any;
 
     const elementBridgeData = createElementBridgeData(elementBridge as any);
-    const expiration = await elementBridgeData.getExpiration(1n);
+    const expiration = await elementBridgeData.getExpiration(1);
 
     expect(expiration).toBe(BigInt(endDate));
   });
@@ -296,26 +293,11 @@ describe("element bridge data", () => {
       balancerContract as any,
       rollupContract as any,
     );
-    const output = await elementBridgeData.getAPR(
+    const termAPR = await elementBridgeData.getTermAPR(
       {
         assetType: AztecAssetType.ERC20,
         erc20Address: testAddress,
         id: 1,
-      },
-      {
-        assetType: AztecAssetType.NOT_USED,
-        erc20Address: EthAddress.ZERO,
-        id: 0,
-      },
-      {
-        assetType: AztecAssetType.ERC20,
-        erc20Address: testAddress,
-        id: 1,
-      },
-      {
-        assetType: AztecAssetType.NOT_USED,
-        erc20Address: EthAddress.ZERO,
-        id: 0,
       },
       expiry,
       BigInt(inputValue),
@@ -326,8 +308,8 @@ describe("element bridge data", () => {
     const yearlyOut = (scaledOut * BigInt(YEAR)) / elementBridgeData.scalingFactor;
     const scaledPercentage = (yearlyOut * elementBridgeData.scalingFactor) / inputValue;
     const percentage2sf = scaledPercentage / (elementBridgeData.scalingFactor / 10000n);
-    const percent = Number(percentage2sf) / 100;
+    const expectedTermAPR = Number(percentage2sf) / 100;
 
-    expect(output[0]).toBe(percent);
+    expect(termAPR).toBe(expectedTermAPR);
   });
 });


### PR DESCRIPTION
# Changes

1. Element client implements from BridgeDataFieldGetters again,
2. changed nonce type to number in Element,
3. `getAPR(...)` function renamed to `getTermAPR(...)` in order to avoid collision with `BridgeDataFieldGetters.getAPR(...)` which has fewer input params than is needed by Element one.

Note: `getTermAPR(...)` returns `Promise<number>` instead of `Promise<[number]>`.

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] There are no unexpected formatting changes, or superfluous debug logs.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewers next convenience.
