### PR TITLE
Lh/yearn rollup processor arg

### DIFF
--- a/src/client/yearn/yearn-bridge-data.test.ts
+++ b/src/client/yearn/yearn-bridge-data.test.ts
@@ -102,7 +102,7 @@ describe("Testing Yearn auxData", () => {
     };
     IRollupProcessor__factory.connect = () => rollupProcessorContract as any;
 
-    const yearnBridgeData = YearnBridgeData.create({} as any);
+    const yearnBridgeData = YearnBridgeData.create({} as any, EthAddress.random());
     const auxDataDepositERC20 = await yearnBridgeData.getAuxData(daiAsset, emptyAsset, yvDaiAsset, emptyAsset);
     expect(auxDataDepositERC20[0]).toBe(0);
     const auxDataDepositETH = await yearnBridgeData.getAuxData(ethAsset, emptyAsset, yvEthAsset, emptyAsset);
@@ -143,7 +143,7 @@ describe("Testing Yearn auxData", () => {
     };
     IRollupProcessor__factory.connect = () => rollupProcessorContract as any;
 
-    const yearnBridgeData = YearnBridgeData.create({} as any);
+    const yearnBridgeData = YearnBridgeData.create({} as any, EthAddress.random());
     const auxDataDepositERC20 = await yearnBridgeData.getAuxData(yvDaiAsset, emptyAsset, daiAsset, emptyAsset);
     expect(auxDataDepositERC20[0]).toBe(1);
     const auxDataDepositETH = await yearnBridgeData.getAuxData(yvEthAsset, emptyAsset, ethAsset, emptyAsset);
@@ -174,7 +174,7 @@ describe("Testing Yearn auxData", () => {
     };
     IRollupProcessor__factory.connect = () => rollupProcessorContract as any;
 
-    const yearnBridgeData = YearnBridgeData.create({} as any);
+    const yearnBridgeData = YearnBridgeData.create({} as any, EthAddress.random());
 
     expect.assertions(1);
     await expect(yearnBridgeData.getAuxData(yvDaiAsset, emptyAsset, ethAsset, emptyAsset)).rejects.toEqual(
@@ -206,7 +206,7 @@ describe("Testing Yearn auxData", () => {
     };
     IRollupProcessor__factory.connect = () => rollupProcessorContract as any;
 
-    const yearnBridgeData = YearnBridgeData.create({} as any);
+    const yearnBridgeData = YearnBridgeData.create({} as any, EthAddress.random());
 
     expect.assertions(1);
     await expect(yearnBridgeData.getAuxData(ethAsset, emptyAsset, yvEthAsset, emptyAsset)).rejects.toEqual(
@@ -250,7 +250,7 @@ describe("Testing Yearn auxData", () => {
     };
     IRollupProcessor__factory.connect = () => rollupProcessorContract as any;
 
-    const yearnBridgeData = YearnBridgeData.create({} as any);
+    const yearnBridgeData = YearnBridgeData.create({} as any, EthAddress.random());
 
     expect.assertions(8);
     await expect(yearnBridgeData.getAuxData(ethAsset, emptyAsset, yvDaiAsset, emptyAsset)).rejects.toEqual(
@@ -326,7 +326,7 @@ describe("Testing Yearn expectedOutput", () => {
     };
     IYearnVault__factory.connect = () => vaultContract as any;
 
-    const yearnBridgeData = YearnBridgeData.create({} as any);
+    const yearnBridgeData = YearnBridgeData.create({} as any, EthAddress.random());
 
     const expectedOutputERC20 = await yearnBridgeData.getExpectedOutput(
       daiAsset,
@@ -360,7 +360,7 @@ describe("Testing Yearn expectedOutput", () => {
     };
     IYearnVault__factory.connect = () => vaultContract as any;
 
-    const yearnBridgeData = YearnBridgeData.create({} as any);
+    const yearnBridgeData = YearnBridgeData.create({} as any, EthAddress.random());
 
     const expectedOutputERC20 = await yearnBridgeData.getExpectedOutput(
       yvDaiAsset,
@@ -394,7 +394,7 @@ describe("Testing Yearn expectedOutput", () => {
     };
     IYearnVault__factory.connect = () => vaultContract as any;
 
-    const yearnBridgeData = YearnBridgeData.create({} as any);
+    const yearnBridgeData = YearnBridgeData.create({} as any, EthAddress.random());
 
     expect.assertions(3);
     await expect(
@@ -409,7 +409,7 @@ describe("Testing Yearn expectedOutput", () => {
   });
 
   it("should throw with incorrect tokens on the input", async () => {
-    const yearnBridgeData = YearnBridgeData.create({} as any);
+    const yearnBridgeData = YearnBridgeData.create({} as any, EthAddress.random());
 
     await expect(
       yearnBridgeData.getExpectedOutput(emptyAsset, emptyAsset, emptyAsset, emptyAsset, 0, 0n),
@@ -438,7 +438,7 @@ describe("Testing Yearn getAPR", () => {
   });
 
   it("should correctly compute APR", async () => {
-    const yearnBridgeData = YearnBridgeData.create({} as any);
+    const yearnBridgeData = YearnBridgeData.create({} as any, EthAddress.random());
     const expectedAPRDai = await yearnBridgeData.getAPR(yvDaiAsset);
     expect(expectedAPRDai).not.toBeUndefined();
     expect(expectedAPRDai).toBeGreaterThan(0);
@@ -482,7 +482,7 @@ describe("Testing Yearn getMarketSize", () => {
     };
     IYearnVault__factory.connect = () => vaultContract as any;
 
-    const yearnBridgeData = YearnBridgeData.create({} as any);
+    const yearnBridgeData = YearnBridgeData.create({} as any, EthAddress.random());
     const expectedMarketSize = (await yearnBridgeData.getMarketSize(daiAsset, emptyAsset, yvDaiAsset, emptyAsset, 0))[0]
       .value;
     expect(expectedMarketSize).toBe(97513214188808613008055674n);

--- a/src/client/yearn/yearn-bridge-data.ts
+++ b/src/client/yearn/yearn-bridge-data.ts
@@ -27,12 +27,12 @@ export class YearnBridgeData implements BridgeDataFieldGetters {
     private rollupProcessor: IRollupProcessor,
   ) {}
 
-  static create(provider: EthereumProvider) {
+  static create(provider: EthereumProvider, rollupProcessor: EthAddress) {
     const ethersProvider = createWeb3Provider(provider);
     return new YearnBridgeData(
       ethersProvider,
       IYearnRegistry__factory.connect("0x50c1a2eA0a861A967D9d0FFE2AE4012c2E053804", ethersProvider),
-      IRollupProcessor__factory.connect("0xFF1F2B4ADb9dF6FC8eAFecDcbF96A2B351680455", ethersProvider),
+      IRollupProcessor__factory.connect(rollupProcessor.toString(), ethersProvider),
     );
   }
 


### PR DESCRIPTION
# Description

The yearn client data is using a constant address rollup processor, which makes it a little impractical for testnet deployments. This PR updates such that an address is passed to the `create` instead. 

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] There are no unexpected formatting changes, or superfluous debug logs.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewers next convenience.
- [x] NatSpec documentation of all the non-test functions is present and is complete.
- [x] Continuous integration (CI) passes.
- [x] Command `forge coverage --match-contract MyContract` returns 100% line coverage.
- [x] All the possible reverts are tested.
