### PR TITLE
measure gas bridges

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -9,7 +9,8 @@ subtask(TASK_COMPILE_SOLIDITY_GET_SOURCE_PATHS).setAction(async (_, __, runSuper
   // Do not generate types for files in the src/test folder unless they are in interface subfolder.
   // (Types of all the interfaces are needed in end to end tests.)
   return paths.filter(
-    (p: any) => (!p.includes("src/test/") && !p.includes("src/deployment") && !p.includes("src/gas")) || p.includes("interface"),
+    (p: any) =>
+      (!p.includes("src/test/") && !p.includes("src/deployment") && !p.includes("src/gas")) || p.includes("interface"),
   );
 });
 

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -9,7 +9,7 @@ subtask(TASK_COMPILE_SOLIDITY_GET_SOURCE_PATHS).setAction(async (_, __, runSuper
   // Do not generate types for files in the src/test folder unless they are in interface subfolder.
   // (Types of all the interfaces are needed in end to end tests.)
   return paths.filter(
-    (p: any) => (!p.includes("src/test/") && !p.includes("src/deployment")) || p.includes("interface"),
+    (p: any) => (!p.includes("src/test/") && !p.includes("src/deployment") && !p.includes("src/gas")) || p.includes("interface"),
   );
 });
 

--- a/src/deployment/curve/CurveDeployment.s.sol
+++ b/src/deployment/curve/CurveDeployment.s.sol
@@ -53,12 +53,14 @@ contract CurveDeployment is BaseDeployment {
         return (bridge, wstEth);
     }
 
-    function deployAndList() public {
+    function deployAndList() public returns (address, address) {
         (address bridge, address wstEth) = deployAndFund();
 
         uint256 addressId = listBridge(bridge, 250000);
         emit log_named_uint("Curve bridge address id", addressId);
 
         listAsset(wstEth, 100000);
+
+        return (bridge, wstEth);
     }
 }

--- a/src/deployment/uniswap/UniswapDeployment.s.sol
+++ b/src/deployment/uniswap/UniswapDeployment.s.sol
@@ -6,8 +6,8 @@ import {BaseDeployment} from "../base/BaseDeployment.s.sol";
 import {UniswapBridge} from "../../bridges/uniswap/UniswapBridge.sol";
 
 contract UniswapDeployment is BaseDeployment {
-    address public constant WETH = address(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
-    address public constant DAI = address(0x6B175474E89094C44Da98b954EedeAC495271d0F);
+    address public constant WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
+    address public constant DAI = 0x6B175474E89094C44Da98b954EedeAC495271d0F;
 
     function deploy() public returns (address) {
         emit log("Deploying uniswap bridge");

--- a/src/deployment/yearn/YearnDeployment.s.sol
+++ b/src/deployment/yearn/YearnDeployment.s.sol
@@ -37,7 +37,7 @@ contract YearnDeployment is BaseDeployment {
         YearnBridge(payable(bridge)).preApprove(latestWethVault);
     }
 
-    function deployAndList() public {
+    function deployAndList() public returns (address) {
         address bridge = deploy();
 
         approveAssets(bridge);
@@ -47,5 +47,7 @@ contract YearnDeployment is BaseDeployment {
 
         listAsset(YEARN_REGISTRY.latestVault(DAI), 100000);
         listAsset(YEARN_REGISTRY.latestVault(WETH), 100000);
+
+        return bridge;
     }
 }

--- a/src/gas/base/GasBase.sol
+++ b/src/gas/base/GasBase.sol
@@ -18,53 +18,53 @@ contract GasBase {
 
     fallback() external {}
 
-    function getSupportedBridgesLength() external view returns (uint256) {
-        return 0;
-    }
-
-    function getSupportedAssetsLength() external view returns (uint256) {
-        return 0;
-    }
-
-    function receiveEthFromBridge(uint256 interactionNonce) external payable {
-        ethPayments[interactionNonce] += msg.value;
+    function receiveEthFromBridge(uint256 _interactionNonce) external payable {
+        ethPayments[_interactionNonce] += msg.value;
     }
 
     function convert(
-        address bridgeAddress,
-        AztecTypes.AztecAsset memory inputAssetA,
-        AztecTypes.AztecAsset memory inputAssetB,
-        AztecTypes.AztecAsset memory outputAssetA,
-        AztecTypes.AztecAsset memory outputAssetB,
-        uint256 totalInputValue,
-        uint256 interactionNonce,
-        uint256 auxInputData,
-        address rollupBeneficiary,
-        uint256 gasLimit
+        address _bridgeAddress,
+        AztecTypes.AztecAsset memory _inputAssetA,
+        AztecTypes.AztecAsset memory _inputAssetB,
+        AztecTypes.AztecAsset memory _outputAssetA,
+        AztecTypes.AztecAsset memory _outputAssetB,
+        uint256 _totalInputValue,
+        uint256 _interactionNonce,
+        uint256 _auxInputData,
+        address _rollupBeneficiary,
+        uint256 _gasLimit
     ) external {
         uint256 paymentSlot;
         assembly {
             paymentSlot := ethPayments.slot
         }
 
-        (bool success, ) = address(defiProxy).delegatecall{gas: gasLimit}(
+        (bool success, ) = address(defiProxy).delegatecall{gas: _gasLimit}(
             abi.encodeWithSelector(
                 DEFI_BRIDGE_PROXY_CONVERT_SELECTOR,
-                bridgeAddress,
-                inputAssetA,
-                inputAssetB,
-                outputAssetA,
-                outputAssetB,
-                totalInputValue,
-                interactionNonce,
-                auxInputData,
+                _bridgeAddress,
+                _inputAssetA,
+                _inputAssetB,
+                _outputAssetA,
+                _outputAssetB,
+                _totalInputValue,
+                _interactionNonce,
+                _auxInputData,
                 paymentSlot,
-                rollupBeneficiary
+                _rollupBeneficiary
             )
         );
 
         if (!success) {
             revert("Failure, should only fail with OOM");
         }
+    }
+
+    function getSupportedBridgesLength() external view returns (uint256) {
+        return 0;
+    }
+
+    function getSupportedAssetsLength() external view returns (uint256) {
+        return 0;
     }
 }

--- a/src/gas/base/GasBase.sol
+++ b/src/gas/base/GasBase.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2022 Aztec.
+pragma solidity >=0.8.4;
+
+import {AztecTypes} from "../../aztec/libraries/AztecTypes.sol";
+
+contract GasBase {
+    bytes4 private constant DEFI_BRIDGE_PROXY_CONVERT_SELECTOR = 0x4bd947a8;
+
+    address public defiProxy;
+    mapping(uint256 => uint256) public ethPayments;
+
+    constructor(address _defiProxy) {
+        defiProxy = _defiProxy;
+    }
+
+    receive() external payable {}
+
+    fallback() external {}
+
+    function getSupportedBridgesLength() external view returns (uint256) {
+        return 0;
+    }
+
+    function getSupportedAssetsLength() external view returns (uint256) {
+        return 0;
+    }
+
+    function receiveEthFromBridge(uint256 interactionNonce) external payable {
+        ethPayments[interactionNonce] += msg.value;
+    }
+
+    struct Temps {
+        uint256 paymentSlot;
+        uint256 gasUsed;
+        bool success;
+    }
+
+    function convert(
+        address bridgeAddress,
+        AztecTypes.AztecAsset memory inputAssetA,
+        AztecTypes.AztecAsset memory inputAssetB,
+        AztecTypes.AztecAsset memory outputAssetA,
+        AztecTypes.AztecAsset memory outputAssetB,
+        uint256 totalInputValue,
+        uint256 interactionNonce,
+        uint256 auxInputData, // (auxData)
+        address rollupBeneficiary,
+        uint256 gasLimit
+    ) external returns (uint256) {
+        Temps memory temps;
+        {
+            uint256 paymentSlot;
+            assembly {
+                mstore(temps, ethPayments.slot)
+                //paymentSlot := ethPayments.slot
+            }
+        }
+
+        temps.gasUsed = gasleft();
+        (temps.success, ) = address(defiProxy).delegatecall{gas: gasLimit}(
+            abi.encodeWithSelector(
+                DEFI_BRIDGE_PROXY_CONVERT_SELECTOR,
+                bridgeAddress,
+                inputAssetA,
+                inputAssetB,
+                outputAssetA,
+                outputAssetB,
+                totalInputValue,
+                interactionNonce,
+                auxInputData,
+                temps.paymentSlot,
+                rollupBeneficiary
+            )
+        );
+        temps.gasUsed -= gasleft();
+
+        if (!temps.success) {
+            revert("Failure, should only fail with OOM");
+        }
+
+        return temps.gasUsed;
+    }
+}

--- a/src/gas/curve/CurveGas.s.sol
+++ b/src/gas/curve/CurveGas.s.sol
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2022 Aztec.
+pragma solidity >=0.8.4;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {CurveStEthBridge} from "../../bridges/curve/CurveStEthBridge.sol";
+import {AztecTypes} from "../../aztec/libraries/AztecTypes.sol";
+import {ISubsidy} from "../../aztec/interfaces/ISubsidy.sol";
+
+import {CurveDeployment} from "../../deployment/curve/CurveDeployment.s.sol";
+import {GasBase} from "../base/GasBase.sol";
+
+interface IRead {
+    function defiBridgeProxy() external view returns (address);
+}
+
+contract CurveMeasure is CurveDeployment {
+    GasBase internal gasBase;
+    CurveStEthBridge internal bridge;
+
+    function measure() public {
+        address defiProxy = IRead(ROLLUP_PROCESSOR).defiBridgeProxy();
+        vm.label(defiProxy, "DefiProxy");
+
+        vm.broadcast();
+        gasBase = new GasBase(defiProxy);
+
+        address temp = ROLLUP_PROCESSOR;
+        ROLLUP_PROCESSOR = address(gasBase);
+        (address bridge, address wstEth) = deployAndList();
+        ROLLUP_PROCESSOR = temp;
+
+        AztecTypes.AztecAsset memory empty;
+        AztecTypes.AztecAsset memory eth = AztecTypes.AztecAsset({
+            id: 0,
+            erc20Address: address(0),
+            assetType: AztecTypes.AztecAssetType.ETH
+        });
+        AztecTypes.AztecAsset memory wstEthAsset = AztecTypes.AztecAsset({
+            id: 1,
+            erc20Address: wstEth,
+            assetType: AztecTypes.AztecAssetType.ERC20
+        });
+
+        vm.broadcast();
+        address(gasBase).call{value: 2 ether}("");
+        emit log_named_uint("Balance of ", address(gasBase).balance);
+
+        // Deposit
+        {
+            vm.broadcast();
+            gasBase.convert(bridge, eth, empty, wstEthAsset, empty, 1 ether, 0, 0, address(this), 250000);
+        }
+
+        // Withdraw
+        {
+            emit log_named_uint("bal", IERC20(wstEthAsset.erc20Address).balanceOf(address(gasBase)));
+
+            vm.broadcast();
+            gasBase.convert(bridge, wstEthAsset, empty, eth, empty, 0.1 ether, 1, 1, address(this), 250000);
+            emit log_named_uint("bal", IERC20(wstEthAsset.erc20Address).balanceOf(address(gasBase)));
+        }
+    }
+}

--- a/src/gas/yearn/YearnGas.s.sol
+++ b/src/gas/yearn/YearnGas.s.sol
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2022 Aztec.
+pragma solidity >=0.8.4;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {YearnBridge} from "../../bridges/yearn/YearnBridge.sol";
+import {AztecTypes} from "../../aztec/libraries/AztecTypes.sol";
+import {ISubsidy} from "../../aztec/interfaces/ISubsidy.sol";
+
+import {YearnDeployment} from "../../deployment/yearn/YearnDeployment.s.sol";
+import {GasBase} from "../base/GasBase.sol";
+
+interface IRead {
+    function defiBridgeProxy() external view returns (address);
+}
+
+contract YearnMeasure is YearnDeployment {
+    GasBase internal gasBase;
+    YearnBridge internal bridge;
+
+    function measure() public {
+        address defiProxy = IRead(ROLLUP_PROCESSOR).defiBridgeProxy();
+        vm.label(defiProxy, "DefiProxy");
+
+        gasBase = new GasBase(defiProxy);
+
+        address temp = ROLLUP_PROCESSOR;
+        ROLLUP_PROCESSOR = address(gasBase);
+        address bridge = deployAndList();
+        ROLLUP_PROCESSOR = temp;
+
+        AztecTypes.AztecAsset memory empty;
+        AztecTypes.AztecAsset memory eth = AztecTypes.AztecAsset({
+            id: 0,
+            erc20Address: address(0),
+            assetType: AztecTypes.AztecAssetType.ETH
+        });
+        AztecTypes.AztecAsset memory vyAsset = AztecTypes.AztecAsset({
+            id: 1,
+            erc20Address: YEARN_REGISTRY.latestVault(WETH),
+            assetType: AztecTypes.AztecAssetType.ERC20
+        });
+
+        vm.deal(address(gasBase), 2 ether);
+        emit log_named_uint("Balance of ", address(gasBase).balance);
+
+        // Deposit
+        {
+            vm.warp(block.timestamp + 1000);
+
+            vm.broadcast();
+            uint256 gas = gasBase.convert(bridge, eth, empty, vyAsset, empty, 1 ether, 0, 0, address(this), 200000);
+
+            emit log_named_uint("Gas      ", gas);
+        }
+
+        // Withdraw
+        {
+            vm.warp(block.timestamp + 1000);
+
+            emit log_named_uint("bal", IERC20(vyAsset.erc20Address).balanceOf(address(gasBase)));
+
+            vm.broadcast();
+            uint256 gas = gasBase.convert(bridge, vyAsset, empty, eth, empty, 0.1 ether, 1, 1, address(this), 200000);
+            emit log_named_uint("bal", IERC20(vyAsset.erc20Address).balanceOf(address(gasBase)));
+
+            emit log_named_uint("Gas      ", gas);
+        }
+    }
+
+    function measureDai() public {
+        address defiProxy = IRead(ROLLUP_PROCESSOR).defiBridgeProxy();
+        vm.label(defiProxy, "DefiProxy");
+
+        gasBase = new GasBase(defiProxy);
+
+        address temp = ROLLUP_PROCESSOR;
+        ROLLUP_PROCESSOR = address(gasBase);
+        address bridge = deployAndList();
+        ROLLUP_PROCESSOR = temp;
+
+        AztecTypes.AztecAsset memory empty;
+        AztecTypes.AztecAsset memory dai = AztecTypes.AztecAsset({
+            id: 0,
+            erc20Address: address(DAI),
+            assetType: AztecTypes.AztecAssetType.ERC20
+        });
+        AztecTypes.AztecAsset memory vyAsset = AztecTypes.AztecAsset({
+            id: 1,
+            erc20Address: YEARN_REGISTRY.latestVault(DAI),
+            assetType: AztecTypes.AztecAssetType.ERC20
+        });
+
+        deal(DAI, address(gasBase), 2 ether);
+        emit log_named_uint("Balance of ", IERC20(DAI).balanceOf(address(gasBase)));
+
+        // Deposit
+        {
+            vm.warp(block.timestamp + 1000);
+
+            vm.broadcast();
+            uint256 gas = gasBase.convert(bridge, dai, empty, vyAsset, empty, 1 ether, 0, 0, address(this), 200000);
+
+            emit log_named_uint("Gas      ", gas);
+        }
+
+        // Withdraw
+        {
+            vm.warp(block.timestamp + 1000);
+
+            emit log_named_uint("bal", IERC20(vyAsset.erc20Address).balanceOf(address(gasBase)));
+
+            vm.broadcast();
+            uint256 gas = gasBase.convert(bridge, vyAsset, empty, dai, empty, 0.1 ether, 1, 1, address(this), 200000);
+            emit log_named_uint("bal", IERC20(vyAsset.erc20Address).balanceOf(address(gasBase)));
+
+            emit log_named_uint("Gas      ", gas);
+        }
+    }
+}

--- a/src/gas/yearn/YearnGas.s.sol
+++ b/src/gas/yearn/YearnGas.s.sol
@@ -22,6 +22,7 @@ contract YearnMeasure is YearnDeployment {
         address defiProxy = IRead(ROLLUP_PROCESSOR).defiBridgeProxy();
         vm.label(defiProxy, "DefiProxy");
 
+        vm.broadcast();
         gasBase = new GasBase(defiProxy);
 
         address temp = ROLLUP_PROCESSOR;
@@ -41,37 +42,31 @@ contract YearnMeasure is YearnDeployment {
             assetType: AztecTypes.AztecAssetType.ERC20
         });
 
-        vm.deal(address(gasBase), 2 ether);
+        vm.broadcast();
+        address(gasBase).call{value: 2 ether}("");
         emit log_named_uint("Balance of ", address(gasBase).balance);
 
         // Deposit
         {
-            vm.warp(block.timestamp + 1000);
-
             vm.broadcast();
-            uint256 gas = gasBase.convert(bridge, eth, empty, vyAsset, empty, 1 ether, 0, 0, address(this), 200000);
-
-            emit log_named_uint("Gas      ", gas);
+            gasBase.convert(bridge, eth, empty, vyAsset, empty, 1 ether, 0, 0, address(this), 250000);
         }
 
         // Withdraw
         {
-            vm.warp(block.timestamp + 1000);
-
             emit log_named_uint("bal", IERC20(vyAsset.erc20Address).balanceOf(address(gasBase)));
 
             vm.broadcast();
-            uint256 gas = gasBase.convert(bridge, vyAsset, empty, eth, empty, 0.1 ether, 1, 1, address(this), 200000);
+            gasBase.convert(bridge, vyAsset, empty, eth, empty, 0.1 ether, 1, 1, address(this), 250000);
             emit log_named_uint("bal", IERC20(vyAsset.erc20Address).balanceOf(address(gasBase)));
-
-            emit log_named_uint("Gas      ", gas);
         }
     }
 
-    function measureDai() public {
+    function measureWeth() public {
         address defiProxy = IRead(ROLLUP_PROCESSOR).defiBridgeProxy();
         vm.label(defiProxy, "DefiProxy");
 
+        vm.broadcast();
         gasBase = new GasBase(defiProxy);
 
         address temp = ROLLUP_PROCESSOR;
@@ -80,41 +75,38 @@ contract YearnMeasure is YearnDeployment {
         ROLLUP_PROCESSOR = temp;
 
         AztecTypes.AztecAsset memory empty;
-        AztecTypes.AztecAsset memory dai = AztecTypes.AztecAsset({
+        AztecTypes.AztecAsset memory wethAsset = AztecTypes.AztecAsset({
             id: 0,
-            erc20Address: address(DAI),
+            erc20Address: address(WETH),
             assetType: AztecTypes.AztecAssetType.ERC20
         });
         AztecTypes.AztecAsset memory vyAsset = AztecTypes.AztecAsset({
             id: 1,
-            erc20Address: YEARN_REGISTRY.latestVault(DAI),
+            erc20Address: YEARN_REGISTRY.latestVault(WETH),
             assetType: AztecTypes.AztecAssetType.ERC20
         });
 
-        deal(DAI, address(gasBase), 2 ether);
-        emit log_named_uint("Balance of ", IERC20(DAI).balanceOf(address(gasBase)));
+        vm.broadcast();
+        WETH.call{value: 2 ether}("");
+
+        vm.broadcast();
+        IERC20(WETH).transfer(address(gasBase), 2 ether);
+
+        emit log_named_uint("Balance of ", IERC20(WETH).balanceOf(address(gasBase)));
 
         // Deposit
         {
-            vm.warp(block.timestamp + 1000);
-
             vm.broadcast();
-            uint256 gas = gasBase.convert(bridge, dai, empty, vyAsset, empty, 1 ether, 0, 0, address(this), 200000);
-
-            emit log_named_uint("Gas      ", gas);
+            gasBase.convert(bridge, wethAsset, empty, vyAsset, empty, 1 ether, 0, 0, address(this), 250000);
         }
 
         // Withdraw
         {
-            vm.warp(block.timestamp + 1000);
-
             emit log_named_uint("bal", IERC20(vyAsset.erc20Address).balanceOf(address(gasBase)));
 
             vm.broadcast();
-            uint256 gas = gasBase.convert(bridge, vyAsset, empty, dai, empty, 0.1 ether, 1, 1, address(this), 200000);
+            gasBase.convert(bridge, vyAsset, empty, wethAsset, empty, 0.1 ether, 1, 1, address(this), 250000);
             emit log_named_uint("bal", IERC20(vyAsset.erc20Address).balanceOf(address(gasBase)));
-
-            emit log_named_uint("Gas      ", gas);
         }
     }
 }


### PR DESCRIPTION
# Description

A base that allows better gas-estimations of defi interactions. Example written for yearn. 

The measurements is a little tricky as foundry by default tries to cram everything in one tx, so much storage is touched. To work around it, we are using a script to broadcast it, the traces from the broadcast can then be used as an estimate. If not adding the `--broadcast` flag when executing the script, the tx will not be published practically, otherwise can be done against an anvil network.

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] There are no unexpected formatting changes, or superfluous debug logs.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewers next convenience.
- [ ] NatSpec documentation of all the non-test functions is present and is complete.
- [ ] Continuous integration (CI) passes.
- [ ] Command `forge coverage --match-contract MyContract` returns 100% line coverage.
- [ ] All the possible reverts are tested.
