### PR TITLE
Integrating mainnet Subsidy deployment in bridges

### DIFF
--- a/src/bridges/base/BridgeBase.sol
+++ b/src/bridges/base/BridgeBase.sol
@@ -3,6 +3,7 @@
 pragma solidity >=0.8.4;
 
 import {IDefiBridge} from "../../aztec/interfaces/IDefiBridge.sol";
+import {ISubsidy} from "../../aztec/interfaces/ISubsidy.sol";
 import {AztecTypes} from "../../aztec/libraries/AztecTypes.sol";
 import {ErrorLib} from "./ErrorLib.sol";
 
@@ -15,6 +16,7 @@ import {ErrorLib} from "./ErrorLib.sol";
 abstract contract BridgeBase is IDefiBridge {
     error MissingImplementation();
 
+    ISubsidy public constant SUBSIDY = ISubsidy(0xABc30E831B5Cc173A9Ed5941714A7845c909e7fA);
     address public immutable ROLLUP_PROCESSOR;
 
     constructor(address _rollupProcessor) {

--- a/src/bridges/erc4626/ERC4626Bridge.sol
+++ b/src/bridges/erc4626/ERC4626Bridge.sol
@@ -126,10 +126,7 @@ contract ERC4626Bridge is BridgeBase {
         }
 
         // Pay out subsidy to _rollupBeneficiary
-        SUBSIDY.claimSubsidy(
-            _computeCriteria(_inputAssetA.erc20Address, _outputAssetA.erc20Address),
-            _rollupBeneficiary
-        );
+        SUBSIDY.claimSubsidy(_computeCriteria(inputToken, outputToken), _rollupBeneficiary);
     }
 
     /**

--- a/src/bridges/erc4626/ERC4626Bridge.sol
+++ b/src/bridges/erc4626/ERC4626Bridge.sol
@@ -125,7 +125,7 @@ contract ERC4626Bridge is BridgeBase {
             revert ErrorLib.InvalidAuxData();
         }
 
-        // Pay out subsidy to _rollupBeneficiary
+        // Accumulate subsidy to _rollupBeneficiary
         SUBSIDY.claimSubsidy(_computeCriteria(inputToken, outputToken), _rollupBeneficiary);
     }
 

--- a/src/bridges/erc4626/ERC4626Bridge.sol
+++ b/src/bridges/erc4626/ERC4626Bridge.sol
@@ -61,7 +61,7 @@ contract ERC4626Bridge is BridgeBase {
         minGasPerMinute[0] = 140;
         minGasPerMinute[1] = 140;
 
-        // We set gas usage in the Subsidy contract
+        // We set gas usage and minGasPerMinute in the Subsidy contract
         SUBSIDY.setGasUsageAndMinGasPerMinute(criteria, gasUsage, minGasPerMinute);
     }
 

--- a/src/bridges/erc4626/ERC4626Bridge.sol
+++ b/src/bridges/erc4626/ERC4626Bridge.sol
@@ -98,10 +98,14 @@ contract ERC4626Bridge is BridgeBase {
             bool
         )
     {
+        address inputToken = _inputAssetA.erc20Address;
+        address outputToken = _outputAssetA.erc20Address;
+
         if (_auxData == 0) {
             // Issuing new shares - input can be ETH
             if (_inputAssetA.assetType == AztecTypes.AztecAssetType.ETH) {
                 WETH.deposit{value: _totalInputValue}();
+                inputToken = address(WETH);
             }
             // If input asset is not the vault asset (or ETH if vault asset is WETH) the following will revert when
             // trying to pull the funds from the bridge
@@ -115,6 +119,7 @@ contract ERC4626Bridge is BridgeBase {
             if (_outputAssetA.assetType == AztecTypes.AztecAssetType.ETH) {
                 IWETH(WETH).withdraw(outputValueA);
                 IRollupProcessor(ROLLUP_PROCESSOR).receiveEthFromBridge{value: outputValueA}(_interactionNonce);
+                outputToken = address(WETH);
             }
         } else {
             revert ErrorLib.InvalidAuxData();

--- a/src/bridges/example/ExampleBridge.sol
+++ b/src/bridges/example/ExampleBridge.sol
@@ -6,7 +6,6 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {AztecTypes} from "../../aztec/libraries/AztecTypes.sol";
 import {ErrorLib} from "../base/ErrorLib.sol";
 import {BridgeBase} from "../base/BridgeBase.sol";
-import {ISubsidy} from "../../aztec/interfaces/ISubsidy.sol";
 
 /**
  * @title An example bridge contract.
@@ -16,15 +15,11 @@ import {ISubsidy} from "../../aztec/interfaces/ISubsidy.sol";
  *      sent to it.
  */
 contract ExampleBridgeContract is BridgeBase {
-    ISubsidy public immutable SUBSIDY;
-
     /**
      * @notice Set address of rollup processor
      * @param _rollupProcessor Address of rollup processor
      */
-    constructor(address _rollupProcessor, ISubsidy _subsidy) BridgeBase(_rollupProcessor) {
-        SUBSIDY = _subsidy;
-
+    constructor(address _rollupProcessor) BridgeBase(_rollupProcessor) {
         address dai = 0x6B175474E89094C44Da98b954EedeAC495271d0F;
         address usdc = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
 

--- a/src/deployment/example/ExampleDeployment.s.sol
+++ b/src/deployment/example/ExampleDeployment.s.sol
@@ -4,18 +4,13 @@ pragma solidity >=0.8.4;
 
 import {BaseDeployment} from "../base/BaseDeployment.s.sol";
 import {ExampleBridgeContract} from "../../bridges/example/ExampleBridge.sol";
-import {Subsidy} from "../../aztec/Subsidy.sol";
-import {ISubsidy} from "../../aztec/interfaces/ISubsidy.sol";
 
 contract ExampleDeployment is BaseDeployment {
     function deploy() public returns (address) {
         emit log("Deploying example bridge");
 
         vm.broadcast();
-        Subsidy sub = new Subsidy();
-
-        vm.broadcast();
-        ExampleBridgeContract bridge = new ExampleBridgeContract(ROLLUP_PROCESSOR, sub);
+        ExampleBridgeContract bridge = new ExampleBridgeContract(ROLLUP_PROCESSOR);
 
         emit log_named_address("Example bridge deployed to", address(bridge));
 

--- a/src/gas/yearn/YearnGas.s.sol
+++ b/src/gas/yearn/YearnGas.s.sol
@@ -16,7 +16,9 @@ interface IRead {
 
 contract YearnMeasure is YearnDeployment {
     GasBase internal gasBase;
-    YearnBridge internal bridge;
+    ISubsidy internal subsidy;
+
+    address internal constant BENEFICIARY = address(0xdeadbeef);
 
     function measure() public {
         address defiProxy = IRead(ROLLUP_PROCESSOR).defiBridgeProxy();
@@ -49,7 +51,7 @@ contract YearnMeasure is YearnDeployment {
         // Deposit
         {
             vm.broadcast();
-            gasBase.convert(bridge, eth, empty, vyAsset, empty, 1 ether, 0, 0, address(this), 250000);
+            gasBase.convert(bridge, eth, empty, vyAsset, empty, 1 ether, 0, 0, address(this), 200000);
         }
 
         // Withdraw
@@ -57,8 +59,74 @@ contract YearnMeasure is YearnDeployment {
             emit log_named_uint("bal", IERC20(vyAsset.erc20Address).balanceOf(address(gasBase)));
 
             vm.broadcast();
-            gasBase.convert(bridge, vyAsset, empty, eth, empty, 0.1 ether, 1, 1, address(this), 250000);
+            gasBase.convert(bridge, vyAsset, empty, eth, empty, 0.1 ether, 1, 1, address(this), 200000);
             emit log_named_uint("bal", IERC20(vyAsset.erc20Address).balanceOf(address(gasBase)));
+        }
+    }
+
+    function measureWithSubsidy() public {
+        address defiProxy = IRead(ROLLUP_PROCESSOR).defiBridgeProxy();
+        vm.label(defiProxy, "DefiProxy");
+
+        vm.broadcast();
+        gasBase = new GasBase(defiProxy);
+
+        address temp = ROLLUP_PROCESSOR;
+        ROLLUP_PROCESSOR = address(gasBase);
+        address bridge = deployAndList();
+        ROLLUP_PROCESSOR = temp;
+
+        subsidy = ISubsidy(YearnBridge(payable(bridge)).SUBSIDY());
+
+        AztecTypes.AztecAsset memory empty;
+        AztecTypes.AztecAsset memory eth = AztecTypes.AztecAsset({
+            id: 0,
+            erc20Address: address(0),
+            assetType: AztecTypes.AztecAssetType.ETH
+        });
+        AztecTypes.AztecAsset memory vyAsset = AztecTypes.AztecAsset({
+            id: 1,
+            erc20Address: YEARN_REGISTRY.latestVault(WETH),
+            assetType: AztecTypes.AztecAssetType.ERC20
+        });
+
+        vm.broadcast();
+        subsidy.registerBeneficiary(BENEFICIARY);
+
+        vm.broadcast();
+        subsidy.subsidize{value: 1 ether}(bridge, 0, 200);
+
+        vm.broadcast();
+        address(gasBase).call{value: 2 ether}("");
+        emit log_named_uint("Balance of ", address(gasBase).balance);
+
+        // Deposit
+        {
+            vm.broadcast();
+            gasBase.convert(bridge, eth, empty, vyAsset, empty, 1 ether, 0, 0, BENEFICIARY, 200000);
+        }
+
+        // Withdraw
+        {
+            emit log_named_uint("bal", IERC20(vyAsset.erc20Address).balanceOf(address(gasBase)));
+
+            vm.broadcast();
+            gasBase.convert(bridge, vyAsset, empty, eth, empty, 0.1 ether, 1, 1, BENEFICIARY, 200000);
+            emit log_named_uint("bal", IERC20(vyAsset.erc20Address).balanceOf(address(gasBase)));
+        }
+
+        emit log_named_uint("Subsidy accumulated", subsidy.claimableAmount(BENEFICIARY));
+        emit log_named_uint("Subsidy balance    ", address(subsidy).balance);
+
+        {
+            if (subsidy.isRegistered(BENEFICIARY)) {
+                emit log("Is registered");
+            }
+            ISubsidy.Subsidy memory sub = subsidy.getSubsidy(bridge, 0);
+            emit log_named_uint("available", sub.available);
+            emit log_named_uint("gasUsage", sub.gasUsage);
+            emit log_named_uint("gasPerMinute", sub.gasPerMinute);
+            emit log_named_uint("lastUpdated", sub.lastUpdated);
         }
     }
 
@@ -97,7 +165,7 @@ contract YearnMeasure is YearnDeployment {
         // Deposit
         {
             vm.broadcast();
-            gasBase.convert(bridge, wethAsset, empty, vyAsset, empty, 1 ether, 0, 0, address(this), 250000);
+            gasBase.convert(bridge, wethAsset, empty, vyAsset, empty, 1 ether, 0, 0, address(this), 17500);
         }
 
         // Withdraw
@@ -105,7 +173,7 @@ contract YearnMeasure is YearnDeployment {
             emit log_named_uint("bal", IERC20(vyAsset.erc20Address).balanceOf(address(gasBase)));
 
             vm.broadcast();
-            gasBase.convert(bridge, vyAsset, empty, wethAsset, empty, 0.1 ether, 1, 1, address(this), 250000);
+            gasBase.convert(bridge, vyAsset, empty, wethAsset, empty, 0.1 ether, 1, 1, address(this), 17500);
             emit log_named_uint("bal", IERC20(vyAsset.erc20Address).balanceOf(address(gasBase)));
         }
     }

--- a/src/test/aztec/base/BridgeTestBase.sol
+++ b/src/test/aztec/base/BridgeTestBase.sol
@@ -5,6 +5,7 @@ pragma solidity >=0.8.4;
 import {Test, Vm} from "forge-std/Test.sol";
 import {AztecTypes} from "./../../../aztec/libraries/AztecTypes.sol";
 import {IRollupProcessor} from "./../../../aztec/interfaces/IRollupProcessor.sol";
+import {ISubsidy} from "../../../aztec/interfaces/ISubsidy.sol";
 
 /**
  * @notice Helper contract that allow us to test bridges against the live rollup by sending mock rollups with defi interactions
@@ -103,6 +104,8 @@ abstract contract BridgeTestBase is Test {
 
     IRollupProcessor internal constant ROLLUP_PROCESSOR = IRollupProcessor(0xFF1F2B4ADb9dF6FC8eAFecDcbF96A2B351680455);
     IRollupProcessor internal constant IMPLEMENTATION = IRollupProcessor(0x3f972e325CecD99a6be267fd36ceB46DCa7C3F28);
+
+    ISubsidy internal constant SUBSIDY = ISubsidy(0xABc30E831B5Cc173A9Ed5941714A7845c909e7fA);
 
     address internal constant ROLLUP_PROVIDER = payable(0xA173BDdF4953C1E8be2cA0695CFc07502Ff3B1e7);
     address internal constant MULTI_SIG = 0xE298a76986336686CC3566469e3520d23D1a8aaD;

--- a/src/test/aztec/base/BridgeTestBase.sol
+++ b/src/test/aztec/base/BridgeTestBase.sol
@@ -123,6 +123,7 @@ abstract contract BridgeTestBase is Test {
     constructor() {
         vm.label(address(ROLLUP_PROCESSOR), "Rollup");
         vm.label(address(IMPLEMENTATION), "Implementation");
+        vm.label(address(SUBSIDY), "Subsidy");
         vm.label(ROLLUP_PROVIDER, "Rollup Provider");
         vm.label(MULTI_SIG, "Multisig");
         vm.label(ROLLUP_PROCESSOR.verifier(), "Verifier");

--- a/src/test/bridges/example/ExampleE2E.t.sol
+++ b/src/test/bridges/example/ExampleE2E.t.sol
@@ -102,6 +102,6 @@ contract ExampleE2ETest is BridgeTestBase {
         // Check that the balance of the rollup is same as before interaction (bridge just sends funds back)
         assertEq(_depositAmount, IERC20(USDC).balanceOf(address(ROLLUP_PROCESSOR)), "Balances must match");
 
-        assertGt(SUBSIDY.claimableAmount(BENEFICIARY), 1, "Claimable was not updated");
+        assertGt(SUBSIDY.claimableAmount(BENEFICIARY), 0, "Claimable was not updated");
     }
 }

--- a/src/test/bridges/example/ExampleE2E.t.sol
+++ b/src/test/bridges/example/ExampleE2E.t.sol
@@ -9,7 +9,6 @@ import {AztecTypes} from "../../../aztec/libraries/AztecTypes.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {ExampleBridgeContract} from "../../../bridges/example/ExampleBridge.sol";
 import {ErrorLib} from "../../../bridges/base/ErrorLib.sol";
-import {ISubsidy, Subsidy} from "../../../aztec/Subsidy.sol";
 
 /**
  * @notice The purpose of this test is to test the bridge in an environment that is as close to the final deployment
@@ -19,18 +18,14 @@ contract ExampleE2ETest is BridgeTestBase {
     address public constant USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
     address private constant BENEFICIARY = address(11);
 
-    ISubsidy private subsidy;
     // The reference to the example bridge
     ExampleBridgeContract internal bridge;
     // To store the id of the example bridge after being added
     uint256 private id;
 
     function setUp() public {
-        // Deploy the Subsidy contract in order to be able to test subsidy
-        subsidy = new Subsidy();
-
         // Deploy a new example bridge
-        bridge = new ExampleBridgeContract(address(ROLLUP_PROCESSOR), subsidy);
+        bridge = new ExampleBridgeContract(address(ROLLUP_PROCESSOR));
 
         // Use the label cheatcode to mark the address with "Example Bridge" in the traces
         vm.label(address(bridge), "Example Bridge");
@@ -58,9 +53,9 @@ contract ExampleE2ETest is BridgeTestBase {
         AztecTypes.AztecAsset memory usdcAsset = getRealAztecAsset(USDC);
         uint256 criteria = bridge.computeCriteria(usdcAsset, emptyAsset, usdcAsset, emptyAsset, 0);
         uint32 gasPerMinute = 200;
-        subsidy.subsidize{value: 1 ether}(address(bridge), criteria, gasPerMinute);
+        SUBSIDY.subsidize{value: 1 ether}(address(bridge), criteria, gasPerMinute);
 
-        subsidy.registerBeneficiary(BENEFICIARY);
+        SUBSIDY.registerBeneficiary(BENEFICIARY);
 
         // Set the rollupBeneficiary on BridgeTestBase so that it gets included in the proofData
         setRollupBeneficiary(BENEFICIARY);
@@ -107,6 +102,6 @@ contract ExampleE2ETest is BridgeTestBase {
         // Check that the balance of the rollup is same as before interaction (bridge just sends funds back)
         assertEq(_depositAmount, IERC20(USDC).balanceOf(address(ROLLUP_PROCESSOR)), "Balances must match");
 
-        assertGt(subsidy.claimableAmount(BENEFICIARY), 1, "Claimable was not updated");
+        assertGt(SUBSIDY.claimableAmount(BENEFICIARY), 1, "Claimable was not updated");
     }
 }

--- a/src/test/bridges/example/ExampleUnit.t.sol
+++ b/src/test/bridges/example/ExampleUnit.t.sol
@@ -30,8 +30,9 @@ contract ExampleUnitTest is BridgeTestBase {
         // Deploy a new example bridge
         bridge = new ExampleBridgeContract(rollupProcessor);
 
-        // Set ETH balance to 0 for clarity (somebody sent ETH to that address on mainnet)
+        // Set ETH balance of bridge and BENEFICIARY to 0 for clarity (somebody sent ETH to that address on mainnet)
         vm.deal(address(bridge), 0);
+        vm.deal(BENEFICIARY, 0);
 
         // Use the label cheatcode to mark the address with "Example Bridge" in the traces
         vm.label(address(bridge), "Example Bridge");
@@ -118,6 +119,7 @@ contract ExampleUnitTest is BridgeTestBase {
 
         assertEq(daiBalanceAfter - daiBalanceBefore, _depositAmount, "Balances must match");
 
+        SUBSIDY.withdraw(BENEFICIARY);
         assertGt(BENEFICIARY.balance, 0, "Subsidy was not claimed");
     }
 }

--- a/src/test/bridges/example/ExampleUnit.t.sol
+++ b/src/test/bridges/example/ExampleUnit.t.sol
@@ -9,7 +9,6 @@ import {AztecTypes} from "../../../aztec/libraries/AztecTypes.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {ExampleBridgeContract} from "../../../bridges/example/ExampleBridge.sol";
 import {ErrorLib} from "../../../bridges/base/ErrorLib.sol";
-import {ISubsidy, Subsidy} from "../../../aztec/Subsidy.sol";
 
 // @notice The purpose of this test is to directly test convert functionality of the bridge.
 contract ExampleUnitTest is BridgeTestBase {
@@ -17,7 +16,6 @@ contract ExampleUnitTest is BridgeTestBase {
     address private constant BENEFICIARY = address(11);
 
     address private rollupProcessor;
-    ISubsidy private subsidy;
     // The reference to the example bridge
     ExampleBridgeContract private bridge;
 
@@ -29,11 +27,8 @@ contract ExampleUnitTest is BridgeTestBase {
         // In unit tests we set address of rollupProcessor to the address of this test contract
         rollupProcessor = address(this);
 
-        // Deploy the Subsidy contract in order to be able to test subsidy
-        subsidy = new Subsidy();
-
         // Deploy a new example bridge
-        bridge = new ExampleBridgeContract(rollupProcessor, subsidy);
+        bridge = new ExampleBridgeContract(rollupProcessor);
 
         // Set ETH balance to 0 for clarity (somebody sent ETH to that address on mainnet)
         vm.deal(address(bridge), 0);
@@ -45,9 +40,9 @@ contract ExampleUnitTest is BridgeTestBase {
         AztecTypes.AztecAsset memory daiAsset = getRealAztecAsset(DAI);
         uint256 criteria = bridge.computeCriteria(daiAsset, emptyAsset, daiAsset, emptyAsset, 0);
         uint32 gasPerMinute = 200;
-        subsidy.subsidize{value: 1 ether}(address(bridge), criteria, gasPerMinute);
+        SUBSIDY.subsidize{value: 1 ether}(address(bridge), criteria, gasPerMinute);
 
-        subsidy.registerBeneficiary(BENEFICIARY);
+        SUBSIDY.registerBeneficiary(BENEFICIARY);
     }
 
     function testInvalidCaller(address _callerAddress) public {


### PR DESCRIPTION
# Changes

1. Updated ExampleBridge with mainnet Subsidy deployment,
2. fixed bug in example test,
3. fixed ExampleDeployment due to changes after rebase,
4. integrated Subsidy to ERC4626 bridge,
5. simplified Yearn bridge and integrated Subsidy in it.

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] There are no unexpected formatting changes, or superfluous debug logs.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewers next convenience.
