### PR TITLE
Add data provider

### DIFF
--- a/src/aztec/DataProvider.sol
+++ b/src/aztec/DataProvider.sol
@@ -5,6 +5,10 @@ pragma solidity >=0.8.4;
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {IRollupProcessor} from "./interfaces/IRollupProcessor.sol";
 
+/**
+ * @notice Helper used for mapping assets and bridges to more meaningful naming
+ * @author Aztec Team
+ */
 contract DataProvider is Ownable {
     struct BridgeData {
         address bridgeAddress;
@@ -36,6 +40,12 @@ contract DataProvider is Ownable {
         ROLLUP_PROCESSOR = IRollupProcessor(_rollupProcessor);
     }
 
+    /**
+     * @notice Adds a bridge with a specific tag
+     * @dev Only callable by the owner
+     * @param _bridgeAddressId The bridge address id for the bridge to list
+     * @param _tag The tag to list with the bridge
+     */
     function addBridge(uint256 _bridgeAddressId, string memory _tag) public onlyOwner {
         address bridgeAddress = ROLLUP_PROCESSOR.getSupportedBridge(_bridgeAddressId);
         if (bridgeAddress == address(0)) {
@@ -50,29 +60,78 @@ contract DataProvider is Ownable {
         });
     }
 
+    /**
+     * @notice Adds an asset with a specific tag
+     * @dev Only callable by the owner
+     * @param _assetId The asset id of the asset to list
+     * @param _tag The tag to list with the asset
+     */
     function addAsset(uint256 _assetId, string memory _tag) public onlyOwner {
         address assetAddress = ROLLUP_PROCESSOR.getSupportedAsset(_assetId);
-        if (assetAddress == address(0)) {
-            revert("Invalid asset");
-        }
         bytes32 digest = keccak256(abi.encode(_tag));
         assets.tagToId[digest] = _assetId;
         assets.data[_assetId] = AssetData({assetAddress: assetAddress, assetId: _assetId, label: _tag});
     }
 
+    /**
+     * @notice Fetch the `BridgeData` related to a specific bridgeAddressId
+     * @param _bridgeAddressId The bridge address id of the bridge to fetch
+     * @return The BridgeData data structure for the given bridge
+     */
     function getBridge(uint256 _bridgeAddressId) public view returns (BridgeData memory) {
         return bridges.data[_bridgeAddressId];
     }
 
+    /**
+     * @notice Fetch the `BridgeData` related to a specific tag
+     * @param _tag The tag of the bridge to fetch
+     * @return The BridgeData data structure for the given bridge
+     */
     function getBridge(string memory _tag) public view returns (BridgeData memory) {
         return bridges.data[bridges.tagToId[keccak256(abi.encode(_tag))]];
     }
 
+    /**
+     * @notice Fetch the `AssetData` related to a specific assetId
+     * @param _assetId The asset id of the asset to fetch
+     * @return The AssetData data structure for the given asset
+     */
     function getAsset(uint256 _assetId) public view returns (AssetData memory) {
         return assets.data[_assetId];
     }
 
+    /**
+     * @notice Fetch the `AssetData` related to a specific tag
+     * @param _tag The tag of the asset to fetch
+     * @return The AssetData data structure for the given asset
+     */
     function getAsset(string memory _tag) public view returns (AssetData memory) {
         return assets.data[assets.tagToId[keccak256(abi.encode(_tag))]];
+    }
+
+    /**
+     * @notice Fetch `AssetData` for all supported assets
+     * @return A list of AssetData data structures, one for every asset
+     */
+    function getAssets() public view returns (AssetData[] memory) {
+        uint256 assetCount = ROLLUP_PROCESSOR.getSupportedAssetsLength();
+        AssetData[] memory assetDatas = new AssetData[](assetCount);
+        for (uint256 i = 0; i < assetCount; i++) {
+            assetDatas[i] = getAsset(i);
+        }
+        return assetDatas;
+    }
+
+    /**
+     * @notice Fetch `BridgeData` for all supported bridges
+     * @return A list of BridgeData data structures, one for every bridge
+     */
+    function getBridges() public view returns (BridgeData[] memory) {
+        uint256 bridgeCount = ROLLUP_PROCESSOR.getSupportedBridgesLength();
+        BridgeData[] memory bridgeDatas = new BridgeData[](bridgeCount);
+        for (uint256 i = 1; i <= bridgeCount; i++) {
+            bridgeDatas[i - 1] = getBridge(i);
+        }
+        return bridgeDatas;
     }
 }

--- a/src/aztec/DataProvider.sol
+++ b/src/aztec/DataProvider.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2022 Aztec.
+pragma solidity >=0.8.4;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {IRollupProcessor} from "./interfaces/IRollupProcessor.sol";
+
+contract DataProvider is Ownable {
+    struct BridgeData {
+        address bridgeAddress;
+        uint256 bridgeAddressId;
+        string label;
+    }
+
+    struct AssetData {
+        address assetAddress;
+        uint256 assetId;
+        string label;
+    }
+
+    struct Bridges {
+        mapping(uint256 => BridgeData) data;
+        mapping(bytes32 => uint256) tagToId;
+    }
+
+    struct Assets {
+        mapping(uint256 => AssetData) data;
+        mapping(bytes32 => uint256) tagToId;
+    }
+
+    IRollupProcessor public immutable ROLLUP_PROCESSOR;
+    Bridges internal bridges;
+    Assets internal assets;
+
+    constructor(address _rollupProcessor) {
+        ROLLUP_PROCESSOR = IRollupProcessor(_rollupProcessor);
+    }
+
+    function addBridge(uint256 _bridgeAddressId, string memory _tag) public onlyOwner {
+        address bridgeAddress = ROLLUP_PROCESSOR.getSupportedBridge(_bridgeAddressId);
+        if (bridgeAddress == address(0)) {
+            revert("Invalid bridge");
+        }
+        bytes32 digest = keccak256(abi.encode(_tag));
+        bridges.tagToId[digest] = _bridgeAddressId;
+        bridges.data[_bridgeAddressId] = BridgeData({
+            bridgeAddress: bridgeAddress,
+            bridgeAddressId: _bridgeAddressId,
+            label: _tag
+        });
+    }
+
+    function addAsset(uint256 _assetId, string memory _tag) public onlyOwner {
+        address assetAddress = ROLLUP_PROCESSOR.getSupportedAsset(_assetId);
+        if (assetAddress == address(0)) {
+            revert("Invalid asset");
+        }
+        bytes32 digest = keccak256(abi.encode(_tag));
+        assets.tagToId[digest] = _assetId;
+        assets.data[_assetId] = AssetData({assetAddress: assetAddress, assetId: _assetId, label: _tag});
+    }
+
+    function getBridge(uint256 _bridgeAddressId) public view returns (BridgeData memory) {
+        return bridges.data[_bridgeAddressId];
+    }
+
+    function getBridge(string memory _tag) public view returns (BridgeData memory) {
+        return bridges.data[bridges.tagToId[keccak256(abi.encode(_tag))]];
+    }
+
+    function getAsset(uint256 _assetId) public view returns (AssetData memory) {
+        return assets.data[_assetId];
+    }
+
+    function getAsset(string memory _tag) public view returns (AssetData memory) {
+        return assets.data[assets.tagToId[keccak256(abi.encode(_tag))]];
+    }
+}

--- a/src/aztec/interfaces/IRollupProcessor.sol
+++ b/src/aztec/interfaces/IRollupProcessor.sol
@@ -107,4 +107,8 @@ interface IRollupProcessor {
     function getSupportedAsset(uint256 _assetId) external view returns (address);
 
     function getEscapeHatchStatus() external view returns (bool, uint256);
+
+    function assetGasLimits(uint256 _bridgeAddressId) external view returns (uint256);
+
+    function bridgeGasLimits(uint256 _bridgeAddressId) external view returns (uint256);
 }

--- a/src/client/aztec/data-provider/DataProvider.ts
+++ b/src/client/aztec/data-provider/DataProvider.ts
@@ -93,4 +93,8 @@ export class DataProviderWrapper {
   async getRollupProvider(): Promise<EthAddress> {
     return EthAddress.fromString(await this.dataProvider.ROLLUP_PROCESSOR());
   }
+
+  async getAccumulatedSubsidyAmount(bridgeCallData: bigint): Promise<bigint> {
+    return (await this.dataProvider.getAccumulatedSubsidyAmount(bridgeCallData)).toBigInt();
+  }
 }

--- a/src/client/aztec/data-provider/DataProvider.ts
+++ b/src/client/aztec/data-provider/DataProvider.ts
@@ -60,6 +60,36 @@ export class DataProviderWrapper {
     };
   }
 
+  async getAssets(): Promise<{ [key: string]: AssetData }> {
+    const assetDatas = await this.dataProvider.getAssets();
+    const dict: { [key: string]: AssetData } = {};
+    assetDatas.forEach(asset => {
+      if (asset.label != "") {
+        dict[asset.label] = {
+          assetAddress: EthAddress.fromString(asset.assetAddress),
+          assetId: asset.assetId.toNumber(),
+          label: asset.label,
+        };
+      }
+    });
+    return dict;
+  }
+
+  async getBridges(): Promise<{ [key: string]: BridgeData }> {
+    const bridgeDatas = await this.dataProvider.getBridges();
+    const dict: { [key: string]: BridgeData } = {};
+    bridgeDatas.forEach(bridge => {
+      if (bridge.label != "") {
+        dict[bridge.label] = {
+          bridgeAddress: EthAddress.fromString(bridge.bridgeAddress),
+          bridgeAddressId: bridge.bridgeAddressId.toNumber(),
+          label: bridge.label,
+        };
+      }
+    });
+    return dict;
+  }
+
   async getRollupProvider(): Promise<EthAddress> {
     return EthAddress.fromString(await this.dataProvider.ROLLUP_PROCESSOR());
   }

--- a/src/client/aztec/data-provider/DataProvider.ts
+++ b/src/client/aztec/data-provider/DataProvider.ts
@@ -1,0 +1,66 @@
+import { EthAddress } from "@aztec/barretenberg/address";
+import { EthereumProvider } from "@aztec/barretenberg/blockchain";
+import { DataProvider__factory } from "../../../../typechain-types";
+import { DataProvider } from "../../../typechain-types";
+import { createWeb3Provider } from "../provider";
+
+export interface AssetData {
+  assetAddress: EthAddress;
+  assetId: number;
+  label: string;
+}
+
+export interface BridgeData {
+  bridgeAddress: EthAddress;
+  bridgeAddressId: number;
+  label: string;
+}
+
+export class DataProviderWrapper {
+  private constructor(private dataProvider: DataProvider) {}
+
+  static create(provider: EthereumProvider, dataProviderAddress: EthAddress) {
+    const ethersProvider = createWeb3Provider(provider);
+    return new DataProviderWrapper(DataProvider__factory.connect(dataProviderAddress.toString(), ethersProvider));
+  }
+
+  async getBridgeByName(name: string): Promise<BridgeData> {
+    const bd = await this.dataProvider.getBridge(name);
+    return {
+      bridgeAddress: EthAddress.fromString(bd.bridgeAddress),
+      bridgeAddressId: bd.bridgeAddressId.toNumber(),
+      label: bd.label,
+    };
+  }
+
+  async getBridgeById(bridgeAddressId: number): Promise<BridgeData> {
+    const bd = await this.dataProvider.getBridge(bridgeAddressId);
+    return {
+      bridgeAddress: EthAddress.fromString(bd.bridgeAddress),
+      bridgeAddressId: bd.bridgeAddressId.toNumber(),
+      label: bd.label,
+    };
+  }
+
+  async getAssetByName(name: string): Promise<AssetData> {
+    const ad = await this.dataProvider.getAsset(name);
+    return {
+      assetAddress: EthAddress.fromString(ad.assetAddress),
+      assetId: ad.assetId.toNumber(),
+      label: ad.label,
+    };
+  }
+
+  async getAssetById(assetId: number): Promise<AssetData> {
+    const ad = await this.dataProvider.getAsset(assetId);
+    return {
+      assetAddress: EthAddress.fromString(ad.assetAddress),
+      assetId: ad.assetId.toNumber(),
+      label: ad.label,
+    };
+  }
+
+  async getRollupProvider(): Promise<EthAddress> {
+    return EthAddress.fromString(await this.dataProvider.ROLLUP_PROCESSOR());
+  }
+}

--- a/src/client/aztec/data-provider/DataProvider.ts
+++ b/src/client/aztec/data-provider/DataProvider.ts
@@ -1,7 +1,7 @@
 import { EthAddress } from "@aztec/barretenberg/address";
 import { EthereumProvider } from "@aztec/barretenberg/blockchain";
 import { DataProvider__factory } from "../../../../typechain-types";
-import { DataProvider } from "../../../typechain-types";
+import { DataProvider } from "../../../../typechain-types";
 import { createWeb3Provider } from "../provider";
 
 export interface AssetData {
@@ -25,7 +25,7 @@ export class DataProviderWrapper {
   }
 
   async getBridgeByName(name: string): Promise<BridgeData> {
-    const bd = await this.dataProvider.getBridge(name);
+    const bd = await this.dataProvider["getBridge(string)"](name);
     return {
       bridgeAddress: EthAddress.fromString(bd.bridgeAddress),
       bridgeAddressId: bd.bridgeAddressId.toNumber(),
@@ -34,7 +34,7 @@ export class DataProviderWrapper {
   }
 
   async getBridgeById(bridgeAddressId: number): Promise<BridgeData> {
-    const bd = await this.dataProvider.getBridge(bridgeAddressId);
+    const bd = await this.dataProvider["getBridge(uint256)"](bridgeAddressId);
     return {
       bridgeAddress: EthAddress.fromString(bd.bridgeAddress),
       bridgeAddressId: bd.bridgeAddressId.toNumber(),
@@ -43,7 +43,7 @@ export class DataProviderWrapper {
   }
 
   async getAssetByName(name: string): Promise<AssetData> {
-    const ad = await this.dataProvider.getAsset(name);
+    const ad = await this.dataProvider["getAsset(string)"](name);
     return {
       assetAddress: EthAddress.fromString(ad.assetAddress),
       assetId: ad.assetId.toNumber(),
@@ -52,7 +52,7 @@ export class DataProviderWrapper {
   }
 
   async getAssetById(assetId: number): Promise<AssetData> {
-    const ad = await this.dataProvider.getAsset(assetId);
+    const ad = await this.dataProvider["getAsset(uint256)"](assetId);
     return {
       assetAddress: EthAddress.fromString(ad.assetAddress),
       assetId: ad.assetId.toNumber(),

--- a/src/deployment/AggregateDeployment.s.sol
+++ b/src/deployment/AggregateDeployment.s.sol
@@ -2,7 +2,11 @@
 // Copyright 2022 Aztec.
 pragma solidity >=0.8.4;
 
-import {Test} from "forge-std/Test.sol";
+import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
+import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+
+import {BaseDeployment} from "./base/BaseDeployment.s.sol";
+import {IRollupProcessor} from "../aztec/interfaces/IRollupProcessor.sol";
 
 import {CompoundDeployment} from "./compound/CompoundDeployment.s.sol";
 import {CurveDeployment} from "./curve/CurveDeployment.s.sol";
@@ -15,7 +19,7 @@ import {YearnDeployment} from "./yearn/YearnDeployment.s.sol";
 /**
  * A helper script that allow easy deployment of multiple bridges
  */
-contract AggregateDeployment is Test {
+contract AggregateDeployment is BaseDeployment {
     function deployAndListAll() public {
         emit log("--- Curve ---");
         {
@@ -29,6 +33,32 @@ contract AggregateDeployment is Test {
             YearnDeployment yDeploy = new YearnDeployment();
             yDeploy.setUp();
             yDeploy.deployAndList();
+        }
+    }
+
+    function readStats() public {
+        IRollupProcessor rp = IRollupProcessor(ROLLUP_PROCESSOR);
+
+        uint256 assetCount = assetLength();
+        emit log_named_uint("Assets added ", assetCount);
+        for (uint256 i = 0; i < assetCount; i++) {
+            string memory symbol = i > 0 ? IERC20Metadata(rp.getSupportedAsset(i)).symbol() : "Eth";
+            uint256 gas = i > 0 ? rp.assetGasLimits(i) : 30000;
+            emit log_named_string(
+                string(abi.encodePacked("  Asset ", Strings.toString(i))),
+                string(abi.encodePacked(symbol, ", ", Strings.toString(gas)))
+            );
+        }
+
+        uint256 bridgeCount = bridgesLength();
+        emit log_named_uint("Bridges added", bridgeCount);
+        for (uint256 i = 1; i <= bridgeCount; i++) {
+            address bridge = rp.getSupportedBridge(i);
+            uint256 gas = rp.bridgeGasLimits(i);
+            emit log_named_string(
+                string(abi.encodePacked("  Bridge ", Strings.toString(i))),
+                string(abi.encodePacked(Strings.toHexString(bridge), ", ", Strings.toString(gas)))
+            );
         }
     }
 }

--- a/src/deployment/base/BaseDeployment.s.sol
+++ b/src/deployment/base/BaseDeployment.s.sol
@@ -55,10 +55,8 @@ abstract contract BaseDeployment is Test {
             NETWORK = Network.MAINNET;
         } else if (envNetworkHash == keccak256(abi.encodePacked("devnet"))) {
             NETWORK = Network.DEVNET;
-            vm.createSelectFork("https://mainnet-fork.aztec.network:8545");
         } else if (envNetworkHash == keccak256(abi.encodePacked("testnet"))) {
             NETWORK = Network.TESTNET;
-            vm.createSelectFork("https://mainnet-fork.aztec.network:8545");
         }
 
         if (envMode) {

--- a/src/deployment/dataprovider/DataProviderDeployment.s.sol
+++ b/src/deployment/dataprovider/DataProviderDeployment.s.sol
@@ -17,43 +17,45 @@ contract DataProviderDeployment is BaseDeployment {
         return address(provider);
     }
 
-    function listBridge(
-        address _provider,
-        uint256 _bridgeAddressId,
-        string memory _tag
-    ) public {
-        vm.broadcast();
-        DataProvider(_provider).addBridge(_bridgeAddressId, _tag);
-        emit log_named_uint(string(abi.encodePacked("[Bridge] Listed ", _tag, " at")), _bridgeAddressId);
-    }
-
-    function listAsset(
-        address _provider,
-        uint256 _assetId,
-        string memory _tag
-    ) public {
-        vm.broadcast();
-        DataProvider(_provider).addAsset(_assetId, _tag);
-        emit log_named_uint(string(abi.encodePacked("[Asset]  Listed ", _tag, " at")), _assetId);
-    }
+    function read() public {}
 
     function deployAndListMany() public {}
 
     function deployAndListDevNet() public {
         address provider = deploy();
 
-        listAsset(provider, 1, "Dai");
-        listAsset(provider, 2, "WSTETH");
-        listAsset(provider, 3, "vyDai");
-        listAsset(provider, 4, "vyWeth");
+        _listAsset(provider, 1, "Dai");
+        _listAsset(provider, 2, "WSTETH");
+        _listAsset(provider, 3, "vyDai");
+        _listAsset(provider, 4, "vyWeth");
 
-        listBridge(provider, 1, "Element Fixed Yield");
-        listBridge(provider, 6, "Curve swap steth pool");
-        listBridge(provider, 7, "Yearn Deposit");
-        listBridge(provider, 8, "Yearn Withdraw");
-        listBridge(provider, 9, "DCA DAI/ETH 7 Days");
+        _listBridge(provider, 1, "Element Fixed Yield");
+        _listBridge(provider, 6, "Curve swap steth pool");
+        _listBridge(provider, 7, "Yearn Deposit");
+        _listBridge(provider, 8, "Yearn Withdraw");
+        _listBridge(provider, 9, "DCA DAI/ETH 7 Days");
 
         DataProvider.BridgeData memory bridge = DataProvider(provider).getBridge("Yearn Withdraw");
         emit log_named_uint(bridge.label, bridge.bridgeAddressId);
+    }
+
+    function _listBridge(
+        address _provider,
+        uint256 _bridgeAddressId,
+        string memory _tag
+    ) internal {
+        vm.broadcast();
+        DataProvider(_provider).addBridge(_bridgeAddressId, _tag);
+        emit log_named_uint(string(abi.encodePacked("[Bridge] Listed ", _tag, " at")), _bridgeAddressId);
+    }
+
+    function _listAsset(
+        address _provider,
+        uint256 _assetId,
+        string memory _tag
+    ) internal {
+        vm.broadcast();
+        DataProvider(_provider).addAsset(_assetId, _tag);
+        emit log_named_uint(string(abi.encodePacked("[Asset]  Listed ", _tag, " at")), _assetId);
     }
 }

--- a/src/deployment/dataprovider/DataProviderDeployment.s.sol
+++ b/src/deployment/dataprovider/DataProviderDeployment.s.sol
@@ -24,7 +24,6 @@ contract DataProviderDeployment is BaseDeployment {
     ) public {
         vm.broadcast();
         DataProvider(_provider).addBridge(_bridgeAddressId, _tag);
-
         emit log_named_uint(string(abi.encodePacked("[Bridge] Listed ", _tag, " at")), _bridgeAddressId);
     }
 

--- a/src/deployment/dataprovider/DataProviderDeployment.s.sol
+++ b/src/deployment/dataprovider/DataProviderDeployment.s.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2022 Aztec.
+pragma solidity >=0.8.12;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {BaseDeployment} from "../base/BaseDeployment.s.sol";
+import {DataProvider} from "../../aztec/DataProvider.sol";
+
+contract DataProviderDeployment is BaseDeployment {
+    function deploy() public returns (address) {
+        emit log("Deploying Data Provider");
+
+        vm.broadcast();
+        DataProvider provider = new DataProvider(ROLLUP_PROCESSOR);
+        emit log_named_address("Data provider deployed to", address(provider));
+
+        return address(provider);
+    }
+
+    function listBridge(
+        address _provider,
+        uint256 _bridgeAddressId,
+        string memory _tag
+    ) public {
+        vm.broadcast();
+        DataProvider(_provider).addBridge(_bridgeAddressId, _tag);
+
+        emit log_named_uint(string.concat("[Bridge] Listed ", _tag, " at"), _bridgeAddressId);
+    }
+
+    function listAsset(
+        address _provider,
+        uint256 _assetId,
+        string memory _tag
+    ) public {
+        vm.broadcast();
+        DataProvider(_provider).addAsset(_assetId, _tag);
+        emit log_named_uint(string.concat("[Asset]  Listed ", _tag, " at"), _assetId);
+    }
+
+    function deployAndListMany() public {}
+
+    function deployAndListDevNet() public {
+        address provider = deploy();
+
+        listAsset(provider, 1, "Dai");
+        listAsset(provider, 2, "WSTETH");
+        listAsset(provider, 3, "vyDai");
+        listAsset(provider, 4, "vyWeth");
+
+        listBridge(provider, 1, "Element Fixed Yield");
+        listBridge(provider, 6, "Curve swap steth pool");
+        listBridge(provider, 7, "Yearn Deposit");
+        listBridge(provider, 8, "Yearn Withdraw");
+        listBridge(provider, 9, "DCA DAI/ETH 7 Days");
+
+        DataProvider.BridgeData memory bridge = DataProvider(provider).getBridge("Yearn Withdraw");
+        emit log_named_uint(bridge.label, bridge.bridgeAddressId);
+    }
+}

--- a/src/deployment/dataprovider/DataProviderDeployment.s.sol
+++ b/src/deployment/dataprovider/DataProviderDeployment.s.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2022 Aztec.
-pragma solidity >=0.8.12;
+pragma solidity >=0.8.4;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {BaseDeployment} from "../base/BaseDeployment.s.sol";
@@ -25,7 +25,7 @@ contract DataProviderDeployment is BaseDeployment {
         vm.broadcast();
         DataProvider(_provider).addBridge(_bridgeAddressId, _tag);
 
-        emit log_named_uint(string.concat("[Bridge] Listed ", _tag, " at"), _bridgeAddressId);
+        emit log_named_uint(string(abi.encodePacked("[Bridge] Listed ", _tag, " at")), _bridgeAddressId);
     }
 
     function listAsset(
@@ -35,7 +35,7 @@ contract DataProviderDeployment is BaseDeployment {
     ) public {
         vm.broadcast();
         DataProvider(_provider).addAsset(_assetId, _tag);
-        emit log_named_uint(string.concat("[Asset]  Listed ", _tag, " at"), _assetId);
+        emit log_named_uint(string(abi.encodePacked("[Asset]  Listed ", _tag, " at")), _assetId);
     }
 
     function deployAndListMany() public {}

--- a/src/deployment/yearn/YearnDeployment.s.sol
+++ b/src/deployment/yearn/YearnDeployment.s.sol
@@ -48,8 +48,8 @@ contract YearnDeployment is BaseDeployment {
         uint256 withdrawAddressId = listBridge(bridge, 800000);
         emit log_named_uint("Yearn withdraw bridge address id", withdrawAddressId);
 
-        listAsset(YEARN_REGISTRY.latestVault(DAI), 100000);
-        listAsset(YEARN_REGISTRY.latestVault(WETH), 100000);
+        listAsset(YEARN_REGISTRY.latestVault(DAI), 55000);
+        listAsset(YEARN_REGISTRY.latestVault(WETH), 55000);
 
         return bridge;
     }

--- a/src/test/aztec/dataprovider/DataProvider.t.sol
+++ b/src/test/aztec/dataprovider/DataProvider.t.sol
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2022 Aztec.
+pragma solidity >=0.8.4;
+
+import {BridgeTestBase} from "../base/BridgeTestBase.sol";
+import {DataProvider} from "../../../aztec/DataProvider.sol";
+
+contract DataProviderTest is BridgeTestBase {
+    DataProvider private provider;
+
+    function setUp() public {
+        provider = new DataProvider(address(ROLLUP_PROCESSOR));
+    }
+
+    function testGetAssetsEmptyLabels() public {
+        DataProvider.AssetData[] memory assets = provider.getAssets();
+
+        for (uint256 i = 0; i < assets.length; i++) {
+            DataProvider.AssetData memory asset = assets[i];
+            assertEq(asset.assetAddress, address(0));
+            assertEq(asset.assetId, 0);
+            assertEq(asset.label, "");
+        }
+    }
+
+    function testGetAssetsWithLabels() public {
+        string[4] memory labels = ["Eth", "Dai", "vyDai", "vyEth"];
+
+        for (uint256 i = 0; i < 4; i++) {
+            provider.addAsset(i, labels[i]);
+        }
+
+        DataProvider.AssetData[] memory assets = provider.getAssets();
+
+        for (uint256 i = 0; i < assets.length; i++) {
+            DataProvider.AssetData memory asset = assets[i];
+            assertEq(asset.assetAddress, ROLLUP_PROCESSOR.getSupportedAsset(i));
+            assertEq(asset.label, labels[i]);
+            assertEq(asset.assetId, i);
+        }
+    }
+
+    function testGetBridgesEmptyLabels() public {
+        DataProvider.BridgeData[] memory bridges = provider.getBridges();
+
+        for (uint256 i = 0; i < bridges.length; i++) {
+            DataProvider.BridgeData memory bridge = bridges[i];
+            assertEq(bridge.bridgeAddress, address(0));
+            assertEq(bridge.bridgeAddressId, 0);
+            assertEq(bridge.label, "");
+        }
+    }
+
+    function testGetBridgesWithLabels() public {
+        uint256 bridgeCount = ROLLUP_PROCESSOR.getSupportedBridgesLength();
+
+        string[] memory labels = new string[](bridgeCount + 1);
+        labels[0] = "start";
+
+        for (uint256 i = 1; i <= bridgeCount; i++) {
+            // Not a proper string but useful to distinguish between them
+            labels[i] = string(abi.encodePacked("Bridge", bytes4(keccak256(abi.encode(i)))));
+            provider.addBridge(i, labels[i]);
+        }
+
+        DataProvider.BridgeData[] memory bridges = provider.getBridges();
+
+        // Offset by one because of we are storing bridges
+        for (uint256 i = 0; i < bridges.length; i++) {
+            DataProvider.BridgeData memory bridge = bridges[i];
+            assertEq(bridge.bridgeAddress, ROLLUP_PROCESSOR.getSupportedBridge(i + 1));
+            assertEq(bridge.bridgeAddressId, i + 1);
+            assertEq(bridge.label, labels[i + 1]);
+        }
+    }
+}

--- a/src/test/aztec/dataprovider/DataProvider.t.sol
+++ b/src/test/aztec/dataprovider/DataProvider.t.sol
@@ -11,6 +11,9 @@ contract DataProviderTest is BridgeTestBase {
 
     function setUp() public {
         provider = new DataProvider(address(ROLLUP_PROCESSOR));
+
+        // fund yearn bridge to ensure that there are funds.
+        SUBSIDY.topUp{value: 10 ether}(ROLLUP_PROCESSOR.getSupportedBridge(7), 0);
     }
 
     function testGetAssetsEmptyLabels() public {

--- a/src/test/aztec/dataprovider/DataProvider.t.sol
+++ b/src/test/aztec/dataprovider/DataProvider.t.sol
@@ -2,6 +2,7 @@
 // Copyright 2022 Aztec.
 pragma solidity >=0.8.4;
 
+import {AztecTypes} from "./../../../aztec/libraries/AztecTypes.sol";
 import {BridgeTestBase} from "../base/BridgeTestBase.sol";
 import {DataProvider} from "../../../aztec/DataProvider.sol";
 
@@ -40,6 +41,22 @@ contract DataProviderTest is BridgeTestBase {
         }
     }
 
+    function testGetAssetWithLabels() public {
+        string[4] memory labels = ["Eth", "Dai", "vyDai", "vyEth"];
+
+        for (uint256 i = 0; i < 4; i++) {
+            provider.addAsset(i, labels[i]);
+            DataProvider.AssetData memory asset = provider.getAsset(labels[i]);
+            assertEq(asset.assetAddress, ROLLUP_PROCESSOR.getSupportedAsset(i));
+            assertEq(asset.label, labels[i]);
+            assertEq(asset.assetId, i);
+        }
+
+        DataProvider.AssetData[] memory assets = provider.getAssets();
+
+        for (uint256 i = 0; i < assets.length; i++) {}
+    }
+
     function testGetBridgesEmptyLabels() public {
         DataProvider.BridgeData[] memory bridges = provider.getBridges();
 
@@ -72,5 +89,65 @@ contract DataProviderTest is BridgeTestBase {
             assertEq(bridge.bridgeAddressId, i + 1);
             assertEq(bridge.label, labels[i + 1]);
         }
+    }
+
+    function testGetBridgeWithLabels() public {
+        uint256 bridgeCount = ROLLUP_PROCESSOR.getSupportedBridgesLength();
+
+        string[] memory labels = new string[](bridgeCount + 1);
+        labels[0] = "start";
+
+        for (uint256 i = 1; i <= bridgeCount; i++) {
+            // Not a proper string but useful to distinguish between them
+            labels[i] = string(abi.encodePacked("Bridge", bytes4(keccak256(abi.encode(i)))));
+            provider.addBridge(i, labels[i]);
+
+            DataProvider.BridgeData memory bridge = provider.getBridge(labels[i]);
+            assertEq(bridge.bridgeAddress, ROLLUP_PROCESSOR.getSupportedBridge(i));
+            assertEq(bridge.bridgeAddressId, i);
+            assertEq(bridge.label, labels[i]);
+        }
+    }
+
+    function testHappySubsidyHelper() public {
+        AztecTypes.AztecAsset memory empty;
+        AztecTypes.AztecAsset memory eth = getRealAztecAsset(address(0));
+        AztecTypes.AztecAsset memory vyvault = getRealAztecAsset(0xa258C4606Ca8206D8aA700cE2143D7db854D168c);
+
+        vm.warp(block.timestamp + 1 days);
+
+        uint256 bridgeCallData = encodeBridgeCallData(7, eth, empty, vyvault, empty, 0);
+        uint256 subsidy = provider.getAccumulatedSubsidyAmount(bridgeCallData);
+
+        assertGt(subsidy, 0, "No subsidy accrued");
+    }
+
+    function testHappySubsidyHelper2InOut() public {
+        AztecTypes.AztecAsset memory eth = getRealAztecAsset(address(0));
+        AztecTypes.AztecAsset memory dai = getRealAztecAsset(0x6B175474E89094C44Da98b954EedeAC495271d0F);
+        uint256 bridgeCallData = encodeBridgeCallData(7, dai, eth, dai, eth, 0);
+        uint256 subsidy = provider.getAccumulatedSubsidyAmount(bridgeCallData);
+        assertGt(subsidy, 0, "No subsidy accrued");
+    }
+
+    function testHappySubsidyHelperVirtual() public {
+        AztecTypes.AztecAsset memory eth = getRealAztecAsset(address(0));
+        AztecTypes.AztecAsset memory virtualAsset = AztecTypes.AztecAsset({
+            id: 0,
+            erc20Address: address(0),
+            assetType: AztecTypes.AztecAssetType.VIRTUAL
+        });
+
+        uint256 bridgeCallData = encodeBridgeCallData(7, virtualAsset, eth, virtualAsset, eth, 0);
+        uint256 subsidy = provider.getAccumulatedSubsidyAmount(bridgeCallData);
+        assertGt(subsidy, 0, "No subsidy accrued");
+    }
+
+    function testUnHappySubsidyHelper() public {
+        AztecTypes.AztecAsset memory empty;
+        AztecTypes.AztecAsset memory dai = getRealAztecAsset(0x6B175474E89094C44Da98b954EedeAC495271d0F);
+        uint256 bridgeCallData = encodeBridgeCallData(1, dai, empty, dai, empty, 0);
+        uint256 subsidy = provider.getAccumulatedSubsidyAmount(bridgeCallData);
+        assertEq(subsidy, 0, "Subsidy have accrued");
     }
 }


### PR DESCRIPTION
# Description

Adds a data provider that can be used to more easily find the bridgeAddressId or assetIds based on labels. 

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] There are no unexpected formatting changes, or superfluous debug logs.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewers next convenience.
- [x] NatSpec documentation of all the non-test functions is present and is complete.
- [x] Continuous integration (CI) passes.
- [x] Command `forge coverage --match-contract MyContract` returns 100% line coverage.
- [x] All the possible reverts are tested.
