### PR TITLE
Fetch address from status endpoint for dev and testnets

### DIFF
--- a/src/deployment/base/BaseDeployment.s.sol
+++ b/src/deployment/base/BaseDeployment.s.sol
@@ -93,24 +93,20 @@ abstract contract BaseDeployment is Test {
         }
     }
 
+    /**
+     * @notice Fetches the testnet rollup processor from the status endpoint
+     * @return The address of the rollup processor
+     */
     function getTestnetRollupProcessor() public returns (address) {
-        string[] memory inputs = new string[](3);
-        inputs[0] = "curl";
-        inputs[1] = "-s";
-        inputs[2] = "https://api.aztec.network/aztec-connect-testnet/falafel/status";
-        bytes memory res = vm.ffi(inputs);
-        string memory json = string(res);
-        return json.readAddress(".blockchainStatus.rollupContractAddress");
+        return _fetchFromStatus("https://api.aztec.network/aztec-connect-testnet/falafel/status");
     }
 
+    /**
+     * @notice Fetches the devnet rollup processor from the status endpoint
+     * @return The address of the rollup processor
+     */
     function getDevnetRollupProcessor() public returns (address) {
-        string[] memory inputs = new string[](3);
-        inputs[0] = "curl";
-        inputs[1] = "-s";
-        inputs[2] = "https://api.aztec.network/aztec-connect-dev/falafel/status";
-        bytes memory res = vm.ffi(inputs);
-        string memory json = string(res);
-        return json.readAddress(".blockchainStatus.rollupContractAddress");
+        return _fetchFromStatus("https://api.aztec.network/aztec-connect-dev/falafel/status");
     }
 
     /**
@@ -212,5 +208,15 @@ abstract contract BaseDeployment is Test {
             }
         }
         return (false, 0);
+    }
+
+    function _fetchFromStatus(string memory _url) private returns (address) {
+        string[] memory inputs = new string[](3);
+        inputs[0] = "curl";
+        inputs[1] = "-s";
+        inputs[2] = _url;
+        bytes memory res = vm.ffi(inputs);
+        string memory json = string(res);
+        return json.readAddress(".blockchainStatus.rollupContractAddress");
     }
 }

--- a/src/deployment/base/BaseDeployment.s.sol
+++ b/src/deployment/base/BaseDeployment.s.sol
@@ -193,6 +193,16 @@ abstract contract BaseDeployment is Test {
         return IRollupProcessor(ROLLUP_PROCESSOR).getSupportedAssetsLength();
     }
 
+    function _fetchFromStatus(string memory _url) private returns (address) {
+        string[] memory inputs = new string[](3);
+        inputs[0] = "curl";
+        inputs[1] = "-s";
+        inputs[2] = _url;
+        bytes memory res = vm.ffi(inputs);
+        string memory json = string(res);
+        return json.readAddress(".blockchainStatus.rollupContractAddress");
+    }
+
     /**
      * @notice Fetch whether an `_asset` is supported or not on the rollup
      */
@@ -208,15 +218,5 @@ abstract contract BaseDeployment is Test {
             }
         }
         return (false, 0);
-    }
-
-    function _fetchFromStatus(string memory _url) private returns (address) {
-        string[] memory inputs = new string[](3);
-        inputs[0] = "curl";
-        inputs[1] = "-s";
-        inputs[2] = _url;
-        bytes memory res = vm.ffi(inputs);
-        string memory json = string(res);
-        return json.readAddress(".blockchainStatus.rollupContractAddress");
     }
 }

--- a/src/deployment/base/BaseDeployment.s.sol
+++ b/src/deployment/base/BaseDeployment.s.sol
@@ -55,8 +55,10 @@ abstract contract BaseDeployment is Test {
             NETWORK = Network.MAINNET;
         } else if (envNetworkHash == keccak256(abi.encodePacked("devnet"))) {
             NETWORK = Network.DEVNET;
+            vm.createSelectFork("https://mainnet-fork.aztec.network:8545");
         } else if (envNetworkHash == keccak256(abi.encodePacked("testnet"))) {
             NETWORK = Network.TESTNET;
+            vm.createSelectFork("https://mainnet-fork.aztec.network:8545");
         }
 
         if (envMode) {

--- a/src/deployment/base/BaseDeployment.s.sol
+++ b/src/deployment/base/BaseDeployment.s.sol
@@ -4,8 +4,10 @@ pragma solidity >=0.8.4;
 
 import {IRollupProcessor} from "../../aztec/interfaces/IRollupProcessor.sol";
 import {Test} from "forge-std/Test.sol";
+import {stdJson} from "forge-std/StdJson.sol";
 
 abstract contract BaseDeployment is Test {
+    using stdJson for string;
     /**
      * @notice Enum used as part of the configuration, defines what network and addresses to use.
      */
@@ -24,9 +26,6 @@ abstract contract BaseDeployment is Test {
         SIMULATE,
         BROADCAST
     }
-
-    address private constant DEVNET_ROLLUP = 0xE33d8C775eCf4a2F6857053068e2E36d1dAdE63F;
-    address private constant TESTNET_ROLLUP = 0x4598038EF8E9fE4284EA211521eD3067640F550F;
 
     address private constant MAINNET_MS = 0xE298a76986336686CC3566469e3520d23D1a8aaD;
     address private constant DEVNET_MS = 0x7095057A08879e09DC1c0a85520e3160A0F67C96;
@@ -86,12 +85,32 @@ abstract contract BaseDeployment is Test {
         if (chainId == 1 && NETWORK == Network.MAINNET) {
             return (getMainnetRollupProcessor(), MAINNET_MS);
         } else if (chainId == 0xa57ec && NETWORK == Network.TESTNET) {
-            return (TESTNET_ROLLUP, TESTNET_MS);
+            return (getTestnetRollupProcessor(), TESTNET_MS);
         } else if (chainId == 0xa57ec && NETWORK == Network.DEVNET) {
-            return (DEVNET_ROLLUP, DEVNET_MS);
+            return (getDevnetRollupProcessor(), DEVNET_MS);
         } else {
             revert("Invalid configuration");
         }
+    }
+
+    function getTestnetRollupProcessor() public returns (address) {
+        string[] memory inputs = new string[](3);
+        inputs[0] = "curl";
+        inputs[1] = "-s";
+        inputs[2] = "https://api.aztec.network/aztec-connect-testnet/falafel/status";
+        bytes memory res = vm.ffi(inputs);
+        string memory json = string(res);
+        return json.readAddress(".blockchainStatus.rollupContractAddress");
+    }
+
+    function getDevnetRollupProcessor() public returns (address) {
+        string[] memory inputs = new string[](3);
+        inputs[0] = "curl";
+        inputs[1] = "-s";
+        inputs[2] = "https://api.aztec.network/aztec-connect-dev/falafel/status";
+        bytes memory res = vm.ffi(inputs);
+        string memory json = string(res);
+        return json.readAddress(".blockchainStatus.rollupContractAddress");
     }
 
     /**


### PR DESCRIPTION
# Description

Replaces the hardcoded addresses in the `BaseDeployment.s.sol` script to use the FFI cheatcode to fetch latest rollup processor addresses for the dev- and testnets. Deployment scripts need to use `--ffi` to get this properly.

Also using `createSelectFork` to simplify deployments

Quality of life improvement. 

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] There are no unexpected formatting changes, or superfluous debug logs.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewers next convenience.
- [x] NatSpec documentation of all the non-test functions is present and is complete.
- [x] Continuous integration (CI) passes.
- [x] Command `forge coverage --match-contract MyContract` returns 100% line coverage.
- [x] All the possible reverts are tested.
