### PR TITLE
Feat: update tags for multiple assets and bridges at once

### DIFF
--- a/src/aztec/DataProvider.sol
+++ b/src/aztec/DataProvider.sol
@@ -87,7 +87,7 @@ contract DataProvider is Ownable {
 
     /**
      * @notice Adds multiple bridges with specific tags
-     * @dev Indicrectly Only callable by the owner
+     * @dev Indirectly Only callable by the owner
      * @param _assetIds List of asset Ids
      * @param _assetTags List of tags to be used for the asset ids
      * @param _bridgeAddressIds The list of bridge address ids

--- a/src/aztec/DataProvider.sol
+++ b/src/aztec/DataProvider.sol
@@ -86,6 +86,31 @@ contract DataProvider is Ownable {
     }
 
     /**
+     * @notice Adds multiple bridges with specific tags
+     * @dev Indicrectly Only callable by the owner
+     * @param _assetIds List of asset Ids
+     * @param _assetTags List of tags to be used for the asset ids
+     * @param _bridgeAddressIds The list of bridge address ids
+     * @param _bridgeTags List of tags to be used for the bridges
+     */
+    function addAssetsAndBridges(
+        uint256[] memory _assetIds,
+        string[] memory _assetTags,
+        uint256[] memory _bridgeAddressIds,
+        string[] memory _bridgeTags
+    ) public {
+        if (_assetIds.length != _assetTags.length || _bridgeAddressIds.length != _bridgeTags.length) {
+            revert("Invalid input lengths");
+        }
+        for (uint256 i = 0; i < _assetTags.length; i++) {
+            addAsset(_assetIds[i], _assetTags[i]);
+        }
+        for (uint256 i = 0; i < _bridgeTags.length; i++) {
+            addBridge(_bridgeAddressIds[i], _bridgeTags[i]);
+        }
+    }
+
+    /**
      * @notice Fetch the `BridgeData` related to a specific bridgeAddressId
      * @param _bridgeAddressId The bridge address id of the bridge to fetch
      * @return The BridgeData data structure for the given bridge

--- a/src/aztec/DataProvider.sol
+++ b/src/aztec/DataProvider.sol
@@ -87,7 +87,7 @@ contract DataProvider is Ownable {
 
     /**
      * @notice Adds multiple bridges with specific tags
-     * @dev Indirectly Only callable by the owner
+     * @dev Indirectly only callable by the owner
      * @param _assetIds List of asset Ids
      * @param _assetTags List of tags to be used for the asset ids
      * @param _bridgeAddressIds The list of bridge address ids

--- a/src/deployment/dataprovider/DataProviderDeployment.s.sol
+++ b/src/deployment/dataprovider/DataProviderDeployment.s.sol
@@ -19,24 +19,35 @@ contract DataProviderDeployment is BaseDeployment {
 
     function read() public {}
 
-    function deployAndListMany() public {}
-
-    function deployAndListDevNet() public {
+    function deployAndListMany() public {
         address provider = deploy();
 
-        _listAsset(provider, 1, "Dai");
-        _listAsset(provider, 2, "WSTETH");
-        _listAsset(provider, 3, "vyDai");
-        _listAsset(provider, 4, "vyWeth");
+        uint256[] memory assetIds = new uint256[](5);
+        string[] memory assetTags = new string[](5);
+        for (uint256 i = 0; i < 5; i++) {
+            assetIds[i] = i;
+        }
+        assetTags[0] = "eth";
+        assetTags[1] = "dai";
+        assetTags[2] = "wsteth";
+        assetTags[3] = "vydai";
+        assetTags[4] = "vyweth";
 
-        _listBridge(provider, 1, "Element Fixed Yield");
-        _listBridge(provider, 6, "Curve swap steth pool");
-        _listBridge(provider, 7, "Yearn Deposit");
-        _listBridge(provider, 8, "Yearn Withdraw");
-        _listBridge(provider, 9, "DCA DAI/ETH 7 Days");
+        uint256[] memory bridgeAddressIds = new uint256[](4);
+        string[] memory bridgeTags = new string[](4);
 
-        DataProvider.BridgeData memory bridge = DataProvider(provider).getBridge("Yearn Withdraw");
-        emit log_named_uint(bridge.label, bridge.bridgeAddressId);
+        bridgeAddressIds[0] = 1;
+        bridgeAddressIds[1] = 6;
+        bridgeAddressIds[2] = 7;
+        bridgeAddressIds[3] = 8;
+
+        bridgeTags[0] = "ElementBridge";
+        bridgeTags[1] = "CurveStEthBridge";
+        bridgeTags[2] = "YearnBridge_Deposit";
+        bridgeTags[3] = "YearnBridge_Withdraw";
+
+        vm.broadcast();
+        DataProvider(provider).addAssetsAndBridges(assetIds, assetTags, bridgeAddressIds, bridgeTags);
     }
 
     function _listBridge(


### PR DESCRIPTION
# Description

Adds a function to add multiple bridges and assets at once to the data provider.

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] There are no unexpected formatting changes, or superfluous debug logs.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewers next convenience.
- [x] NatSpec documentation of all the non-test functions is present and is complete.
- [x] Continuous integration (CI) passes.
- [x] Command `forge coverage --match-contract MyContract` returns 100% line coverage.
- [x] All the possible reverts are tested.
