### PR TITLE
fix: add +1 for assets length to fetch eth asset as well

### DIFF
--- a/src/aztec/DataProvider.sol
+++ b/src/aztec/DataProvider.sol
@@ -148,12 +148,13 @@ contract DataProvider is Ownable {
 
     /**
      * @notice Fetch `AssetData` for all supported assets
+     * @dev +1 because the Eth base asset is added as well
      * @return A list of AssetData data structures, one for every asset
      */
     function getAssets() public view returns (AssetData[] memory) {
         uint256 assetCount = ROLLUP_PROCESSOR.getSupportedAssetsLength();
-        AssetData[] memory assetDatas = new AssetData[](assetCount);
-        for (uint256 i = 0; i < assetCount; i++) {
+        AssetData[] memory assetDatas = new AssetData[](assetCount + 1);
+        for (uint256 i = 0; i <= assetCount; i++) {
             assetDatas[i] = getAsset(i);
         }
         return assetDatas;

--- a/src/deployment/dataprovider/DataProviderDeployment.s.sol
+++ b/src/deployment/dataprovider/DataProviderDeployment.s.sol
@@ -17,7 +17,24 @@ contract DataProviderDeployment is BaseDeployment {
         return address(provider);
     }
 
-    function read() public {}
+    function read() public {
+        // Todo: Replace address of data provider
+        DataProvider provider = DataProvider(0);
+
+        DataProvider.AssetData[] memory assets = provider.getAssets();
+        for (uint256 i = 0; i < assets.length; i++) {
+            DataProvider.AssetData memory asset = assets[i];
+            emit log_named_uint(asset.label, asset.assetId);
+        }
+
+        DataProvider.BridgeData[] memory bridges = provider.getBridges();
+        for (uint256 i = 0; i < bridges.length; i++) {
+            DataProvider.BridgeData memory bridge = bridges[i];
+            if (bridge.bridgeAddressId != 0) {
+                emit log_named_uint(bridge.label, bridge.bridgeAddressId);
+            }
+        }
+    }
 
     function deployAndListMany() public {
         address provider = deploy();
@@ -33,18 +50,20 @@ contract DataProviderDeployment is BaseDeployment {
         assetTags[3] = "vydai";
         assetTags[4] = "vyweth";
 
-        uint256[] memory bridgeAddressIds = new uint256[](4);
-        string[] memory bridgeTags = new string[](4);
+        uint256[] memory bridgeAddressIds = new uint256[](5);
+        string[] memory bridgeTags = new string[](5);
 
         bridgeAddressIds[0] = 1;
         bridgeAddressIds[1] = 6;
         bridgeAddressIds[2] = 7;
         bridgeAddressIds[3] = 8;
+        bridgeAddressIds[4] = 9;
 
         bridgeTags[0] = "ElementBridge";
         bridgeTags[1] = "CurveStEthBridge";
         bridgeTags[2] = "YearnBridge_Deposit";
         bridgeTags[3] = "YearnBridge_Withdraw";
+        bridgeTags[4] = "ElementBridge2M";
 
         vm.broadcast();
         DataProvider(provider).addAssetsAndBridges(assetIds, assetTags, bridgeAddressIds, bridgeTags);

--- a/src/deployment/dataprovider/DataProviderDeployment.s.sol
+++ b/src/deployment/dataprovider/DataProviderDeployment.s.sol
@@ -19,7 +19,7 @@ contract DataProviderDeployment is BaseDeployment {
 
     function read() public {
         // Todo: Replace address of data provider
-        DataProvider provider = DataProvider(0);
+        DataProvider provider = DataProvider(address(0));
 
         DataProvider.AssetData[] memory assets = provider.getAssets();
         for (uint256 i = 0; i < assets.length; i++) {

--- a/src/test/aztec/dataprovider/DataProvider.t.sol
+++ b/src/test/aztec/dataprovider/DataProvider.t.sol
@@ -52,11 +52,18 @@ contract DataProviderTest is BridgeTestBase {
         provider.addAssetsAndBridges(assetIds, assetTags, bridgeAddressIds, bridgeTags);
 
         DataProvider.AssetData[] memory assets = provider.getAssets();
+        assertEq(assets.length, ROLLUP_PROCESSOR.getSupportedAssetsLength() + 1);
         for (uint256 i = 0; i < assets.length; i++) {
             DataProvider.AssetData memory asset = assets[i];
-            assertEq(asset.assetId, i);
-            assertEq(asset.assetAddress, ROLLUP_PROCESSOR.getSupportedAsset(asset.assetId));
-            assertEq(asset.label, assetTags[i]);
+            if (i < assetIds.length) {
+                assertEq(asset.assetAddress, ROLLUP_PROCESSOR.getSupportedAsset(asset.assetId));
+                assertEq(asset.label, assetTags[i]);
+                assertEq(asset.assetId, i);
+            } else {
+                assertEq(asset.assetAddress, address(0));
+                assertEq(asset.label, "");
+                assertEq(asset.assetId, 0);
+            }
         }
 
         DataProvider.BridgeData[] memory bridges = provider.getBridges();
@@ -84,19 +91,26 @@ contract DataProviderTest is BridgeTestBase {
     }
 
     function testGetAssetsWithLabels() public {
-        string[4] memory labels = ["Eth", "Dai", "vyDai", "vyEth"];
+        string[4] memory labels = ["eth", "dai", "vydai", "vyeth"];
 
         for (uint256 i = 0; i < 4; i++) {
             provider.addAsset(i, labels[i]);
         }
 
         DataProvider.AssetData[] memory assets = provider.getAssets();
+        assertEq(assets.length, ROLLUP_PROCESSOR.getSupportedAssetsLength() + 1); // remember Eth base asset
 
         for (uint256 i = 0; i < assets.length; i++) {
             DataProvider.AssetData memory asset = assets[i];
-            assertEq(asset.assetAddress, ROLLUP_PROCESSOR.getSupportedAsset(i));
-            assertEq(asset.label, labels[i]);
-            assertEq(asset.assetId, i);
+            if (i < labels.length) {
+                assertEq(asset.assetAddress, ROLLUP_PROCESSOR.getSupportedAsset(i));
+                assertEq(asset.label, labels[i]);
+                assertEq(asset.assetId, i);
+            } else {
+                assertEq(asset.assetAddress, address(0));
+                assertEq(asset.label, "");
+                assertEq(asset.assetId, 0);
+            }
         }
     }
 


### PR DESCRIPTION
# Description

Fixes a flag in the Data Provider where not all assets were returned by the `getAssets()` getter because of the offset by the Eth base asset. 

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] There are no unexpected formatting changes, or superfluous debug logs.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewers next convenience.
- [x] NatSpec documentation of all the non-test functions is present and is complete.
- [x] Continuous integration (CI) passes.
- [x] Command `forge coverage --match-contract MyContract` returns 100% line coverage.
- [x] All the possible reverts are tested.
