### PR TITLE
Handle multiple DefiBridgeProcessed events in `sendDefiRollup(...)`

### DIFF
--- a/src/test/aztec/base/BridgeTestBase.t.sol
+++ b/src/test/aztec/base/BridgeTestBase.t.sol
@@ -59,38 +59,6 @@ contract BridgeTestBaseTest is BridgeTestBase {
         assertTrue(isAsync, "Interaction unexpectedly async");
     }
 
-    function testGetDefiBridgeProcessedDataIncorrectNumEvents() public {
-        vm.recordLogs();
-        emit DefiBridgeProcessed(126, 12, 41, 9769836, 35345, true, "");
-        emit DefiBridgeProcessed(12354, 354, 623, 26634, 6342, true, "");
-        vm.expectRevert("Incorrect number of events found");
-        _getDefiBridgeProcessedData();
-    }
-
-    function testGetDefiBridgeProcessedDataIncorrectNumEventsAsync() public {
-        vm.recordLogs();
-        emit AsyncDefiBridgeProcessed(126, 12, 1e18);
-        emit AsyncDefiBridgeProcessed(126, 12, 1e18);
-        vm.expectRevert("Incorrect number of events found");
-        _getDefiBridgeProcessedData();
-    }
-
-    function testGetDefiBridgeProcessedDataIncorrectNumEventsNoEvent() public {
-        vm.recordLogs();
-        vm.expectRevert("Incorrect number of events found");
-        _getDefiBridgeProcessedData();
-    }
-
-    function testGetDefiBridgeProcessedDataIncorrectNumEventsSyncAndAsync() public {
-        vm.recordLogs();
-        emit DefiBridgeProcessed(126, 12, 41, 9769836, 35345, true, "");
-        emit AsyncDefiBridgeProcessed(126, 12, 1e18);
-        emit AsyncDefiBridgeProcessed(126, 12, 1e18);
-        emit DefiBridgeProcessed(12354, 354, 623, 26634, 6342, true, "");
-        vm.expectRevert("Incorrect number of events found");
-        _getDefiBridgeProcessedData();
-    }
-
     function testRollupBeneficiaryEncoding() public {
         address beneficiary = 0x508383c4cbD351dC2d4F632C65Ee9d2BC79612EC;
         this.setRollupBeneficiary(beneficiary);


### PR DESCRIPTION
# Description

When bridge finalises interactions from its `convert(...)` function more than 1 `DefiBridgeProcessed` events get emitted which caused `_getDefiBridgeProcessedData()` function to revert. This PR fixes it.

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] There are no unexpected formatting changes, or superfluous debug logs.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewers next convenience.
- [x] NatSpec documentation of all the non-test functions is present and is complete.
- [ ] Continuous integration (CI) passes.
- [ ] Command `forge coverage --match-contract MyContract` returns 100% line coverage.
- [x] All the possible reverts are tested.
