### PR TITLE
fix: extend aggregate to include euler

### DIFF
--- a/src/deployment/AggregateDeployment.s.sol
+++ b/src/deployment/AggregateDeployment.s.sol
@@ -34,14 +34,38 @@ contract AggregateDeployment is BaseDeployment {
             yDeploy.setUp();
             yDeploy.deployAndList();
         }
+
+        emit log("--- ERC4626 ---");
+        {
+            ERC4626Deployment deploy = new ERC4626Deployment();
+            deploy.setUp();
+            deploy.deployAndList();
+        }
+
+        emit log("--- Euler ---");
+        {
+            address erc4626EulerWETH = 0x3c66B18F67CA6C1A71F829E2F6a0c987f97462d0;
+            uint256 weWethAssetId = listAsset(erc4626EulerWETH, 55000);
+            emit log_named_uint("ERC4626 euler weth id", weWethAssetId);
+
+            address erc4626EulerWSTETH = 0x60897720AA966452e8706e74296B018990aEc527;
+            uint256 wewstEthAssetId = listAsset(erc4626EulerWSTETH, 55000);
+            emit log_named_uint("ERC4626 euler wstEth id", wewstEthAssetId);
+
+            address erc4626EulerDai = 0x4169Df1B7820702f566cc10938DA51F6F597d264;
+            uint256 wedaiAssetId = listAsset(erc4626EulerDai, 55000);
+            emit log_named_uint("ERC4626 euler dai id", wedaiAssetId);
+        }
+
+        readStats();
     }
 
     function readStats() public {
         IRollupProcessor rp = IRollupProcessor(ROLLUP_PROCESSOR);
 
         uint256 assetCount = assetLength();
-        emit log_named_uint("Assets added ", assetCount);
-        for (uint256 i = 0; i < assetCount; i++) {
+        emit log_named_uint("Assets", assetCount + 1);
+        for (uint256 i = 0; i <= assetCount; i++) {
             string memory symbol = i > 0 ? IERC20Metadata(rp.getSupportedAsset(i)).symbol() : "Eth";
             uint256 gas = i > 0 ? rp.assetGasLimits(i) : 30000;
             emit log_named_string(
@@ -51,7 +75,7 @@ contract AggregateDeployment is BaseDeployment {
         }
 
         uint256 bridgeCount = bridgesLength();
-        emit log_named_uint("Bridges added", bridgeCount);
+        emit log_named_uint("Bridges", bridgeCount);
         for (uint256 i = 1; i <= bridgeCount; i++) {
             address bridge = rp.getSupportedBridge(i);
             uint256 gas = rp.bridgeGasLimits(i);

--- a/src/deployment/erc4626/ERC4626Deployment.s.sol
+++ b/src/deployment/erc4626/ERC4626Deployment.s.sol
@@ -17,4 +17,13 @@ contract ERC4626Deployment is BaseDeployment {
 
         return address(bridge);
     }
+
+    function deployAndList() public returns (address) {
+        address bridge = deploy();
+
+        uint256 depositAddressId = listBridge(bridge, 300000);
+        emit log_named_uint("ERC4626 bridge address id", depositAddressId);
+
+        return bridge;
+    }
 }


### PR DESCRIPTION
# Description

Extends the aggregate deployment script to deploy the ERC4626 bridge + add euler erc4626 wrappers from timeless for dai, weth and wsteth.

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] There are no unexpected formatting changes, or superfluous debug logs.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewers next convenience.
- [x] NatSpec documentation of all the non-test functions is present and is complete.
- [x] Continuous integration (CI) passes.
- [x] Command `forge coverage --match-contract MyContract` returns 100% line coverage.
- [x] All the possible reverts are tested.
