### PR TITLE
Stacking lido's apr on top of euler's

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aztec/bridge-clients",
-  "version": "0.1.62",
+  "version": "0.1.63",
   "description": "This repo contains the solidity files and typescript helper class for all of the Aztec Connect Bridge Contracts",
   "repository": "git@github.com:AztecProtocol/aztec-connect-bridges.git",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Description
Stacking lido's apr on top of euler's when the underlying is wstETH.

## Note
@joss-aztec The bridge class takes into consideration the lido yield if you create its instance with `createWithLido` function. I had to do it like this because the class is extending `ERC4626BridgeData` and it's not allowed by typescript to override a parent's class without keeping its arguments.

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] There are no unexpected formatting changes, or superfluous debug logs.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewers next convenience.
- [ ] NatSpec documentation of all the non-test functions is present and is complete.
- [ ] Continuous integration (CI) passes.
- [ ] Command `forge coverage --match-contract MyContract` returns 100% line coverage.
- [ ] All the possible reverts are tested.
