### PR TITLE
rollupBeneficiary slot packing fix in BridgeTestBase

### DIFF
--- a/src/test/aztec/base/BridgeTestBase.sol
+++ b/src/test/aztec/base/BridgeTestBase.sol
@@ -359,6 +359,11 @@ abstract contract BridgeTestBase is Test {
     {
         uint256 nextRollupId_ = nextRollupId;
 
+        // SLOADing rollupBeneficiary directly from storage in YUL could cause issues because address could be packed
+        // into a slot with other data. I could solve this issue by simply moving rollupBeneficiary between two 256 bit
+        // vars but I think this is more robust because we might modify this contract and run into the issue gain.
+        address rollupBeneficiaryUnpacked = rollupBeneficiary;
+
         /* solhint-disable no-inline-assembly */
         assembly {
             data := mload(0x40)
@@ -370,7 +375,7 @@ abstract contract BridgeTestBase is Test {
             mstore(add(data, 0x60), mul(nextRollupId_, 2))
             mstore(add(data, 0x180), _encodedBridgeCallData)
             mstore(add(data, 0x580), _totalInputValue)
-            mstore(add(data, 0x11a0), sload(rollupBeneficiary.slot))
+            mstore(add(data, 0x11a0), rollupBeneficiaryUnpacked)
 
             // Mock values
             // mstore(add(data, 0x20), 0x0000000000000000000000000000000000000000000000000000000000000000)


### PR DESCRIPTION
# Description

@LHerskind Fixed the cause of the bug the hackathon participants were facing yesterday. We should be more careful with SLOADing in YUL because it tends to cause these bugs which are shitty to debug.

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] There are no unexpected formatting changes, or superfluous debug logs.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewers next convenience.
- [x] NatSpec documentation of all the non-test functions is present and is complete.
- [x] Continuous integration (CI) passes.
- [ ] Command `forge coverage --match-contract MyContract` returns 100% line coverage.
- [ ] All the possible reverts are tested.
