### PR TITLE
AAVE v2 client

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aztec/bridge-clients",
-  "version": "0.1.63",
+  "version": "0.1.64",
   "description": "This repo contains the solidity files and typescript helper class for all of the Aztec Connect Bridge Contracts",
   "repository": "git@github.com:AztecProtocol/aztec-connect-bridges.git",
   "license": "Apache-2.0",

--- a/src/client/aavev2/aavev2-bridge-data.test.ts
+++ b/src/client/aavev2/aavev2-bridge-data.test.ts
@@ -1,5 +1,5 @@
 import { EthAddress } from "@aztec/barretenberg/address";
-import { IERC4626, IERC4626__factory, ILidoOracle } from "../../../typechain-types";
+import { IERC4626, IERC4626__factory } from "../../../typechain-types";
 import { AztecAsset, AztecAssetType } from "../bridge-data";
 import { AaveV2BridgeData } from "./aavev2-bridge-data";
 
@@ -54,17 +54,17 @@ describe("AaveV2 bridge data", () => {
     expect(apr).toBeGreaterThan(0);
   });
 
-  // it("should correctly fetch market size", async () => {
-  //   const aavev2BridgeData = AaveV2BridgeData.create({} as any);
-  //   const assetValue = (await aavev2BridgeData.getMarketSize(daiAsset, emptyAsset, emptyAsset, emptyAsset, 0))[0];
-  //   expect(assetValue.assetId).toBe(daiAsset.id);
-  //   expect(assetValue.value).toBeGreaterThan(0);
-  // });
+  it("should correctly fetch market size", async () => {
+    const aaveV2BridgeData = AaveV2BridgeData.create({} as any);
+    const assetValue = (await aaveV2BridgeData.getMarketSize(daiAsset, emptyAsset, emptyAsset, emptyAsset, 0))[0];
+    expect(assetValue.assetId).toBe(daiAsset.id);
+    expect(assetValue.value).toBeGreaterThan(0);
+  });
 
-  // it("should correctly fetch market size for ETH", async () => {
-  //   const aavev2BridgeData = AaveV2BridgeData.create({} as any);
-  //   const assetValue = (await aavev2BridgeData.getMarketSize(ethAsset, emptyAsset, emptyAsset, emptyAsset, 0))[0];
-  //   expect(assetValue.assetId).toBe(ethAsset.id);
-  //   expect(assetValue.value).toBeGreaterThan(0);
-  // });
+  it("should correctly fetch market size for ETH", async () => {
+    const aaveV2BridgeData = AaveV2BridgeData.create({} as any);
+    const assetValue = (await aaveV2BridgeData.getMarketSize(ethAsset, emptyAsset, emptyAsset, emptyAsset, 0))[0];
+    expect(assetValue.assetId).toBe(ethAsset.id);
+    expect(assetValue.value).toBeGreaterThan(0);
+  });
 });

--- a/src/client/aavev2/aavev2-bridge-data.test.ts
+++ b/src/client/aavev2/aavev2-bridge-data.test.ts
@@ -1,0 +1,70 @@
+import { EthAddress } from "@aztec/barretenberg/address";
+import { IERC4626, IERC4626__factory, ILidoOracle } from "../../../typechain-types";
+import { AztecAsset, AztecAssetType } from "../bridge-data";
+import { AaveV2BridgeData } from "./aavev2-bridge-data";
+
+jest.mock("../aztec/provider", () => ({
+  createWeb3Provider: jest.fn(),
+}));
+
+type Mockify<T> = {
+  [P in keyof T]: jest.Mock | any;
+};
+
+describe("AaveV2 bridge data", () => {
+  let erc4626Contract: Mockify<IERC4626>;
+
+  let ethAsset: AztecAsset;
+  let wa2DaiAsset: AztecAsset;
+  let daiAsset: AztecAsset;
+  let emptyAsset: AztecAsset;
+
+  beforeAll(() => {
+    ethAsset = {
+      id: 0,
+      assetType: AztecAssetType.ETH,
+      erc20Address: EthAddress.ZERO,
+    };
+    wa2DaiAsset = {
+      id: 7,
+      assetType: AztecAssetType.ERC20,
+      erc20Address: EthAddress.fromString("0xbcb91e0B4Ad56b0d41e0C168E3090361c0039abC"),
+    };
+    daiAsset = {
+      id: 1,
+      assetType: AztecAssetType.ERC20,
+      erc20Address: EthAddress.fromString("0x6b175474e89094c44da98b954eedeac495271d0f"),
+    };
+    emptyAsset = {
+      id: 0,
+      assetType: AztecAssetType.NOT_USED,
+      erc20Address: EthAddress.ZERO,
+    };
+  });
+
+  it("should correctly fetch APR", async () => {
+    erc4626Contract = {
+      ...erc4626Contract,
+      asset: jest.fn().mockResolvedValue(daiAsset.erc20Address.toString()),
+    };
+    IERC4626__factory.connect = () => erc4626Contract as any;
+
+    const aavev2BridgeData = AaveV2BridgeData.create({} as any);
+    const apr = await aavev2BridgeData.getAPR(wa2DaiAsset);
+    expect(apr).toBeGreaterThan(0);
+  });
+
+  // it("should correctly fetch market size", async () => {
+  //   const aavev2BridgeData = AaveV2BridgeData.create({} as any);
+  //   const assetValue = (await aavev2BridgeData.getMarketSize(daiAsset, emptyAsset, emptyAsset, emptyAsset, 0))[0];
+  //   expect(assetValue.assetId).toBe(daiAsset.id);
+  //   expect(assetValue.value).toBeGreaterThan(0);
+  // });
+
+  // it("should correctly fetch market size for ETH", async () => {
+  //   const aavev2BridgeData = AaveV2BridgeData.create({} as any);
+  //   const assetValue = (await aavev2BridgeData.getMarketSize(ethAsset, emptyAsset, emptyAsset, emptyAsset, 0))[0];
+  //   expect(assetValue.assetId).toBe(ethAsset.id);
+  //   expect(assetValue.value).toBeGreaterThan(0);
+  // });
+});

--- a/src/client/aavev2/aavev2-bridge-data.ts
+++ b/src/client/aavev2/aavev2-bridge-data.ts
@@ -3,11 +3,12 @@ import { EthereumProvider } from "@aztec/barretenberg/blockchain";
 import { Web3Provider } from "@ethersproject/providers";
 import "isomorphic-fetch";
 import { createWeb3Provider } from "../aztec/provider";
-import { AztecAsset } from "../bridge-data";
+import { AztecAsset, AztecAssetType } from "../bridge-data";
 
 import { ERC4626BridgeData } from "../erc4626/erc4626-bridge-data";
 
 export class AaveV2BridgeData extends ERC4626BridgeData {
+  private readonly subgraphWethId = "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2";
   private readonly RAY = 10 ** 27;
 
   protected constructor(ethersProvider: Web3Provider) {
@@ -47,9 +48,9 @@ export class AaveV2BridgeData extends ERC4626BridgeData {
     // --> filter out the ones working with LP tokens (symbol starts with "Amm")
     const relevantResult = result.data.reserves.filter((r: any) => {
       return !r.symbol.startsWith("Amm");
-    });
+    })[0];
 
-    return (relevantResult[0].liquidityRate * 100) / this.RAY;
+    return (relevantResult.liquidityRate * 100) / this.RAY;
   }
 
   /**
@@ -60,7 +61,6 @@ export class AaveV2BridgeData extends ERC4626BridgeData {
    * @param outputAssetB - ignored
    * @param auxData - ignored
    * @return The amount of the underlying asset deposited to AaveV2
-   * @dev the returned value is displayed as totalSupply in AaveV2's UI
    */
   async getMarketSize(
     inputAssetA: AztecAsset,
@@ -69,6 +69,39 @@ export class AaveV2BridgeData extends ERC4626BridgeData {
     outputAssetB: AztecAsset,
     auxData: number,
   ): Promise<AssetValue[]> {
-    return [];
+    const subgraphAssetId =
+      inputAssetA.assetType === AztecAssetType.ETH
+        ? this.subgraphWethId
+        : inputAssetA.erc20Address.toString().toLowerCase();
+
+    const result = await (
+      await fetch("https://api.thegraph.com/subgraphs/name/aave/protocol-v2", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          query: `
+            query($id: String!) {
+              reserves(where: {underlyingAsset: $id}) {
+                symbol
+                totalLiquidity
+              }
+            }
+          `,
+          variables: {
+            id: subgraphAssetId,
+          },
+        }),
+      })
+    ).json();
+
+    // There tend to be 2 pools: 1 working with LP tokens, other working with native assets
+    // --> filter out the ones working with LP tokens (symbol starts with "Amm")
+    const relevantResult = result.data.reserves.filter((r: any) => {
+      return !r.symbol.startsWith("Amm");
+    })[0];
+
+    return [{ assetId: inputAssetA.id, value: BigInt(relevantResult.totalLiquidity) }];
   }
 }

--- a/src/client/aavev2/aavev2-bridge-data.ts
+++ b/src/client/aavev2/aavev2-bridge-data.ts
@@ -1,0 +1,74 @@
+import { AssetValue } from "@aztec/barretenberg/asset";
+import { EthereumProvider } from "@aztec/barretenberg/blockchain";
+import { Web3Provider } from "@ethersproject/providers";
+import "isomorphic-fetch";
+import { createWeb3Provider } from "../aztec/provider";
+import { AztecAsset } from "../bridge-data";
+
+import { ERC4626BridgeData } from "../erc4626/erc4626-bridge-data";
+
+export class AaveV2BridgeData extends ERC4626BridgeData {
+  private readonly RAY = 10 ** 27;
+
+  protected constructor(ethersProvider: Web3Provider) {
+    super(ethersProvider);
+  }
+
+  static create(provider: EthereumProvider) {
+    const ethersProvider = createWeb3Provider(provider);
+    return new AaveV2BridgeData(ethersProvider);
+  }
+
+  async getAPR(yieldAsset: AztecAsset): Promise<number> {
+    const underlyingAddress = await this.getAsset(yieldAsset.erc20Address);
+    const result = await (
+      await fetch("https://api.thegraph.com/subgraphs/name/aave/protocol-v2", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          query: `
+        query($id: String!) {
+          reserves(where: {underlyingAsset: $id}) {
+            symbol
+            liquidityRate
+          }
+        }
+      `,
+          variables: {
+            id: underlyingAddress.toString().toLowerCase(),
+          },
+        }),
+      })
+    ).json();
+
+    // There tend to be 2 pools: 1 working with LP tokens, other working with native assets
+    // --> filter out the ones working with LP tokens (symbol starts with "Amm")
+    const relevantResult = result.data.reserves.filter((r: any) => {
+      return !r.symbol.startsWith("Amm");
+    });
+
+    return (relevantResult[0].liquidityRate * 100) / this.RAY;
+  }
+
+  /**
+   * @notice Gets market size which in this case means the amount of underlying asset deposited to AaveV2
+   * @param inputAssetA - The underlying asset
+   * @param inputAssetB - ignored
+   * @param outputAssetA - ignored
+   * @param outputAssetB - ignored
+   * @param auxData - ignored
+   * @return The amount of the underlying asset deposited to AaveV2
+   * @dev the returned value is displayed as totalSupply in AaveV2's UI
+   */
+  async getMarketSize(
+    inputAssetA: AztecAsset,
+    inputAssetB: AztecAsset,
+    outputAssetA: AztecAsset,
+    outputAssetB: AztecAsset,
+    auxData: number,
+  ): Promise<AssetValue[]> {
+    return [];
+  }
+}


### PR DESCRIPTION
# Description

Implementation of AAVE v2 client.

## Note
The value returned by `getMarketSize(...)` is lower than the one in AAVE's UI (e.g. for Dai it's 140M vs 200M). I think the reason is that in AAVE UI they show for all the protocol versions and not just for v2. I asked on [Discord](https://discord.com/channels/602826299974877205/636902500041228309/1031876343706689566) and will update it if needed. I think it's good idea to merge this now so that @joss-aztec has a client to work with ASAP.

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] There are no unexpected formatting changes, or superfluous debug logs.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewers next convenience.
- [ ] NatSpec documentation of all the non-test functions is present and is complete.
- [ ] Continuous integration (CI) passes.
- [ ] Command `forge coverage --match-contract MyContract` returns 100% line coverage.
- [ ] All the possible reverts are tested.
