### PR TITLE
Liquity deployment + AAVE v2 ERC4626 wrapper listing

### DIFF
--- a/src/deployment/AggregateDeployment.s.sol
+++ b/src/deployment/AggregateDeployment.s.sol
@@ -71,12 +71,6 @@ contract AggregateDeployment is BaseDeployment {
             emit log_named_uint("ERC4626 euler wstEth id", wewstEthAssetId);
 
             address erc4626EulerDai = 0x4169Df1B7820702f566cc10938DA51F6F597d264;
-            if (erc4626EulerDai.code.length == 0) {
-                vm.broadcast();
-                address(0x1e8020cFB10b6a6a9B5F06e3ABAe140f7DE541E1).call(
-                    hex"abeccaa40000000000000000000000006b175474e89094c44da98b954eedeac495271d0f"
-                );
-            }
             lister.listVault(erc4626Bridge, erc4626EulerDai);
             uint256 wedaiAssetId = listAsset(erc4626EulerDai, 55000);
             emit log_named_uint("ERC4626 euler dai id", wedaiAssetId);
@@ -101,6 +95,22 @@ contract AggregateDeployment is BaseDeployment {
             LiquityTroveDeployment deploy = new LiquityTroveDeployment();
             deploy.setUp();
             deploy.deployAndList(350);
+        }
+
+        emit log("--- AAVE v2 ---");
+        {
+            ERC4626Lister lister = new ERC4626Lister();
+            lister.setUp();
+
+            address erc4626AaveV2Dai = 0xbcb91e0B4Ad56b0d41e0C168E3090361c0039abC;
+            lister.listVault(erc4626Bridge, erc4626AaveV2Dai);
+            uint256 erc4626AaveV2DaiId = listAsset(erc4626AaveV2Dai, 55000);
+            emit log_named_uint("ERC4626 aave v2 dai id", erc4626AaveV2DaiId);
+
+            address erc4626AaveV2WETH = 0xc21F107933612eCF5677894d45fc060767479A9b;
+            lister.listVault(erc4626Bridge, erc4626AaveV2WETH);
+            uint256 erc4626AaveV2WETHId = listAsset(erc4626AaveV2WETH, 55000);
+            emit log_named_uint("ERC4626 aave v2 weth id", erc4626AaveV2WETHId);
         }
     }
 

--- a/src/deployment/AggregateDeployment.s.sol
+++ b/src/deployment/AggregateDeployment.s.sol
@@ -88,6 +88,20 @@ contract AggregateDeployment is BaseDeployment {
             deploy.setUp();
             deploy.deployAndList();
         }
+
+        emit log("--- Liquity CR 250%---");
+        {
+            LiquityTroveDeployment deploy = new LiquityTroveDeployment();
+            deploy.setUp();
+            deploy.deployAndList(250);
+        }
+
+        emit log("--- Liquity CR 350%---");
+        {
+            LiquityTroveDeployment deploy = new LiquityTroveDeployment();
+            deploy.setUp();
+            deploy.deployAndList(350);
+        }
     }
 
     function bogota() public {
@@ -118,7 +132,7 @@ contract AggregateDeployment is BaseDeployment {
         {
             LiquityTroveDeployment deploy = new LiquityTroveDeployment();
             deploy.setUp();
-            deploy.deployAndList();
+            deploy.deployAndList(250);
         }
 
         emit log("--- Curve steth lp ---");

--- a/src/deployment/AggregateDeployment.s.sol
+++ b/src/deployment/AggregateDeployment.s.sol
@@ -30,16 +30,16 @@ contract AggregateDeployment is BaseDeployment {
     function deployAndListAll() public {
         emit log("--- Curve ---");
         {
-            CurveDeployment cDeploy = new CurveDeployment();
-            cDeploy.setUp();
-            cDeploy.deployAndList();
+            CurveDeployment curveDeployment = new CurveDeployment();
+            curveDeployment.setUp();
+            curveDeployment.deployAndList();
         }
 
         emit log("--- Yearn ---");
         {
-            YearnDeployment yDeploy = new YearnDeployment();
-            yDeploy.setUp();
-            yDeploy.deployAndList();
+            YearnDeployment yearnDeployment = new YearnDeployment();
+            yearnDeployment.setUp();
+            yearnDeployment.deployAndList();
         }
 
         emit log("--- Element 2M ---");
@@ -50,9 +50,12 @@ contract AggregateDeployment is BaseDeployment {
 
         emit log("--- ERC4626 ---");
         {
-            ERC4626Deployment deploy = new ERC4626Deployment();
-            deploy.setUp();
-            erc4626Bridge = deploy.deployAndList();
+            ERC4626Deployment erc4626Deployment = new ERC4626Deployment();
+            erc4626Deployment.setUp();
+            erc4626Bridge = erc4626Deployment.deploy();
+
+            uint256 depositAddressId = listBridge(erc4626Bridge, 300000);
+            emit log_named_uint("ERC4626 bridge address id (300k gas)", depositAddressId);
         }
 
         emit log("--- Euler ---");
@@ -78,9 +81,18 @@ contract AggregateDeployment is BaseDeployment {
 
         emit log("--- DCA ---");
         {
-            DCADeployment deploy = new DCADeployment();
-            deploy.setUp();
-            deploy.deployAndList();
+            DCADeployment dcaDeployment = new DCADeployment();
+            dcaDeployment.setUp();
+            dcaDeployment.deployAndList();
+        }
+
+        emit log("--- ERC4626 400k and 500k gas configurations ---");
+        {
+            uint256 depositAddressId = listBridge(erc4626Bridge, 400000);
+            emit log_named_uint("ERC4626 bridge address id (400k gas)", depositAddressId);
+
+            uint256 depositAddressId = listBridge(erc4626Bridge, 500000);
+            emit log_named_uint("ERC4626 bridge address id (500k gas)", depositAddressId);
         }
 
         emit log("--- AAVE v2 ---");
@@ -99,18 +111,13 @@ contract AggregateDeployment is BaseDeployment {
             emit log_named_uint("ERC4626 aave v2 weth id", erc4626AaveV2WETHId);
         }
 
-        emit log("--- Liquity CR 250%---");
+        emit log("--- Liquity 275% CR and 400% CR deployments ---");
         {
-            LiquityTroveDeployment deploy = new LiquityTroveDeployment();
-            deploy.setUp();
-            deploy.deployAndList(250);
-        }
+            LiquityTroveDeployment liquityTroveDeployment = new LiquityTroveDeployment();
+            liquityTroveDeployment.setUp();
 
-        emit log("--- Liquity CR 350%---");
-        {
-            LiquityTroveDeployment deploy = new LiquityTroveDeployment();
-            deploy.setUp();
-            deploy.deployAndList(350);
+            liquityTroveDeployment.deployAndList(275);
+            liquityTroveDeployment.deployAndList(400);
         }
     }
 

--- a/src/deployment/AggregateDeployment.s.sol
+++ b/src/deployment/AggregateDeployment.s.sol
@@ -83,20 +83,6 @@ contract AggregateDeployment is BaseDeployment {
             deploy.deployAndList();
         }
 
-        emit log("--- Liquity CR 250%---");
-        {
-            LiquityTroveDeployment deploy = new LiquityTroveDeployment();
-            deploy.setUp();
-            deploy.deployAndList(250);
-        }
-
-        emit log("--- Liquity CR 350%---");
-        {
-            LiquityTroveDeployment deploy = new LiquityTroveDeployment();
-            deploy.setUp();
-            deploy.deployAndList(350);
-        }
-
         emit log("--- AAVE v2 ---");
         {
             ERC4626Lister lister = new ERC4626Lister();
@@ -111,6 +97,20 @@ contract AggregateDeployment is BaseDeployment {
             lister.listVault(erc4626Bridge, erc4626AaveV2WETH);
             uint256 erc4626AaveV2WETHId = listAsset(erc4626AaveV2WETH, 55000);
             emit log_named_uint("ERC4626 aave v2 weth id", erc4626AaveV2WETHId);
+        }
+
+        emit log("--- Liquity CR 250%---");
+        {
+            LiquityTroveDeployment deploy = new LiquityTroveDeployment();
+            deploy.setUp();
+            deploy.deployAndList(250);
+        }
+
+        emit log("--- Liquity CR 350%---");
+        {
+            LiquityTroveDeployment deploy = new LiquityTroveDeployment();
+            deploy.setUp();
+            deploy.deployAndList(350);
         }
     }
 

--- a/src/deployment/AggregateDeployment.s.sol
+++ b/src/deployment/AggregateDeployment.s.sol
@@ -91,7 +91,7 @@ contract AggregateDeployment is BaseDeployment {
             uint256 depositAddressId = listBridge(erc4626Bridge, 400000);
             emit log_named_uint("ERC4626 bridge address id (400k gas)", depositAddressId);
 
-            uint256 depositAddressId = listBridge(erc4626Bridge, 500000);
+            depositAddressId = listBridge(erc4626Bridge, 500000);
             emit log_named_uint("ERC4626 bridge address id (500k gas)", depositAddressId);
         }
 

--- a/src/deployment/erc4626/ERC4626Deployment.s.sol
+++ b/src/deployment/erc4626/ERC4626Deployment.s.sol
@@ -17,13 +17,4 @@ contract ERC4626Deployment is BaseDeployment {
 
         return address(bridge);
     }
-
-    function deployAndList() public returns (address) {
-        address bridge = deploy();
-
-        uint256 depositAddressId = listBridge(bridge, 300000);
-        emit log_named_uint("ERC4626 bridge address id", depositAddressId);
-
-        return bridge;
-    }
 }

--- a/src/deployment/liquity/LiquityTroveDeployment.s.sol
+++ b/src/deployment/liquity/LiquityTroveDeployment.s.sol
@@ -6,8 +6,6 @@ import {BaseDeployment} from "../base/BaseDeployment.s.sol";
 import {TroveBridge} from "../../bridges/liquity/TroveBridge.sol";
 
 contract LiquityTroveDeployment is BaseDeployment {
-    uint256 internal constant INITIAL_CR = 250;
-
     function deploy(uint256 _initialCr) public returns (address) {
         emit log("Deploying example bridge");
 

--- a/src/deployment/liquity/LiquityTroveDeployment.s.sol
+++ b/src/deployment/liquity/LiquityTroveDeployment.s.sol
@@ -8,19 +8,19 @@ import {TroveBridge} from "../../bridges/liquity/TroveBridge.sol";
 contract LiquityTroveDeployment is BaseDeployment {
     uint256 internal constant INITIAL_CR = 250;
 
-    function deploy() public returns (address) {
+    function deploy(uint256 _initialCr) public returns (address) {
         emit log("Deploying example bridge");
 
         vm.broadcast();
-        TroveBridge bridge = new TroveBridge(ROLLUP_PROCESSOR, INITIAL_CR);
+        TroveBridge bridge = new TroveBridge(ROLLUP_PROCESSOR, _initialCr);
 
         emit log_named_address("Example bridge deployed to", address(bridge));
 
         return address(bridge);
     }
 
-    function deployAndList() public {
-        address bridge = deploy();
+    function deployAndList(uint256 _initialCr) public {
+        address bridge = deploy(_initialCr);
         uint256 addressId = listBridge(bridge, 1000000);
         emit log_named_uint("Example bridge address id", addressId);
 


### PR DESCRIPTION
# Changes

1. Listing AAVE wrappers,
2. Liquity TroveBridge deployment in Aggregate,
3. removed Euler wrapper deployment on testnet since testnet will get forked from a newer block which should have it deployed.

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] There are no unexpected formatting changes, or superfluous debug logs.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewers next convenience.
- [ ] NatSpec documentation of all the non-test functions is present and is complete.
- [ ] Continuous integration (CI) passes.
- [ ] Command `forge coverage --match-contract MyContract` returns 100% line coverage.
- [ ] All the possible reverts are tested.
