### PR TITLE
upgrade element bridge to use falafel's new REST API

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aztec/bridge-clients",
-  "version": "0.1.73",
+  "version": "0.1.74",
   "description": "This repo contains the solidity files and typescript helper class for all of the Aztec Connect Bridge Contracts",
   "repository": "git@github.com:AztecProtocol/aztec-connect-bridges.git",
   "license": "Apache-2.0",

--- a/src/client/element/element-bridge-data.test.ts
+++ b/src/client/element/element-bridge-data.test.ts
@@ -186,7 +186,7 @@ describe("element bridge data", () => {
       EthAddress.ZERO,
       EthAddress.ZERO,
       EthAddress.ZERO,
-      "https://api.aztec.network/aztec-connect-prod/falafel/graphql",
+      "https://api.aztec.network/aztec-connect-prod/falafel",
     ); // can pass in dummy values here as the above factories do all of the work
   };
 

--- a/src/client/element/element-bridge-data.ts
+++ b/src/client/element/element-bridge-data.ts
@@ -68,7 +68,7 @@ export class ElementBridgeData implements BridgeDataFieldGetters {
   private constructor(
     private elementBridgeContract: ElementBridge,
     private balancerContract: IVault,
-    private rollupContract: IRollupProcessor,
+    private rollupContract: RollupProcessor,
     private falafelEndpoint: string,
   ) {}
 
@@ -124,8 +124,7 @@ export class ElementBridgeData implements BridgeDataFieldGetters {
     });
 
     const data = await response.json();
-    const txhash = `0x${data["data"]["block"]["ethTxHash"]}`;
-    const tx = await this.elementBridgeContract.provider.getTransactionReceipt(txhash);
+    const tx = await this.elementBridgeContract.provider.getTransactionReceipt(data["ethTxHash"]);
     return tx.blockNumber;
   }
 

--- a/src/client/element/element-bridge-data.ts
+++ b/src/client/element/element-bridge-data.ts
@@ -120,7 +120,7 @@ export class ElementBridgeData implements BridgeDataFieldGetters {
 
     const response = await fetch(`${this.falafelEndpoint}/rollup/${id}`, {
       headers: { "Content-Type": "application/json" },
-      method: "GET"
+      method: "GET",
     });
 
     const data = await response.json();

--- a/src/client/element/element-bridge-data.ts
+++ b/src/client/element/element-bridge-data.ts
@@ -68,8 +68,8 @@ export class ElementBridgeData implements BridgeDataFieldGetters {
   private constructor(
     private elementBridgeContract: ElementBridge,
     private balancerContract: IVault,
-    private rollupContract: RollupProcessor,
-    private falafelGraphQlEndpoint: string,
+    private rollupContract: IRollupProcessor,
+    private falafelEndpoint: string,
   ) {}
 
   static create(
@@ -77,13 +77,13 @@ export class ElementBridgeData implements BridgeDataFieldGetters {
     elementBridgeAddress: EthAddress,
     balancerAddress: EthAddress,
     rollupContractAddress: EthAddress,
-    falafelGraphQlEndpoint: string,
+    falafelEndpoint: string,
   ) {
     const ethersProvider = createWeb3Provider(provider);
     const elementBridgeContract = ElementBridge__factory.connect(elementBridgeAddress.toString(), ethersProvider);
     const rollupContract = RollupProcessor__factory.connect(rollupContractAddress.toString(), ethersProvider);
     const vaultContract = IVault__factory.connect(balancerAddress.toString(), ethersProvider);
-    return new ElementBridgeData(elementBridgeContract, vaultContract, rollupContract, falafelGraphQlEndpoint);
+    return new ElementBridgeData(elementBridgeContract, vaultContract, rollupContract, falafelEndpoint);
   }
 
   private async storeEventBlocks(events: AsyncDefiBridgeProcessedEvent[]) {
@@ -117,20 +117,10 @@ export class ElementBridgeData implements BridgeDataFieldGetters {
 
   private async getBlockNumber(interactionNonce: number) {
     const id = Math.floor(interactionNonce / 32);
-    const query = `query Block($id: Int!) {
-      block: rollup(id: $id) {
-        ethTxHash
-      }
-    }`;
 
-    const response = await fetch(this.falafelGraphQlEndpoint, {
+    const response = await fetch(`${this.falafelEndpoint}/rollup/${id}`, {
       headers: { "Content-Type": "application/json" },
-      method: "POST",
-      body: JSON.stringify({
-        query,
-        operationName: "Block",
-        variables: { id },
-      }),
+      method: "GET"
     });
 
     const data = await response.json();


### PR DESCRIPTION
# Description

[This PR ](https://github.com/AztecProtocol/aztec2-internal/pull/1681) is adding new APIs that will replace graphQL functionality. 
Updating logic here to use new APIs. Once this is merged & released, we can remove graphQL altogether from falafel

Setting this as "draft" until new Falafel APIs are released

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] There are no unexpected formatting changes, or superfluous debug logs.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewers next convenience.
- [x] NatSpec documentation of all the non-test functions is present and is complete.
- [ ] Continuous integration (CI) passes.
- [ ] Command `forge coverage --match-contract MyContract` returns 100% line coverage.
- [ ] All the possible reverts are tested.
