### PR TITLE
Janb/compound client

### DIFF
--- a/src/client/compound/compound-bridge-data.test.ts
+++ b/src/client/compound/compound-bridge-data.test.ts
@@ -1,0 +1,92 @@
+import { EthAddress } from "@aztec/barretenberg/address";
+import { BigNumber } from "ethers";
+import {
+  ICERC20,
+  ICERC20__factory,
+  ICompoundERC4626,
+  ICompoundERC4626__factory,
+  IERC20,
+  IERC20__factory,
+} from "../../../typechain-types";
+import { AztecAsset, AztecAssetType } from "../bridge-data";
+import { CompoundBridgeData } from "./compound-bridge-data";
+
+jest.mock("../aztec/provider", () => ({
+  createWeb3Provider: jest.fn(),
+}));
+
+type Mockify<T> = {
+  [P in keyof T]: jest.Mock | any;
+};
+
+describe("compound lending bridge data", () => {
+  let compoundERC4626Contract: Mockify<ICompoundERC4626>;
+  let cerc20Contract: Mockify<ICERC20>;
+  let erc20Contract: Mockify<IERC20>;
+
+  let daiAsset: AztecAsset;
+  let wcdaiAsset: AztecAsset;
+  let emptyAsset: AztecAsset;
+
+  beforeAll(() => {
+    daiAsset = {
+      id: 1,
+      assetType: AztecAssetType.ERC20,
+      erc20Address: EthAddress.fromString("0x6B175474E89094C44Da98b954EedeAC495271d0F"),
+    };
+    wcdaiAsset = {
+      id: 12, // Asset has not yet been registered on RollupProcessor so this id is random
+      assetType: AztecAssetType.ERC20,
+      erc20Address: EthAddress.random(),
+    };
+    emptyAsset = {
+      id: 0,
+      assetType: AztecAssetType.NOT_USED,
+      erc20Address: EthAddress.ZERO,
+    };
+  });
+
+  it("should correctly compute expected APR", async () => {
+    // Setup mocks
+    compoundERC4626Contract = {
+      ...compoundERC4626Contract,
+      cToken: jest.fn().mockResolvedValue("0x5d3a536E4D6DbD6114cc1Ead35777bAB948E3643"),
+    };
+    ICompoundERC4626__factory.connect = () => compoundERC4626Contract as any;
+
+    cerc20Contract = {
+      ...cerc20Contract,
+      supplyRatePerBlock: jest.fn().mockResolvedValue(BigNumber.from("338149955")),
+    };
+    ICERC20__factory.connect = () => cerc20Contract as any;
+    const compoundBridgeData = CompoundBridgeData.create({} as any);
+
+    // Test the code using mocked controller
+    const APR = await compoundBridgeData.getAPR(wcdaiAsset);
+    expect(APR).toBe(0.0710926465392);
+  });
+
+  it("should correctly compute market size", async () => {
+    // Setup mocks
+    compoundERC4626Contract = {
+      ...compoundERC4626Contract,
+      cToken: jest.fn().mockResolvedValue("0x5d3a536E4D6DbD6114cc1Ead35777bAB948E3643"),
+    };
+    ICompoundERC4626__factory.connect = () => compoundERC4626Contract as any;
+
+    erc20Contract = {
+      ...erc20Contract,
+      balanceOf: jest.fn().mockResolvedValue(BigNumber.from("368442895892448315882277748")),
+    };
+    IERC20__factory.connect = () => erc20Contract as any;
+    const compoundBridgeData = CompoundBridgeData.create({} as any);
+
+    // Test the code using mocked controller
+    const marketSizeMint = (await compoundBridgeData.getMarketSize(daiAsset, emptyAsset, wcdaiAsset, emptyAsset, 0))[0];
+    const marketSizeRedeem = (
+      await compoundBridgeData.getMarketSize(wcdaiAsset, emptyAsset, daiAsset, emptyAsset, 1)
+    )[0];
+    expect(marketSizeMint.value).toBe(marketSizeRedeem.value);
+    expect(marketSizeMint.value).toBe(368442895892448315882277748n);
+  });
+});

--- a/src/client/compound/compound-bridge-data.test.ts
+++ b/src/client/compound/compound-bridge-data.test.ts
@@ -76,9 +76,16 @@ describe("compound lending bridge data", () => {
 
     erc20Contract = {
       ...erc20Contract,
-      balanceOf: jest.fn().mockResolvedValue(BigNumber.from("368442895892448315882277748")),
+      balanceOf: jest.fn().mockResolvedValue(BigNumber.from("354266465288194354360018823")),
     };
     IERC20__factory.connect = () => erc20Contract as any;
+
+    cerc20Contract = {
+      ...cerc20Contract,
+      totalBorrows: jest.fn().mockResolvedValue(BigNumber.from("302183964811046170986358904")),
+    };
+    IERC20__factory.connect = () => erc20Contract as any;
+
     const compoundBridgeData = CompoundBridgeData.create({} as any);
 
     // Test the code using mocked controller
@@ -87,6 +94,6 @@ describe("compound lending bridge data", () => {
       await compoundBridgeData.getMarketSize(wcdaiAsset, emptyAsset, daiAsset, emptyAsset, 1)
     )[0];
     expect(marketSizeMint.value).toBe(marketSizeRedeem.value);
-    expect(marketSizeMint.value).toBe(368442895892448315882277748n);
+    expect(marketSizeMint.value).toBe(656450430099240525346377727n);
   });
 });

--- a/src/client/compound/compound-bridge-data.ts
+++ b/src/client/compound/compound-bridge-data.ts
@@ -1,0 +1,78 @@
+import { EthAddress } from "@aztec/barretenberg/address";
+import { AssetValue } from "@aztec/barretenberg/asset";
+import { EthereumProvider } from "@aztec/barretenberg/blockchain";
+import { Web3Provider } from "@ethersproject/providers";
+import "isomorphic-fetch";
+import { ICERC20__factory, ICompoundERC4626__factory, IERC20__factory } from "../../../typechain-types";
+import { createWeb3Provider } from "../aztec/provider";
+import { AztecAsset, AztecAssetType } from "../bridge-data";
+
+import { ERC4626BridgeData } from "../erc4626/erc4626-bridge-data";
+
+export class CompoundBridgeData extends ERC4626BridgeData {
+  protected constructor(ethersProvider: Web3Provider) {
+    super(ethersProvider);
+  }
+
+  static create(provider: EthereumProvider) {
+    const ethersProvider = createWeb3Provider(provider);
+    return new CompoundBridgeData(ethersProvider);
+  }
+
+  async getAPR(yieldAsset: AztecAsset): Promise<number> {
+    // Not taking into account how the deposited funds will change the yield
+    // The approximate number of blocks per year that is assumed by the interest rate model
+
+    const blocksPerYear = 2102400;
+
+    // To get the cToken first call cToken on the wrapper contract
+    const cTokenAddress = await this.getCToken(yieldAsset.erc20Address);
+    const cToken = ICERC20__factory.connect(cTokenAddress.toString(), this.ethersProvider);
+
+    const supplyRatePerBlock = await cToken.supplyRatePerBlock();
+    return supplyRatePerBlock.mul(blocksPerYear).toNumber() / 10 ** 16;
+  }
+
+  async getMarketSize(
+    inputAssetA: AztecAsset,
+    inputAssetB: AztecAsset,
+    outputAssetA: AztecAsset,
+    outputAssetB: AztecAsset,
+    auxData: number,
+  ): Promise<AssetValue[]> {
+    let cTokenAddress;
+    let underlyingAsset;
+    if (auxData === 0) {
+      // Minting
+      cTokenAddress = this.getCToken(outputAssetA.erc20Address);
+      underlyingAsset = inputAssetA;
+    } else if (auxData === 1) {
+      // Redeeming
+      cTokenAddress = this.getCToken(inputAssetA.erc20Address);
+      underlyingAsset = outputAssetA;
+    } else {
+      throw "Invalid auxData";
+    }
+
+    let marketSize;
+    if (underlyingAsset.assetType === AztecAssetType.ETH) {
+      marketSize = await this.ethersProvider.getBalance(cTokenAddress.toString());
+    } else {
+      marketSize = await IERC20__factory.connect(
+        underlyingAsset.erc20Address.toString(),
+        this.ethersProvider,
+      ).balanceOf(cTokenAddress.toString());
+    }
+    return [
+      {
+        assetId: underlyingAsset.id,
+        value: marketSize.toBigInt(),
+      },
+    ];
+  }
+
+  private async getCToken(shareAddress: EthAddress): Promise<EthAddress> {
+    const share = ICompoundERC4626__factory.connect(shareAddress.toString(), this.ethersProvider);
+    return EthAddress.fromString(await share.cToken());
+  }
+}

--- a/src/interfaces/compound/ICERC20.sol
+++ b/src/interfaces/compound/ICERC20.sol
@@ -10,6 +10,8 @@ interface ICERC20 is IERC20 {
 
     function balanceOfUnderlying(address) external view returns (uint256);
 
+    function totalBorrows() external view returns (uint256);
+
     function exchangeRateStored() external view returns (uint256);
 
     function exchangeRateCurrent() external returns (uint256);

--- a/src/interfaces/compound/ICERC20.sol
+++ b/src/interfaces/compound/ICERC20.sol
@@ -1,0 +1,24 @@
+// Note: only used in client
+pragma solidity >=0.8.4;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface ICERC20 is IERC20 {
+    function supplyRatePerBlock() external view returns (uint256);
+
+    function accrueInterest() external;
+
+    function balanceOfUnderlying(address) external view returns (uint256);
+
+    function exchangeRateStored() external view returns (uint256);
+
+    function exchangeRateCurrent() external returns (uint256);
+
+    function mint(uint256) external returns (uint256);
+
+    function redeem(uint256) external returns (uint256);
+
+    function redeemUnderlying(uint256) external returns (uint256);
+
+    function underlying() external returns (address);
+}

--- a/src/interfaces/compound/ICompoundERC4626.sol
+++ b/src/interfaces/compound/ICompoundERC4626.sol
@@ -1,0 +1,8 @@
+// Note: only used in client
+pragma solidity >=0.8.4;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface ICompoundERC4626 {
+    function cToken() external view virtual returns (address);
+}


### PR DESCRIPTION
# Description

Took the original implementation of compound client, removed functions which already exist in ERC4626 client, made it extend ERC4626 client and modified the remaining functions to work with wrapped cTokens instead of cTokens.

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] There are no unexpected formatting changes, or superfluous debug logs.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewers next convenience.
- [x] NatSpec documentation of all the non-test functions is present and is complete.
- [ ] Continuous integration (CI) passes.
- [ ] Command `forge coverage --match-contract MyContract` returns 100% line coverage.
- [ ] All the possible reverts are tested.
