### PR TITLE
Fix `bounds` and ordering

### DIFF
--- a/src/deployment/AggregateDeployment.s.sol
+++ b/src/deployment/AggregateDeployment.s.sol
@@ -88,11 +88,11 @@ contract AggregateDeployment is BaseDeployment {
 
         emit log("--- ERC4626 400k and 500k gas configurations ---");
         {
-            uint256 depositAddressId = listBridge(erc4626Bridge, 400000);
-            emit log_named_uint("ERC4626 bridge address id (400k gas)", depositAddressId);
-
-            depositAddressId = listBridge(erc4626Bridge, 500000);
+            uint256 depositAddressId = listBridge(erc4626Bridge, 500000);
             emit log_named_uint("ERC4626 bridge address id (500k gas)", depositAddressId);
+
+            depositAddressId = listBridge(erc4626Bridge, 400000);
+            emit log_named_uint("ERC4626 bridge address id (400k gas)", depositAddressId);
         }
 
         emit log("--- AAVE v2 ---");
@@ -143,13 +143,6 @@ contract AggregateDeployment is BaseDeployment {
             UniswapDeployment deploy = new UniswapDeployment();
             deploy.setUp();
             deploy.deployAndList();
-        }
-
-        emit log("--- Liquity ---");
-        {
-            LiquityTroveDeployment deploy = new LiquityTroveDeployment();
-            deploy.setUp();
-            deploy.deployAndList(250);
         }
 
         emit log("--- Curve steth lp ---");

--- a/src/deployment/dataprovider/DataProviderDeployment.s.sol
+++ b/src/deployment/dataprovider/DataProviderDeployment.s.sol
@@ -92,8 +92,8 @@ contract DataProviderDeployment is BaseDeployment {
     function deployAndListMany() public returns (address) {
         address provider = deploy();
 
-        uint256[] memory assetIds = new uint256[](8);
-        string[] memory assetTags = new string[](8);
+        uint256[] memory assetIds = new uint256[](10);
+        string[] memory assetTags = new string[](10);
         for (uint256 i = 0; i < assetIds.length; i++) {
             assetIds[i] = i;
         }
@@ -105,9 +105,11 @@ contract DataProviderDeployment is BaseDeployment {
         assetTags[5] = "weweth";
         assetTags[6] = "wewsteth";
         assetTags[7] = "wedai";
+        assetTags[8] = "we2dai";
+        assetTags[9] = "we2weth";
 
-        uint256[] memory bridgeAddressIds = new uint256[](7);
-        string[] memory bridgeTags = new string[](7);
+        uint256[] memory bridgeAddressIds = new uint256[](9);
+        string[] memory bridgeTags = new string[](9);
 
         bridgeAddressIds[0] = 1;
         bridgeAddressIds[1] = 6;
@@ -116,6 +118,8 @@ contract DataProviderDeployment is BaseDeployment {
         bridgeAddressIds[4] = 9;
         bridgeAddressIds[5] = 10;
         bridgeAddressIds[6] = 11;
+        bridgeAddressIds[7] = 12;
+        bridgeAddressIds[8] = 13;
 
         bridgeTags[0] = "ElementBridge";
         bridgeTags[1] = "CurveStEthBridge";
@@ -124,6 +128,8 @@ contract DataProviderDeployment is BaseDeployment {
         bridgeTags[4] = "ElementBridge2M";
         bridgeTags[5] = "ERC4626";
         bridgeTags[6] = "DCA400K";
+        bridgeTags[7] = "ERC4626_500K";
+        bridgeTags[8] = "ERC4626:400K";
 
         vm.broadcast();
         DataProvider(provider).addAssetsAndBridges(assetIds, assetTags, bridgeAddressIds, bridgeTags);

--- a/src/deployment/dataprovider/DataProviderDeployment.s.sol
+++ b/src/deployment/dataprovider/DataProviderDeployment.s.sol
@@ -129,7 +129,7 @@ contract DataProviderDeployment is BaseDeployment {
         bridgeTags[5] = "ERC4626";
         bridgeTags[6] = "DCA400K";
         bridgeTags[7] = "ERC4626_500K";
-        bridgeTags[8] = "ERC4626:400K";
+        bridgeTags[8] = "ERC4626_400K";
 
         vm.broadcast();
         DataProvider(provider).addAssetsAndBridges(assetIds, assetTags, bridgeAddressIds, bridgeTags);

--- a/src/test/bridges/erc4626/ERC4626.t.sol
+++ b/src/test/bridges/erc4626/ERC4626.t.sol
@@ -19,9 +19,9 @@ contract ERC4626Test is BridgeTestBase {
         0x3c66B18F67CA6C1A71F829E2F6a0c987f97462d0, // ERC4626-Wrapped Euler WETH (weWETH)
         0x20706baA0F89e2dccF48eA549ea5A13B9b30462f, // ERC4626-Wrapped Euler oSQTH (weoSQTH)
         0x60897720AA966452e8706e74296B018990aEc527, //  ERC4626-Wrapped Euler wstETH (wewstETH)
-        0x4169Df1B7820702f566cc10938DA51F6F597d264 //  ERC4626-Wrapped Euler DAI (weDAI)
-        //        0xbcb91e0B4Ad56b0d41e0C168E3090361c0039abC, //  ERC4626-Wrapped AAVE V2 DAI (wa2DAI)
-        //        0xc21F107933612eCF5677894d45fc060767479A9b //  ERC4626-Wrapped AAVE V2 WETH (wa2WETH)
+        0x4169Df1B7820702f566cc10938DA51F6F597d264, //  ERC4626-Wrapped Euler DAI (weDAI)
+        0xbcb91e0B4Ad56b0d41e0C168E3090361c0039abC, //  ERC4626-Wrapped AAVE V2 DAI (wa2DAI)
+        0xc21F107933612eCF5677894d45fc060767479A9b //  ERC4626-Wrapped AAVE V2 WETH (wa2WETH)
     ];
     AztecTypes.AztecAsset[] private shares;
     AztecTypes.AztecAsset[] private assets;
@@ -102,7 +102,7 @@ contract ERC4626Test is BridgeTestBase {
     }
 
     function testFullFlow(uint96 _assetAmount, uint96 _shareAmount) public {
-        uint256 assetAmount = bound(_assetAmount, 100, type(uint256).max);
+        uint256 assetAmount = bound(_assetAmount, 100, type(uint96).max);
 
         for (uint256 i = 0; i < shares.length; ++i) {
             deal(assets[i].erc20Address, address(ROLLUP_PROCESSOR), assetAmount);
@@ -162,7 +162,7 @@ contract ERC4626Test is BridgeTestBase {
     }
 
     function testEthWrappingAndUnwrapping(uint96 _assetAmount) public {
-        uint256 assetAmount = bound(_assetAmount, 10, type(uint256).max);
+        uint256 assetAmount = bound(_assetAmount, 10, type(uint96).max);
         IERC20 weth = IERC20(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
 
         bridge.listVault(wethVault);
@@ -221,7 +221,7 @@ contract ERC4626Test is BridgeTestBase {
         uint96 _shareAmount,
         uint96 _yield
     ) public {
-        uint256 assetAmount = bound(_assetAmount, 10, type(uint256).max);
+        uint256 assetAmount = bound(_assetAmount, 10, type(uint96).max);
         IERC20 weth = IERC20(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
 
         address beneficiary = address(11);

--- a/src/test/bridges/liquity/StabilityPoolBridgeUnit.t.sol
+++ b/src/test/bridges/liquity/StabilityPoolBridgeUnit.t.sol
@@ -49,7 +49,7 @@ contract StabilityPoolBridgeUnitTest is TestUtil {
         uint64 _ethRewards,
         uint72 _lqtyRewards
     ) public {
-        uint256 depositAmount = bound(_depositAmount, 10, type(uint128).max);
+        uint256 depositAmount = bound(_depositAmount, 10, type(uint96).max);
         uint256 spbReceived = _deposit(depositAmount);
 
         AztecTypes.AztecAsset memory inputAssetA = AztecTypes.AztecAsset(


### PR DESCRIPTION
# Description

- Update usage of `bound` to use more precise lower limits. After the `forge-std` update, could more easily hit large values, which made forge crash with overflow.
- Updates ordering of aggregate deployment to have parity with mainnet.

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] There are no unexpected formatting changes, or superfluous debug logs.
- [ ] The branch has been rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewers next convenience.
- [ ] NatSpec documentation of all the non-test functions is present and is complete.
- [ ] Continuous integration (CI) passes.
- [ ] Command `forge coverage --match-contract MyContract` returns 100% line coverage.
- [ ] All the possible reverts are tested.
