### PR TITLE
Add gas units to data provider return value

### DIFF
--- a/src/deployment/AggregateDeployment.s.sol
+++ b/src/deployment/AggregateDeployment.s.sol
@@ -119,6 +119,8 @@ contract AggregateDeployment is BaseDeployment {
             liquityTroveDeployment.deployAndList(275);
             liquityTroveDeployment.deployAndList(400);
         }
+
+        readStats();
     }
 
     function bogota() public {

--- a/src/deployment/dataprovider/DataProviderDeployment.s.sol
+++ b/src/deployment/dataprovider/DataProviderDeployment.s.sol
@@ -105,7 +105,7 @@ contract DataProviderDeployment is BaseDeployment {
         string[] memory assetTags = new string[](supportedAssetLength);
         for (uint256 i = 0; i < supportedAssetLength; i++) {
             assetIds[i] = i;
-            assetTags[i] = i == 0 ? "Eth" : IERC20Metadata(rp..getSupportedAsset(i)).symbol();
+            assetTags[i] = i == 0 ? "Eth" : IERC20Metadata(rp.getSupportedAsset(i)).symbol();
         }
 
         uint256[] memory bridgeAddressIds = new uint256[](11);

--- a/src/deployment/dataprovider/DataProviderDeployment.s.sol
+++ b/src/deployment/dataprovider/DataProviderDeployment.s.sol
@@ -100,9 +100,10 @@ contract DataProviderDeployment is BaseDeployment {
         DataProvider provider = DataProvider(_provider);
         IRollupProcessor rp = provider.ROLLUP_PROCESSOR();
 
-        uint256[] memory assetIds = new uint256[](13);
-        string[] memory assetTags = new string[](13);
-        for (uint256 i = 0; i < assetIds.length; i++) {
+        uint256 supportedAssetLength = rp.getSupportedAssetsLength();
+        uint256[] memory assetIds = new uint256[](supportedAssetLength);
+        string[] memory assetTags = new string[](supportedAssetLength);
+        for (uint256 i = 0; i < supportedAssetLength; i++) {
             assetIds[i] = i;
             assetTags[i] = i == 0 ? "Eth" : IERC20Metadata(rp..getSupportedAsset(i)).symbol();
         }
@@ -122,13 +123,13 @@ contract DataProviderDeployment is BaseDeployment {
         bridgeAddressIds[9] = 14;
         bridgeAddressIds[10] = 15;
 
-        bridgeTags[0] = "ElementBridge";
-        bridgeTags[1] = "CurveStEthBridge";
-        bridgeTags[2] = "YearnBridge_Deposit";
-        bridgeTags[3] = "YearnBridge_Withdraw";
-        bridgeTags[4] = "ElementBridge2M";
-        bridgeTags[5] = "ERC4626";
-        bridgeTags[6] = "DCA400K";
+        bridgeTags[0] = "ElementBridge_800K";
+        bridgeTags[1] = "CurveStEthBridge_250K";
+        bridgeTags[2] = "YearnBridgeDeposit_200K";
+        bridgeTags[3] = "YearnBridgeWithdraw_800K";
+        bridgeTags[4] = "ElementBridge_2M";
+        bridgeTags[5] = "ERC4626_300K";
+        bridgeTags[6] = "DCA_400K";
         bridgeTags[7] = "ERC4626_500K";
         bridgeTags[8] = "ERC4626_400K";
         bridgeTags[9] = "Liquity275_550K";

--- a/src/deployment/dataprovider/DataProviderDeployment.s.sol
+++ b/src/deployment/dataprovider/DataProviderDeployment.s.sol
@@ -91,8 +91,8 @@ contract DataProviderDeployment is BaseDeployment {
     function deployAndListMany() public returns (address) {
         address provider = deploy();
 
-        uint256[] memory assetIds = new uint256[](10);
-        string[] memory assetTags = new string[](10);
+        uint256[] memory assetIds = new uint256[](13);
+        string[] memory assetTags = new string[](13);
         for (uint256 i = 0; i < assetIds.length; i++) {
             assetIds[i] = i;
         }
@@ -106,9 +106,12 @@ contract DataProviderDeployment is BaseDeployment {
         assetTags[7] = "wedai";
         assetTags[8] = "we2dai";
         assetTags[9] = "we2weth";
+        assetTags[10] = "lusd";
+        assetTags[11] = "tb-275";
+        assetTags[12] = "tb-400";
 
-        uint256[] memory bridgeAddressIds = new uint256[](9);
-        string[] memory bridgeTags = new string[](9);
+        uint256[] memory bridgeAddressIds = new uint256[](11);
+        string[] memory bridgeTags = new string[](11);
 
         bridgeAddressIds[0] = 1;
         bridgeAddressIds[1] = 6;
@@ -119,6 +122,8 @@ contract DataProviderDeployment is BaseDeployment {
         bridgeAddressIds[6] = 11;
         bridgeAddressIds[7] = 12;
         bridgeAddressIds[8] = 13;
+        bridgeAddressIds[9] = 14;
+        bridgeAddressIds[10] = 15;
 
         bridgeTags[0] = "ElementBridge";
         bridgeTags[1] = "CurveStEthBridge";
@@ -129,9 +134,13 @@ contract DataProviderDeployment is BaseDeployment {
         bridgeTags[6] = "DCA400K";
         bridgeTags[7] = "ERC4626_500K";
         bridgeTags[8] = "ERC4626_400K";
+        bridgeTags[9] = "Liquity275_550K";
+        bridgeTags[10] = "Liquity400_550K";
 
         vm.broadcast();
         DataProvider(provider).addAssetsAndBridges(assetIds, assetTags, bridgeAddressIds, bridgeTags);
+
+        readProvider(provider);
 
         return provider;
     }

--- a/src/test/aztec/dataprovider/DataProvider.t.sol
+++ b/src/test/aztec/dataprovider/DataProvider.t.sol
@@ -188,15 +188,21 @@ contract DataProviderTest is BridgeTestBase {
         vm.warp(block.timestamp + 1 days);
 
         uint256 bridgeCallData = ROLLUP_ENCODER.encodeBridgeCallData(7, eth, empty, vyvault, empty, 0);
-        (uint256 criteria, uint256 subsidy) = provider.getAccumulatedSubsidyAmount(bridgeCallData);
+        (uint256 criteria, uint256 subsidy, uint256 gasUnits) = provider.getAccumulatedSubsidyAmount(bridgeCallData);
         assertEq(criteria, 0, "Subsidy have accrued");
         assertGt(subsidy, 0, "No subsidy accrued");
+        assertGe(subsidy, gasUnits * block.basefee, "Invalid gas units accrued");
+        assertEq(gasUnits, subsidy / block.basefee, "Invalid gas units accrued");
 
         {
             uint256 bridgeCallData = ROLLUP_ENCODER.encodeBridgeCallData(7, vyvault, empty, eth, empty, 1);
-            (uint256 criteria, uint256 subsidy) = provider.getAccumulatedSubsidyAmount(bridgeCallData);
+            (uint256 criteria, uint256 subsidy, uint256 gasUnits) = provider.getAccumulatedSubsidyAmount(
+                bridgeCallData
+            );
             assertEq(criteria, 1, "Wrong criteria");
             assertEq(subsidy, 0, "Subsidy accrued");
+            assertGe(subsidy, gasUnits * block.basefee, "Invalid gas units accrued");
+            assertEq(gasUnits, subsidy / block.basefee, "Invalid gas units accrued");
         }
     }
 
@@ -204,9 +210,11 @@ contract DataProviderTest is BridgeTestBase {
         AztecTypes.AztecAsset memory eth = ROLLUP_ENCODER.getRealAztecAsset(address(0));
         AztecTypes.AztecAsset memory dai = ROLLUP_ENCODER.getRealAztecAsset(0x6B175474E89094C44Da98b954EedeAC495271d0F);
         uint256 bridgeCallData = ROLLUP_ENCODER.encodeBridgeCallData(7, dai, eth, dai, eth, 0);
-        (uint256 criteria, uint256 subsidy) = provider.getAccumulatedSubsidyAmount(bridgeCallData);
+        (uint256 criteria, uint256 subsidy, uint256 gasUnits) = provider.getAccumulatedSubsidyAmount(bridgeCallData);
         assertEq(criteria, 0, "Wrong criteria");
         assertGt(subsidy, 0, "No subsidy accrued");
+        assertGe(subsidy, gasUnits * block.basefee, "Invalid gas units accrued");
+        assertEq(gasUnits, subsidy / block.basefee, "Invalid gas units accrued");
     }
 
     function testHappySubsidyHelperVirtual() public {
@@ -218,17 +226,21 @@ contract DataProviderTest is BridgeTestBase {
         });
 
         uint256 bridgeCallData = ROLLUP_ENCODER.encodeBridgeCallData(7, virtualAsset, eth, virtualAsset, eth, 0);
-        (uint256 criteria, uint256 subsidy) = provider.getAccumulatedSubsidyAmount(bridgeCallData);
+        (uint256 criteria, uint256 subsidy, uint256 gasUnits) = provider.getAccumulatedSubsidyAmount(bridgeCallData);
         assertEq(criteria, 0, "Wrong criteria");
         assertGt(subsidy, 0, "No subsidy accrued");
+        assertGe(subsidy, gasUnits * block.basefee, "Invalid gas units accrued");
+        assertEq(gasUnits, subsidy / block.basefee, "Invalid gas units accrued");
     }
 
     function testUnHappySubsidyHelper() public {
         AztecTypes.AztecAsset memory empty;
         AztecTypes.AztecAsset memory dai = ROLLUP_ENCODER.getRealAztecAsset(0x6B175474E89094C44Da98b954EedeAC495271d0F);
         uint256 bridgeCallData = ROLLUP_ENCODER.encodeBridgeCallData(1, dai, empty, dai, empty, 0);
-        (uint256 criteria, uint256 subsidy) = provider.getAccumulatedSubsidyAmount(bridgeCallData);
+        (uint256 criteria, uint256 subsidy, uint256 gasUnits) = provider.getAccumulatedSubsidyAmount(bridgeCallData);
         assertEq(criteria, 0, "Wrong criteria");
         assertEq(subsidy, 0, "Subsidy have accrued");
+        assertGe(subsidy, gasUnits * block.basefee, "Invalid gas units accrued");
+        assertEq(gasUnits, subsidy / block.basefee, "Invalid gas units accrued");
     }
 }

--- a/src/test/aztec/dataprovider/DataProvider.t.sol
+++ b/src/test/aztec/dataprovider/DataProvider.t.sol
@@ -14,6 +14,7 @@ contract DataProviderTest is BridgeTestBase {
 
         // fund yearn bridge to ensure that there are funds.
         SUBSIDY.topUp{value: 10 ether}(ROLLUP_PROCESSOR.getSupportedBridge(7), 0);
+        SUBSIDY.topUp{value: 10 ether}(ROLLUP_PROCESSOR.getSupportedBridge(7), 1);
     }
 
     function testAddMultipleAssetsAndBridgesWrongInput() public {
@@ -200,7 +201,7 @@ contract DataProviderTest is BridgeTestBase {
                 bridgeCallData
             );
             assertEq(criteria, 1, "Wrong criteria");
-            assertEq(subsidy, 0, "Subsidy accrued");
+            assertGe(subsidy, 0, "Subsidy accrued");
             assertGe(subsidy, gasUnits * block.basefee, "Invalid gas units accrued");
             assertEq(gasUnits, subsidy / block.basefee, "Invalid gas units accrued");
         }


### PR DESCRIPTION
# Description

Returns the number of gas units as well as the eth subsidized for `getAccumulatedSubsidyAmount`

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] There are no unexpected formatting changes, or superfluous debug logs.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewers next convenience.
- [x] NatSpec documentation of all the non-test functions is present and is complete.
- [x] Continuous integration (CI) passes.
- [x] Command `forge coverage --match-contract MyContract` returns 100% line coverage.
- [x] All the possible reverts are tested.
