### PR TITLE
Repaying LUSD debt with collateral in TroveBridge

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "compile:typechain": "forge build && typechain --target ethers-v5 --out-dir ./typechain-types './out/!(test*|Test*|*.t.sol|*.s.sol)/*.json'",
     "compile:client-dest": "yarn compile:typechain && tsc --project tsconfig.client-dest.json",
     "build": "forge build && yarn compile:client-dest",
-    "test:pinned:14000000": "forge test --fork-block-number 14000000 --match-contract 'Element|OracleHelper' --fork-url https://mainnet.infura.io/v3/9928b52099854248b3a096be07a6b23c",
+    "test:pinned:14000000": "forge test --fork-block-number 14000000 --match-contract 'Element' --fork-url https://mainnet.infura.io/v3/9928b52099854248b3a096be07a6b23c",
     "test:pinned:14970000": "forge test --fork-block-number 14970000 -m 'testRedistributionSuccessfulSwap|testRedistributionExitWhenICREqualsMCR' --fork-url https://mainnet.infura.io/v3/9928b52099854248b3a096be07a6b23c",
     "test:pinned:14972000": "forge test --fork-block-number 14972000 -m 'testRedistributionFailingSwap' --fork-url https://mainnet.infura.io/v3/9928b52099854248b3a096be07a6b23c",
     "test:pinned": "yarn test:pinned:14000000 && yarn test:pinned:14970000 && yarn test:pinned:14972000",

--- a/src/bridges/liquity/TroveBridge.sol
+++ b/src/bridges/liquity/TroveBridge.sol
@@ -507,14 +507,13 @@ contract TroveBridge is BridgeBase, ERC20, Ownable, IUniswapV3SwapCallback {
         // Compute how much debt to be repay
         uint256 tbTotalSupply = totalSupply(); // SLOAD optimization
         uint256 debtToRepay = (_tbAmount * debtBefore) / tbTotalSupply;
-        if (debtToRepay <= _tbAmount) revert ErrorLib.InvalidOutputB();
         // Compute how much collateral to withdraw
         uint256 collToWithdraw = (_tbAmount * collBefore) / tbTotalSupply;
 
         IUniswapV3PoolActions(LUSD_USDC_POOL).swap(
             address(this), // recipient
             false, // zeroForOne
-            -int256(debtToRepay - _tbAmount), // amount of LUSD to receive
+            -int256(debtToRepay), // amount of LUSD to receive
             SQRT_PRICE_LIMIT_X96,
             abi.encode(SwapCallbackData({debtToRepay: debtToRepay, collToWithdraw: collToWithdraw}))
         );

--- a/src/bridges/liquity/TroveBridge.sol
+++ b/src/bridges/liquity/TroveBridge.sol
@@ -88,7 +88,7 @@ contract TroveBridge is BridgeBase, ERC20, Ownable, IUniswapV3SwapCallback {
 
     uint256 public immutable INITIAL_ICR;
 
-    // Price precision of LUSD/ETH
+    // Price precision
     uint256 public constant PRECISION = 1e18;
 
     // We are not setting price impact protection and in both swaps zeroForOne is false so sqrtPriceLimitX96
@@ -432,9 +432,9 @@ contract TroveBridge is BridgeBase, ERC20, Ownable, IUniswapV3SwapCallback {
 
     /**
      * @notice Repay debt by selling part of the collateral for LUSD.
-     * @param _totalInputValue Amount of TB to burn (and input LUSD to use for repayment if `_lusdOnInput` param
-     *                         is set to true).
-     * @param _maxPrice Maximum acceptable price of LUSD denominated in ETH (LUSD/ETH price).
+     * @param _totalInputValue Amount of TB to burn (and input LUSD to use for repayment if `_lusdInput` param is set
+     *                         to true).
+     * @param _maxPrice Maximum acceptable price of LUSD denominated in ETH.
      * @param _interactionNonce Same as in convert(...) method.
      * @param _lusdInput If true the debt will be covered by both the LUSD on input and by selling part of the
      *                   collateral. If false the debt will be covered only by selling the collateral.

--- a/src/bridges/liquity/TroveBridge.sol
+++ b/src/bridges/liquity/TroveBridge.sol
@@ -525,7 +525,7 @@ contract TroveBridge is BridgeBase, ERC20, Ownable, IUniswapV3SwapCallback {
 
         // Check price at which collateral was sold was sufficient
         uint256 collateralSold = collToWithdraw - collateralReturned;
-        uint256 swapPrice = (collateralSold * PRECISION) / debtToRepay;
+        uint256 swapPrice = (debtToRepay * PRECISION) / collateralSold;
         if (swapPrice < _minPrice) revert InsufficientAmountOut();
 
         // Flash swap didn't revert - burn all input TB

--- a/src/bridges/liquity/TroveBridge.sol
+++ b/src/bridges/liquity/TroveBridge.sol
@@ -49,7 +49,7 @@ contract TroveBridge is BridgeBase, ERC20, Ownable, IUniswapV3SwapCallback {
     using Strings for uint256;
 
     error NonZeroTotalSupply();
-    error InvalidStatus(Status acceptableStatus1, Status acceptableStatus2, Status received);
+    error InvalidStatus(Status status);
     error InvalidDeltaAmounts();
     error OwnerNotLast();
     error InsufficientAmountOut();
@@ -217,7 +217,7 @@ contract TroveBridge is BridgeBase, ERC20, Ownable, IUniswapV3SwapCallback {
             _outputAssetB.erc20Address == LUSD
         ) {
             // Borrowing
-            if (troveStatus != Status.active) revert InvalidStatus(Status.active, Status.active, troveStatus);
+            if (troveStatus != Status.active) revert InvalidStatus(troveStatus);
             (outputValueA, outputValueB) = _borrow(_totalInputValue, _auxData);
             subsidyCriteria = 0;
         } else if (
@@ -226,7 +226,7 @@ contract TroveBridge is BridgeBase, ERC20, Ownable, IUniswapV3SwapCallback {
             _outputAssetA.assetType == AztecTypes.AztecAssetType.ETH
         ) {
             // Repaying
-            if (troveStatus != Status.active) revert InvalidStatus(Status.active, Status.active, troveStatus);
+            if (troveStatus != Status.active) revert InvalidStatus(troveStatus);
             if (_outputAssetB.erc20Address == LUSD) {
                 // A case when the trove was partially redeemed (1 TB corresponding to less than 1 LUSD of debt) or not
                 // redeemed and not touched by redistribution (1 TB corresponding to exactly 1 LUSD of debt)
@@ -249,7 +249,7 @@ contract TroveBridge is BridgeBase, ERC20, Ownable, IUniswapV3SwapCallback {
                 outputValueA = _redeem(_totalInputValue, _interactionNonce);
                 // Repaying and redeeming has the same subsidy criteria
             } else {
-                revert InvalidStatus(Status.closedByRedemption, Status.closedByLiquidation, troveStatus);
+                revert InvalidStatus(troveStatus);
             }
             subsidyCriteria = 1;
         } else {

--- a/src/bridges/liquity/TroveBridge.sol
+++ b/src/bridges/liquity/TroveBridge.sol
@@ -88,7 +88,7 @@ contract TroveBridge is BridgeBase, ERC20, Ownable, IUniswapV3SwapCallback {
 
     uint256 public immutable INITIAL_ICR;
 
-    // Used when computing acceptable slippage in `_repayWithCollateral(...)` function
+    // Price precision of LUSD/ETH
     uint256 public constant PRECISION = 1e18;
 
     // We are not setting price impact protection and in both swaps zeroForOne is false so sqrtPriceLimitX96
@@ -434,7 +434,7 @@ contract TroveBridge is BridgeBase, ERC20, Ownable, IUniswapV3SwapCallback {
      * @notice Repay debt by selling part of the collateral for LUSD.
      * @param _totalInputValue Amount of TB to burn (and input LUSD to use for repayment if `_lusdOnInput` param
      *                         is set to true).
-     * @param _maxPrice Maximum acceptable price of LUSD denominated in ETH (ETH/LUSD price).
+     * @param _maxPrice Maximum acceptable price of LUSD denominated in ETH (LUSD/ETH price).
      * @param _interactionNonce Same as in convert(...) method.
      * @param _lusdInput If true the debt will be covered by both the LUSD on input and by selling part of the
      *                   collateral. If false the debt will be covered only by selling the collateral.

--- a/src/test/bridges/liquity/TroveBridgeE2E.t.sol
+++ b/src/test/bridges/liquity/TroveBridgeE2E.t.sol
@@ -60,6 +60,14 @@ contract TroveBridgeE2ETest is BridgeTestBase, TroveBridgeTestBase {
         _repay(collateral);
     }
 
+    function testFullFlowRepayingWithColl(uint96 _collateral) public {
+        // Setting maximum only to 100 ETH because liquidity in the UNI pools is not sufficient for higher amounts
+        uint256 collateral = bound(_collateral, 1e17, 1e20);
+
+        _borrow(collateral);
+        _repayWithCollateral(collateral);
+    }
+
     function _borrow(uint256 _collateral) public {
         // Mint the collateral amount of ETH to rollupProcessor
         vm.deal(address(ROLLUP_PROCESSOR), _collateral);
@@ -109,5 +117,26 @@ contract TroveBridgeE2ETest is BridgeTestBase, TroveBridgeTestBase {
 
         assertApproxEqAbs(outputValueA, _collateral, 1, "output value differs from collateral by more than 1 wei");
         assertEq(outputValueB, 0, "Non-zero LUSD amount returned");
+    }
+
+    function _repayWithCollateral(uint256 _collateral) public {
+        uint256 tbBalance = bridge.balanceOf(address(ROLLUP_PROCESSOR));
+
+        // Mint the amount to repay to rollup processor - sufficient amount is not there since borrowing because we
+        // need to pay for the borrowing fee
+        deal(lusdAsset.erc20Address, address(ROLLUP_PROCESSOR), tbBalance + bridge.DUST());
+
+        // Compute repay calldata
+        ROLLUP_ENCODER.defiInteractionL2(id, tbAsset, emptyAsset, ethAsset, emptyAsset, _getPrice(-1e20), tbBalance);
+
+        (uint256 outputValueA, uint256 outputValueB, ) = ROLLUP_ENCODER.processRollupAndGetBridgeResult();
+
+        // Given that ICR was set to 160% and the debt has been repaid with collateral, received collateral should be
+        // approx. equal to (deposit collateral amount) * (100/160). Given that borrowing fee and fee for the flash
+        // swap was paid the actual collateral received will be slightly less.
+        uint256 expectedEthReceived = _collateral - (_collateral * 100) / 160;
+        uint256 expectedEthReceivedWithTolerance = (expectedEthReceived * 90) / 100;
+
+        assertGt(outputValueA, expectedEthReceivedWithTolerance, "Not enough collateral received");
     }
 }

--- a/src/test/bridges/liquity/TroveBridgeE2E.t.sol
+++ b/src/test/bridges/liquity/TroveBridgeE2E.t.sol
@@ -68,7 +68,7 @@ contract TroveBridgeE2ETest is BridgeTestBase, TroveBridgeTestBase {
         _repayWithCollateral(collateral);
     }
 
-    function _borrow(uint256 _collateral) public {
+    function _borrow(uint256 _collateral) private {
         // Mint the collateral amount of ETH to rollupProcessor
         vm.deal(address(ROLLUP_PROCESSOR), _collateral);
 
@@ -103,7 +103,7 @@ contract TroveBridgeE2ETest is BridgeTestBase, TroveBridgeTestBase {
         );
     }
 
-    function _repay(uint256 _collateral) public {
+    function _repay(uint256 _collateral) private {
         uint256 tbBalance = bridge.balanceOf(address(ROLLUP_PROCESSOR));
 
         // Mint the amount to repay to rollup processor - sufficient amount is not there since borrowing because we
@@ -119,7 +119,7 @@ contract TroveBridgeE2ETest is BridgeTestBase, TroveBridgeTestBase {
         assertEq(outputValueB, 0, "Non-zero LUSD amount returned");
     }
 
-    function _repayWithCollateral(uint256 _collateral) public {
+    function _repayWithCollateral(uint256 _collateral) private {
         uint256 tbBalance = bridge.balanceOf(address(ROLLUP_PROCESSOR));
 
         // Mint the amount to repay to rollup processor - sufficient amount is not there since borrowing because we
@@ -129,7 +129,7 @@ contract TroveBridgeE2ETest is BridgeTestBase, TroveBridgeTestBase {
         // Compute repay calldata
         ROLLUP_ENCODER.defiInteractionL2(id, tbAsset, emptyAsset, ethAsset, emptyAsset, _getPrice(-1e20), tbBalance);
 
-        (uint256 outputValueA, uint256 outputValueB, ) = ROLLUP_ENCODER.processRollupAndGetBridgeResult();
+        (uint256 outputValueA, , ) = ROLLUP_ENCODER.processRollupAndGetBridgeResult();
 
         // Given that ICR was set to 160% and the debt has been repaid with collateral, received collateral should be
         // approx. equal to (deposit collateral amount) * (100/160). Given that borrowing fee and fee for the flash

--- a/src/test/bridges/liquity/TroveBridgeE2E.t.sol
+++ b/src/test/bridges/liquity/TroveBridgeE2E.t.sol
@@ -93,7 +93,7 @@ contract TroveBridgeE2ETest is BridgeTestBase, TroveBridgeTestBase {
         deal(lusdAsset.erc20Address, address(ROLLUP_PROCESSOR), tbBalanceAfterBorrowing + bridge.DUST());
 
         // Compute repay calldata
-        ROLLUP_ENCODER.defiInteractionL2(id, tbAsset, lusdAsset, ethAsset, lusdAsset, MAX_FEE, tbBalanceAfterBorrowing);
+        ROLLUP_ENCODER.defiInteractionL2(id, tbAsset, lusdAsset, ethAsset, lusdAsset, 0, tbBalanceAfterBorrowing);
 
         (outputValueA, outputValueB, ) = ROLLUP_ENCODER.processRollupAndGetBridgeResult();
 

--- a/src/test/bridges/liquity/TroveBridgeE2E.t.sol
+++ b/src/test/bridges/liquity/TroveBridgeE2E.t.sol
@@ -16,6 +16,10 @@ contract TroveBridgeE2ETest is BridgeTestBase, TroveBridgeTestBase {
     // To store the id of the trove bridge after being added
     uint256 private id;
 
+    AztecTypes.AztecAsset private ethAsset;
+    AztecTypes.AztecAsset private tbAsset;
+    AztecTypes.AztecAsset private lusdAsset;
+
     function setUp() public {
         // Deploy a new trove bridge
         vm.prank(OWNER);
@@ -38,27 +42,30 @@ contract TroveBridgeE2ETest is BridgeTestBase, TroveBridgeTestBase {
 
         vm.stopPrank();
 
+        // Setup assets
+        ethAsset = ROLLUP_ENCODER.getRealAztecAsset(address(0));
+        tbAsset = ROLLUP_ENCODER.getRealAztecAsset(address(bridge));
+        lusdAsset = ROLLUP_ENCODER.getRealAztecAsset(tokens["LUSD"].addr);
+
         // Fetch the id of the trove bridge
         id = ROLLUP_PROCESSOR.getSupportedBridgesLength();
 
         _openTrove();
     }
 
-    // @dev In order to avoid overflows we set _collateral to be uint96 instead of uint256.
     function testFullFlow(uint96 _collateral) public {
         uint256 collateral = bound(_collateral, 1e17, 1e21);
 
-        // Use the helper function to fetch Aztec assets
-        AztecTypes.AztecAsset memory ethAsset = ROLLUP_ENCODER.getRealAztecAsset(address(0));
-        AztecTypes.AztecAsset memory tbAsset = ROLLUP_ENCODER.getRealAztecAsset(address(bridge));
-        AztecTypes.AztecAsset memory lusdAsset = ROLLUP_ENCODER.getRealAztecAsset(tokens["LUSD"].addr);
+        _borrow(collateral);
+        _repay(collateral);
+    }
 
-        // BORROW
+    function _borrow(uint256 _collateral) public {
         // Mint the collateral amount of ETH to rollupProcessor
-        vm.deal(address(ROLLUP_PROCESSOR), collateral);
+        vm.deal(address(ROLLUP_PROCESSOR), _collateral);
 
         // Compute borrow calldata
-        ROLLUP_ENCODER.defiInteractionL2(id, ethAsset, emptyAsset, tbAsset, lusdAsset, MAX_FEE, collateral);
+        ROLLUP_ENCODER.defiInteractionL2(id, ethAsset, emptyAsset, tbAsset, lusdAsset, MAX_FEE, _collateral);
 
         (uint256 debtBeforeBorrowing, uint256 collBeforeBorrowing, , ) = TROVE_MANAGER.getEntireDebtAndColl(
             address(bridge)
@@ -71,7 +78,7 @@ contract TroveBridgeE2ETest is BridgeTestBase, TroveBridgeTestBase {
         );
         assertEq(
             collAfterBorrowing - collBeforeBorrowing,
-            collateral,
+            _collateral,
             "Collateral increase differs from deposited collateral"
         );
         uint256 tbBalanceAfterBorrowing = bridge.balanceOf(address(ROLLUP_PROCESSOR));
@@ -83,21 +90,24 @@ contract TroveBridgeE2ETest is BridgeTestBase, TroveBridgeTestBase {
         assertEq(outputValueA, tbBalanceAfterBorrowing, "Debt amount doesn't equal outputValueA");
         assertEq(
             outputValueB,
-            bridge.computeAmtToBorrow(collateral),
+            bridge.computeAmtToBorrow(_collateral),
             "Borrowed amount doesn't equal expected borrow amount"
         );
+    }
 
-        // REPAY
-        // Mint the amount to repay to rollup processor - sufficient amount is not there since borrowing because there
-        // we need to pay for the borrowing fee
-        deal(lusdAsset.erc20Address, address(ROLLUP_PROCESSOR), tbBalanceAfterBorrowing + bridge.DUST());
+    function _repay(uint256 _collateral) public {
+        uint256 tbBalance = bridge.balanceOf(address(ROLLUP_PROCESSOR));
+
+        // Mint the amount to repay to rollup processor - sufficient amount is not there since borrowing because we
+        // need to pay for the borrowing fee
+        deal(lusdAsset.erc20Address, address(ROLLUP_PROCESSOR), tbBalance + bridge.DUST());
 
         // Compute repay calldata
-        ROLLUP_ENCODER.defiInteractionL2(id, tbAsset, lusdAsset, ethAsset, lusdAsset, 0, tbBalanceAfterBorrowing);
+        ROLLUP_ENCODER.defiInteractionL2(id, tbAsset, lusdAsset, ethAsset, lusdAsset, 0, tbBalance);
 
-        (outputValueA, outputValueB, ) = ROLLUP_ENCODER.processRollupAndGetBridgeResult();
+        (uint256 outputValueA, uint256 outputValueB, ) = ROLLUP_ENCODER.processRollupAndGetBridgeResult();
 
-        assertApproxEqAbs(outputValueA, collateral, 1, "output value differs from colalteral by more than 1 wei");
+        assertApproxEqAbs(outputValueA, _collateral, 1, "output value differs from collateral by more than 1 wei");
         assertEq(outputValueB, 0, "Non-zero LUSD amount returned");
     }
 }

--- a/src/test/bridges/liquity/TroveBridgeTestBase.sol
+++ b/src/test/bridges/liquity/TroveBridgeTestBase.sol
@@ -185,4 +185,17 @@ contract TroveBridgeTestBase is TestUtil {
 
         vm.stopPrank();
     }
+
+    /**
+     * @param _ethPriceDiff LUSD denominated difference from the current ETH price
+     * @return Price of LUSD denominated in ETH corresponding to the current market price of ETH modified
+     *         by `_ethPriceDiff`
+     */
+    function _getPrice(int256 _ethPriceDiff) internal returns (uint64) {
+        // Set minPrice equal to that from Liquity's oracle increased by 100 LUSD
+        uint256 minEthPrice = uint256(int256(TROVE_MANAGER.priceFeed().fetchPrice()) + _ethPriceDiff);
+        // Invert the price so that it represent max price at which I am willing to buy LUSD and not min price at which
+        // I am willing to sell ETH (just for consistency sake)
+        return uint64((bridge.PRECISION() * bridge.PRECISION()) / minEthPrice);
+    }
 }

--- a/src/test/bridges/liquity/TroveBridgeUnit.t.sol
+++ b/src/test/bridges/liquity/TroveBridgeUnit.t.sol
@@ -561,7 +561,7 @@ contract TroveBridgeUnitTest is TroveBridgeTestBase {
             outputAssetB,
             inputValue,
             _interactionNonce,
-            0,
+            _getMinPriceLowerThanCurrent(),
             address(0)
         );
 
@@ -598,11 +598,6 @@ contract TroveBridgeUnitTest is TroveBridgeTestBase {
 
         uint256 rollupProcessorEthBalanceBefore = rollupProcessor.balance;
 
-        // Set minPrice equal to that from Liquity's oracle decreased by 100 LUSD
-        // Decreasing by 100 LUSD to make sure the call doesn't revert in normal circumstances
-        uint256 price = TROVE_MANAGER.priceFeed().fetchPrice();
-        uint64 minPrice = uint64((price / 1e18 - 100) * bridge.PRECISION());
-
         (uint256 outputValueA, uint256 outputValueB, ) = bridge.convert(
             inputAssetA,
             emptyAsset,
@@ -610,7 +605,7 @@ contract TroveBridgeUnitTest is TroveBridgeTestBase {
             emptyAsset,
             inputValue,
             1,
-            minPrice,
+            _getMinPriceLowerThanCurrent(),
             address(0)
         );
 
@@ -710,5 +705,12 @@ contract TroveBridgeUnitTest is TroveBridgeTestBase {
         if (subsidy.code.length == 0) {
             vm.etch(subsidy, address(new Subsidy()).code);
         }
+    }
+
+    function _getMinPriceLowerThanCurrent() private returns (uint64) {
+        // Set minPrice equal to that from Liquity's oracle decreased by 100 LUSD
+        // Decreasing by 100 LUSD to make sure the call doesn't revert in normal circumstances
+        uint256 price = TROVE_MANAGER.priceFeed().fetchPrice();
+        return uint64((price / 1e18 - 100) * bridge.PRECISION());
     }
 }

--- a/src/test/bridges/liquity/TroveBridgeUnit.t.sol
+++ b/src/test/bridges/liquity/TroveBridgeUnit.t.sol
@@ -107,8 +107,9 @@ contract TroveBridgeUnitTest is TroveBridgeTestBase {
 
         uint256 rollupProcessorEthBalanceBefore = rollupProcessor.balance;
 
-        // ETH price corresponding to 1 ETH being worth 100 LUSD (if call doesn't revert I cry)
-        uint64 minPrice = uint64(100 * bridge.PRECISION());
+        // Set minPrice equal to that from Liquity's oracle increased by 100 LUSD
+        uint256 price = TROVE_MANAGER.priceFeed().fetchPrice();
+        uint64 minPrice = uint64((price / 1e18 + 100) * bridge.PRECISION());
 
         vm.expectRevert(TroveBridge.InsufficientAmountOut.selector);
         bridge.convert(inputAssetA, emptyAsset, outputAssetA, emptyAsset, inputValue, 1, minPrice, address(0));
@@ -597,6 +598,11 @@ contract TroveBridgeUnitTest is TroveBridgeTestBase {
 
         uint256 rollupProcessorEthBalanceBefore = rollupProcessor.balance;
 
+        // Set minPrice equal to that from Liquity's oracle decreased by 100 LUSD
+        // Decreasing by 100 LUSD to make sure the call doesn't revert in normal circumstances
+        uint256 price = TROVE_MANAGER.priceFeed().fetchPrice();
+        uint64 minPrice = uint64((price / 1e18 - 100) * bridge.PRECISION());
+
         (uint256 outputValueA, uint256 outputValueB, ) = bridge.convert(
             inputAssetA,
             emptyAsset,
@@ -604,7 +610,7 @@ contract TroveBridgeUnitTest is TroveBridgeTestBase {
             emptyAsset,
             inputValue,
             1,
-            0,
+            minPrice,
             address(0)
         );
 

--- a/src/test/bridges/liquity/TroveBridgeUnit.t.sol
+++ b/src/test/bridges/liquity/TroveBridgeUnit.t.sol
@@ -594,8 +594,10 @@ contract TroveBridgeUnitTest is TroveBridgeTestBase {
         // Given that ICR was set to 160% and the debt has been repaid with collateral, received collateral should be
         // approx. equal to (deposit collateral amount) * (100/160). Given that borrowing fee and fee for the flash
         // swap was paid the actual collateral received will be slightly less.
-        uint256 expectedEthReceived = (ROLLUP_PROCESSOR_ETH_BALANCE * 100) / 160;
-        assertGt(rollupProcessorEthBalanceDiff, expectedEthReceived, "Not enough collateral received");
+        uint256 expectedEthReceived = ROLLUP_PROCESSOR_ETH_BALANCE - (ROLLUP_PROCESSOR_ETH_BALANCE * 100) / 160;
+
+        // Accepting to receive at most 0.05 ETH less after repaying
+        assertGt(rollupProcessorEthBalanceDiff, expectedEthReceived - 5e16, "Not enough collateral received");
     }
 
     function _redeem() private {

--- a/src/test/bridges/liquity/TroveBridgeUnit.t.sol
+++ b/src/test/bridges/liquity/TroveBridgeUnit.t.sol
@@ -35,7 +35,7 @@ contract TroveBridgeUnitTest is TroveBridgeTestBase {
     function testInvalidTroveStatus() public {
         // Attempt borrowing when trove was not opened - state 0
         vm.deal(rollupProcessor, ROLLUP_PROCESSOR_ETH_BALANCE);
-        vm.expectRevert(abi.encodeWithSignature("InvalidStatus(uint8,uint8,uint8)", 1, 1, 0));
+        vm.expectRevert(abi.encodeWithSignature("InvalidStatus(uint8)", 0));
         bridge.convert(
             AztecTypes.AztecAsset(3, address(0), AztecTypes.AztecAssetType.ETH),
             emptyAsset,

--- a/src/test/bridges/liquity/TroveBridgeUnit.t.sol
+++ b/src/test/bridges/liquity/TroveBridgeUnit.t.sol
@@ -105,8 +105,6 @@ contract TroveBridgeUnitTest is TroveBridgeTestBase {
         // Transfer TB to the bridge
         IERC20(inputAssetA.erc20Address).transfer(address(bridge), inputValue);
 
-        uint256 rollupProcessorEthBalanceBefore = rollupProcessor.balance;
-
         // Set minPrice equal to that from Liquity's oracle increased by 100 LUSD
         uint256 price = TROVE_MANAGER.priceFeed().fetchPrice();
         uint64 minPrice = uint64((price / 1e18 + 100) * bridge.PRECISION());

--- a/src/test/bridges/liquity/TroveBridgeUnit.t.sol
+++ b/src/test/bridges/liquity/TroveBridgeUnit.t.sol
@@ -263,7 +263,7 @@ contract TroveBridgeUnitTest is TroveBridgeTestBase {
             outputAssetB,
             inputValue,
             1,
-            MAX_FEE,
+            0,
             address(0)
         );
 
@@ -523,7 +523,7 @@ contract TroveBridgeUnitTest is TroveBridgeTestBase {
             outputAssetB,
             inputValue,
             _interactionNonce,
-            MAX_FEE,
+            0,
             address(0)
         );
 

--- a/src/test/bridges/liquity/TroveBridgeUnit.t.sol
+++ b/src/test/bridges/liquity/TroveBridgeUnit.t.sol
@@ -740,17 +740,4 @@ contract TroveBridgeUnitTest is TroveBridgeTestBase {
             vm.etch(subsidy, address(new Subsidy()).code);
         }
     }
-
-    /**
-     * @param _ethPriceDiff LUSD denominated difference from the current ETH price
-     * @return Price of LUSD denominated in ETH corresponding to the current market price of ETH modified
-     *         by `_ethPriceDiff`
-     */
-    function _getPrice(int256 _ethPriceDiff) private returns (uint64) {
-        // Set minPrice equal to that from Liquity's oracle increased by 100 LUSD
-        uint256 minEthPrice = uint256(int256(TROVE_MANAGER.priceFeed().fetchPrice()) + _ethPriceDiff);
-        // Invert the price so that it represent max price at which I am willing to buy LUSD and not min price at which
-        // I am willing to sell ETH (just for consistency sake)
-        return uint64((bridge.PRECISION() * bridge.PRECISION()) / minEthPrice);
-    }
 }


### PR DESCRIPTION
# Description
Since it turned out that having 2 assets on input can be tricky UX-wise I am adding an option of repaying the debt only with user's collateral in this PR. This will result in users having the option to repay debt by only providing TB on input (and not LUSD). To achieve this flash swaps are used.

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] There are no unexpected formatting changes, or superfluous debug logs.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewers next convenience.
- [x] NatSpec documentation of all the non-test functions is present and is complete.
- [x] Continuous integration (CI) passes.
- [ ] Command `forge coverage --match-contract MyContract` returns 100% line coverage.
- [x] All the possible reverts are tested.
