### PR TITLE
chore: use `forge fmt` instead of `prettier`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,17 +22,22 @@ jobs:
           shell: /bin/bash
           command: |
             yarn config set script-shell /bin/bash
-            yarn
-            yarn install:foundry
+            yarn install:foundryup
             export PATH=/home/circleci/.foundry/bin:$PATH
-            export PATH=/home/circleci/.forge/bin:$PATH
-            yarn setup:foundry
+            yarn install:foundry
+      - run:
+          name: Build Project
+          shell: /bin/bash
+          command: |
+            export PATH=/home/circleci/.foundry/bin:$PATH
+            yarn install:dependencies
             yarn build
       - run:
           name: Check Formatting
           shell: /bin/bash
           command: |
             yarn config set script-shell /bin/bash
+            export PATH=/home/circleci/.foundry/bin:$PATH
             yarn formatting:check
       - run:
           name: Check Linting Errors in Contracts
@@ -52,7 +57,6 @@ jobs:
           command: |
             yarn config set script-shell /bin/bash
             export PATH=/home/circleci/.foundry/bin:$PATH
-            export PATH=/home/circleci/.forge/bin:$PATH
             yarn test:contracts
       - run:
           name: Test Clients
@@ -60,16 +64,7 @@ jobs:
           command: |
             yarn config set script-shell /bin/bash
             export PATH=/home/circleci/.foundry/bin:$PATH
-            export PATH=/home/circleci/.forge/bin:$PATH
             yarn test:clients
-      - run:
-          name: Build
-          shell: /bin/bash
-          command: |
-            yarn config set script-shell /bin/bash
-            export PATH=/home/circleci/.foundry/bin:$PATH
-            export PATH=/home/circleci/.forge/bin:$PATH
-            yarn build
   publish:
     docker:
       - image: "cimg/python:3.10.6"
@@ -89,15 +84,19 @@ jobs:
             export PATH=/home/cicleci/.local/bin:$PATH
             vyper --version
       - run:
-          name: Setup Foundry and Build
+          name: Setup Foundry
           shell: /bin/bash
           command: |
             yarn config set script-shell /bin/bash
-            yarn
-            yarn install:foundry
+            yarn install:foundryup
             export PATH=/home/circleci/.foundry/bin:$PATH
-            export PATH=/home/circleci/.forge/bin:$PATH
-            yarn setup:foundry
+            yarn install:foundry
+      - run:
+          name: Build Project
+          shell: /bin/bash
+          command: |
+            export PATH=/home/circleci/.foundry/bin:$PATH
+            yarn install:dependencies
             yarn build
       - run:
           name: Publish

--- a/foundry.toml
+++ b/foundry.toml
@@ -11,4 +11,7 @@ ffi = true
 optimizer = true
 optimizer_runs = 100000
 
+[fmt]
+variable_override_spacing=false
+
 # See more config options https://github.com/gakonst/foundry/tree/master/config

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "test:contracts": "forge test --no-match-contract 'Element' --no-match-test 'testRedistribution' && yarn test:pinned",
     "test:clients": "yarn compile:typechain && jest test",
     "test": "yarn test:contracts && yarn test:clients",
-    "formatting": "yarn prettier --write .",
-    "formatting:check": "prettier --check .",
+    "formatting": "forge fmt && yarn prettier --write ./src/client/**/*.ts",
+    "formatting:check": "forge fmt --check && prettier --check ./src/client/**/*.ts",
     "lint": "yarn lint:contracts && yarn lint:clients",
     "lint:contracts": "solhint --config ./.solhint.json --fix \"src/**/*.sol\"",
     "lint:clients": "eslint \"src/**/*.{ts,tsx}\""

--- a/package.json
+++ b/package.json
@@ -5,9 +5,10 @@
   "repository": "git@github.com:AztecProtocol/aztec-connect-bridges.git",
   "license": "Apache-2.0",
   "scripts": {
-    "install:foundry": "curl -L https://foundry.paradigm.xyz | bash",
-    "setup:foundry": "foundryup & git submodule update --init --recursive",
-    "setup": "yarn && yarn install:foundry && yarn setup:foundry",
+    "install:foundryup": "curl -L https://foundry.paradigm.xyz | bash",
+    "install:foundry": "foundryup",
+    "install:dependencies": "git submodule update --init --recursive && yarn",
+    "setup": "yarn install:foundryup && yarn install:foundry && yarn",
     "clean": "rm -rf ./cache ./dest ./out ./typechain-types ./client-dest",
     "compile:typechain": "forge build && typechain --target ethers-v5 --out-dir ./typechain-types './out/!(test*|Test*|*.t.sol|*.s.sol)/*.json'",
     "compile:client-dest": "yarn compile:typechain && tsc --project tsconfig.client-dest.json",
@@ -37,17 +38,15 @@
     "typescript": "^4.8.4"
   },
   "devDependencies": {
-    "@types/jest": "^29.2.0",
-    "@typescript-eslint/eslint-plugin": "^5.40.1",
-    "@typescript-eslint/parser": "^5.40.1",
-    "eslint": "^8.25.0",
+    "@types/jest": "^29.2.3",
+    "@typescript-eslint/eslint-plugin": "^5.43.0",
+    "@typescript-eslint/parser": "^5.43.0",
+    "eslint": "^8.27.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-prettier": "^4.2.1",
-    "jest": "^29.2.1",
+    "jest": "^29.3.1",
     "prettier": "^2.7.1",
-    "prettier-plugin-solidity": "^1.0.0-beta.24",
     "solhint": "https://github.com/LHerskind/solhint",
-    "solhint-plugin-prettier": "^0.0.5",
     "ts-jest": "^29.0.3"
   },
   "jest": {

--- a/src/aztec/DataProvider.sol
+++ b/src/aztec/DataProvider.sol
@@ -75,11 +75,8 @@ contract DataProvider is Ownable {
         address bridgeAddress = ROLLUP_PROCESSOR.getSupportedBridge(_bridgeAddressId);
         bytes32 digest = keccak256(abi.encode(_tag));
         bridges.tagToId[digest] = _bridgeAddressId;
-        bridges.data[_bridgeAddressId] = BridgeData({
-            bridgeAddress: bridgeAddress,
-            bridgeAddressId: _bridgeAddressId,
-            label: _tag
-        });
+        bridges.data[_bridgeAddressId] =
+            BridgeData({bridgeAddress: bridgeAddress, bridgeAddressId: _bridgeAddressId, label: _tag});
     }
 
     /**
@@ -190,15 +187,7 @@ contract DataProvider is Ownable {
      * @return The amount of eth claimed at the current gas prices
      * @return The number of gas units (eth claimed / basefee)
      */
-    function getAccumulatedSubsidyAmount(uint256 _bridgeCallData)
-        public
-        view
-        returns (
-            uint256,
-            uint256,
-            uint256
-        )
-    {
+    function getAccumulatedSubsidyAmount(uint256 _bridgeCallData) public view returns (uint256, uint256, uint256) {
         AccVal memory vars;
 
         vars.bridgeAddressId = _bridgeCallData & MASK_THIRTY_TWO_BITS;
@@ -226,12 +215,7 @@ contract DataProvider is Ownable {
 
         (bool success, bytes memory returnData) = vars.bridgeAddress.staticcall(
             abi.encodeWithSelector(
-                BridgeBase.computeCriteria.selector,
-                inputA,
-                inputB,
-                outputA,
-                outputB,
-                uint64(auxData)
+                BridgeBase.computeCriteria.selector, inputA, inputB, outputA, outputB, uint64(auxData)
             )
         );
 
@@ -247,21 +231,19 @@ contract DataProvider is Ownable {
 
     function _aztecAsset(uint256 _assetId) internal view returns (AztecTypes.AztecAsset memory) {
         if (_assetId >= VIRTUAL_ASSET_ID_FLAG) {
-            return
-                AztecTypes.AztecAsset({
-                    id: _assetId - VIRTUAL_ASSET_ID_FLAG,
-                    erc20Address: address(0),
-                    assetType: AztecTypes.AztecAssetType.VIRTUAL
-                });
+            return AztecTypes.AztecAsset({
+                id: _assetId - VIRTUAL_ASSET_ID_FLAG,
+                erc20Address: address(0),
+                assetType: AztecTypes.AztecAssetType.VIRTUAL
+            });
         }
 
         if (_assetId > 0) {
-            return
-                AztecTypes.AztecAsset({
-                    id: _assetId,
-                    erc20Address: ROLLUP_PROCESSOR.getSupportedAsset(_assetId),
-                    assetType: AztecTypes.AztecAssetType.ERC20
-                });
+            return AztecTypes.AztecAsset({
+                id: _assetId,
+                erc20Address: ROLLUP_PROCESSOR.getSupportedAsset(_assetId),
+                assetType: AztecTypes.AztecAssetType.ERC20
+            });
         }
 
         return AztecTypes.AztecAsset({id: 0, erc20Address: address(0), assetType: AztecTypes.AztecAssetType.ETH});

--- a/src/aztec/Subsidy.sol
+++ b/src/aztec/Subsidy.sol
@@ -60,7 +60,7 @@ contract Subsidy is ISubsidy {
 
     // @dev Using min possible `msg.value` upon subsidizing in order to limit possibility of front running attacks
     // --> e.g. attacker front-running real subsidy tx by sending 1 wei value tx making the real one revert
-    uint256 public constant override(ISubsidy) MIN_SUBSIDY_VALUE = 1e17;
+    uint256 public constant override (ISubsidy) MIN_SUBSIDY_VALUE = 1e17;
 
     // address bridge => uint256 criteria => Subsidy subsidy
     mapping(address => mapping(uint256 => Subsidy)) public subsidies;
@@ -73,7 +73,7 @@ contract Subsidy is ISubsidy {
      * @param _beneficiary The address of the beneficiary to query
      * @return The amount of claimable ETH for `_beneficiary`
      */
-    function claimableAmount(address _beneficiary) external view override(ISubsidy) returns (uint256) {
+    function claimableAmount(address _beneficiary) external view override (ISubsidy) returns (uint256) {
         return beneficiaries[_beneficiary].claimable;
     }
 
@@ -82,7 +82,7 @@ contract Subsidy is ISubsidy {
      * @param _beneficiary The address of the beneficiary to check
      * @return True if the `_beneficiary` is registered, false otherwise
      */
-    function isRegistered(address _beneficiary) external view override(ISubsidy) returns (bool) {
+    function isRegistered(address _beneficiary) external view override (ISubsidy) returns (bool) {
         return beneficiaries[_beneficiary].registered;
     }
 
@@ -92,7 +92,12 @@ contract Subsidy is ISubsidy {
      * @param _criteria The criteria of the subsidy
      * @return The subsidy data object
      */
-    function getSubsidy(address _bridge, uint256 _criteria) external view override(ISubsidy) returns (Subsidy memory) {
+    function getSubsidy(address _bridge, uint256 _criteria)
+        external
+        view
+        override (ISubsidy)
+        returns (Subsidy memory)
+    {
         return subsidies[_bridge][_criteria];
     }
 
@@ -109,13 +114,13 @@ contract Subsidy is ISubsidy {
         uint256[] calldata _criteria,
         uint32[] calldata _gasUsage,
         uint32[] calldata _minGasPerMinute
-    ) external override(ISubsidy) {
+    ) external override (ISubsidy) {
         uint256 criteriasLength = _criteria.length;
         if (criteriasLength != _gasUsage.length || criteriasLength != _minGasPerMinute.length) {
             revert ArrayLengthsDoNotMatch();
         }
 
-        for (uint256 i; i < criteriasLength; ) {
+        for (uint256 i; i < criteriasLength;) {
             setGasUsageAndMinGasPerMinute(_criteria[i], _gasUsage[i], _minGasPerMinute[i]);
             unchecked {
                 ++i;
@@ -132,7 +137,7 @@ contract Subsidy is ISubsidy {
      *      IDefiBridge.convert(...) function to be as predictable as possible. If the cost is too variable users would
      *      overpay since RollupProcessor works with constant gas limits.
      */
-    function registerBeneficiary(address _beneficiary) external override(ISubsidy) {
+    function registerBeneficiary(address _beneficiary) external override (ISubsidy) {
         beneficiaries[_beneficiary].registered = true;
         emit BeneficiaryRegistered(_beneficiary);
     }
@@ -147,11 +152,7 @@ contract Subsidy is ISubsidy {
      *                                       3) subsidy.gasUsage not set: `subsidy.gasUsage` == 0,
      *                                       4) ETH value sent too low: `msg.value` < `MIN_SUBSIDY_VALUE`.
      */
-    function subsidize(
-        address _bridge,
-        uint256 _criteria,
-        uint32 _gasPerMinute
-    ) external payable override(ISubsidy) {
+    function subsidize(address _bridge, uint256 _criteria, uint32 _gasPerMinute) external payable override (ISubsidy) {
         if (msg.value < MIN_SUBSIDY_VALUE) {
             revert SubsidyTooLow();
         }
@@ -184,7 +185,7 @@ contract Subsidy is ISubsidy {
      * @param _criteria A value defining the specific bridge call to subsidize
      * @dev Reverts if `available` is 0.
      */
-    function topUp(address _bridge, uint256 _criteria) external payable override(ISubsidy) {
+    function topUp(address _bridge, uint256 _criteria) external payable override (ISubsidy) {
         // Caching subsidy in order to minimize number of SLOADs and SSTOREs
         Subsidy memory sub = subsidies[_bridge][_criteria];
 
@@ -206,7 +207,7 @@ contract Subsidy is ISubsidy {
      * @param _beneficiary Address which is going to receive the subsidy
      * @return subsidy ETH amount which was added to the `_beneficiary` claimable balance
      */
-    function claimSubsidy(uint256 _criteria, address _beneficiary) external override(ISubsidy) returns (uint256) {
+    function claimSubsidy(uint256 _criteria, address _beneficiary) external override (ISubsidy) returns (uint256) {
         if (_beneficiary == address(0)) {
             return 0;
         }
@@ -249,14 +250,14 @@ contract Subsidy is ISubsidy {
      * @param _beneficiary Address which is going to receive the subsidy
      * @return - ETH amount which was sent to the `_beneficiary`
      */
-    function withdraw(address _beneficiary) external override(ISubsidy) returns (uint256) {
+    function withdraw(address _beneficiary) external override (ISubsidy) returns (uint256) {
         uint256 withdrawableBalance = beneficiaries[_beneficiary].claimable;
         // Immediately updating the balance to avoid re-entrancy attack
         beneficiaries[_beneficiary].claimable = 0;
 
         // Sending 30k gas in a call to allow receiver to be a multi-sig and write to storage
         /* solhint-disable avoid-low-level-calls */
-        (bool success, ) = _beneficiary.call{value: withdrawableBalance, gas: 30000}("");
+        (bool success,) = _beneficiary.call{value: withdrawableBalance, gas: 30000}("");
         if (!success) {
             revert EthTransferFailed();
         }
@@ -281,11 +282,10 @@ contract Subsidy is ISubsidy {
      * @param _gasUsage The gas usage of the subsidized action. Used as upper limit for subsidy.
      * @param _minGasPerMinute Minimum amount of gas per minute that subsidizer has to subsidize
      */
-    function setGasUsageAndMinGasPerMinute(
-        uint256 _criteria,
-        uint32 _gasUsage,
-        uint32 _minGasPerMinute
-    ) public override(ISubsidy) {
+    function setGasUsageAndMinGasPerMinute(uint256 _criteria, uint32 _gasUsage, uint32 _minGasPerMinute)
+        public
+        override (ISubsidy)
+    {
         // Loading `sub` first in order to not overwrite `sub.available` in case this function was already called
         // and a subsidy was set.
         Subsidy memory sub = subsidies[msg.sender][_criteria];

--- a/src/aztec/Subsidy.sol
+++ b/src/aztec/Subsidy.sol
@@ -60,7 +60,7 @@ contract Subsidy is ISubsidy {
 
     // @dev Using min possible `msg.value` upon subsidizing in order to limit possibility of front running attacks
     // --> e.g. attacker front-running real subsidy tx by sending 1 wei value tx making the real one revert
-    uint256 public constant override (ISubsidy) MIN_SUBSIDY_VALUE = 1e17;
+    uint256 public constant override(ISubsidy) MIN_SUBSIDY_VALUE = 1e17;
 
     // address bridge => uint256 criteria => Subsidy subsidy
     mapping(address => mapping(uint256 => Subsidy)) public subsidies;

--- a/src/aztec/interfaces/IDefiBridge.sol
+++ b/src/aztec/interfaces/IDefiBridge.sol
@@ -31,7 +31,8 @@ interface IDefiBridge {
      *      `_interactionNonce` it would simply mean that more of the same virtual asset is minted.
      * @dev If this interaction is async the function has to return `(0,0 true)`. Async interaction will be finalised at
      *      a later time and its output assets will be returned in a `IDefiBridge.finalise(...)` call.
-     **/
+     *
+     */
     function convert(
         AztecTypes.AztecAsset calldata _inputAssetA,
         AztecTypes.AztecAsset calldata _inputAssetB,
@@ -41,14 +42,7 @@ interface IDefiBridge {
         uint256 _interactionNonce,
         uint64 _auxData,
         address _rollupBeneficiary
-    )
-        external
-        payable
-        returns (
-            uint256 outputValueA,
-            uint256 outputValueB,
-            bool isAsync
-        );
+    ) external payable returns (uint256 outputValueA, uint256 outputValueB, bool isAsync);
 
     /**
      * @notice A function that finalises asynchronous interaction.
@@ -62,7 +56,8 @@ interface IDefiBridge {
      * @return outputValueB An amount of `_outputAssetB` returned from this interaction.
      * @dev This function should use the `BridgeBase.onlyRollup()` modifier to ensure it can only be called from
      *      the `RollupProcessor.processAsyncDefiInteraction(uint256 _interactionNonce)` method.
-     **/
+     *
+     */
     function finalise(
         AztecTypes.AztecAsset calldata _inputAssetA,
         AztecTypes.AztecAsset calldata _inputAssetB,
@@ -70,12 +65,5 @@ interface IDefiBridge {
         AztecTypes.AztecAsset calldata _outputAssetB,
         uint256 _interactionNonce,
         uint64 _auxData
-    )
-        external
-        payable
-        returns (
-            uint256 outputValueA,
-            uint256 outputValueB,
-            bool interactionComplete
-        );
+    ) external payable returns (uint256 outputValueA, uint256 outputValueB, bool interactionComplete);
 }

--- a/src/aztec/interfaces/ISubsidy.sol
+++ b/src/aztec/interfaces/ISubsidy.sol
@@ -20,11 +20,7 @@ interface ISubsidy {
         uint32 lastUpdated;
     }
 
-    function setGasUsageAndMinGasPerMinute(
-        uint256 _criteria,
-        uint32 _gasUsage,
-        uint32 _minGasPerMinute
-    ) external;
+    function setGasUsageAndMinGasPerMinute(uint256 _criteria, uint32 _gasUsage, uint32 _minGasPerMinute) external;
 
     function setGasUsageAndMinGasPerMinute(
         uint256[] calldata _criteria,
@@ -34,11 +30,7 @@ interface ISubsidy {
 
     function registerBeneficiary(address _beneficiary) external;
 
-    function subsidize(
-        address _bridge,
-        uint256 _criteria,
-        uint32 _gasPerMinute
-    ) external payable;
+    function subsidize(address _bridge, uint256 _criteria, uint32 _gasPerMinute) external payable;
 
     function topUp(address _bridge, uint256 _criteria) external payable;
 

--- a/src/bridges/angle/AngleSLPBridge.sol
+++ b/src/bridges/angle/AngleSLPBridge.sol
@@ -89,17 +89,7 @@ contract AngleSLPBridge is BridgeBase {
         uint256 _interactionNonce,
         uint64 _auxData,
         address _rollupBeneficiary
-    )
-        external
-        payable
-        override(BridgeBase)
-        onlyRollup
-        returns (
-            uint256 outputValueA,
-            uint256,
-            bool
-        )
-    {
+    ) external payable override (BridgeBase) onlyRollup returns (uint256 outputValueA, uint256, bool) {
         address inputAssetA;
         address outputAssetA;
 
@@ -154,7 +144,7 @@ contract AngleSLPBridge is BridgeBase {
         AztecTypes.AztecAsset calldata,
         AztecTypes.AztecAsset calldata,
         uint64 _auxData
-    ) public pure override(BridgeBase) returns (uint256) {
+    ) public pure override (BridgeBase) returns (uint256) {
         if (_auxData > 1) {
             revert ErrorLib.InvalidAuxData();
         }
@@ -193,13 +183,9 @@ contract AngleSLPBridge is BridgeBase {
      * @param _amount Amount of sanToken to withdraw
      * @param _outputAssetA Address of the underlying ERC20
      */
-    function _withdraw(
-        address _poolManager,
-        uint256 _amount,
-        address _outputAssetA
-    ) internal {
+    function _withdraw(address _poolManager, uint256 _amount, address _outputAssetA) internal {
         // we check if we need to harvest or not
-        (, , , , , uint256 sanRate, , , ) = STABLE_MASTER.collateralMap(_poolManager);
+        (,,,,, uint256 sanRate,,,) = STABLE_MASTER.collateralMap(_poolManager);
         uint256 estimatedOutputValue = (_amount * sanRate) / 1e18;
         uint256 currentBalance = IERC20(_outputAssetA).balanceOf(address(_poolManager));
 
@@ -223,7 +209,7 @@ contract AngleSLPBridge is BridgeBase {
      * @param _poolManager Address of the poolManager
      */
     function _preApprove(address _poolManager) private {
-        (IERC20 token, address sanToken, , , , , , , ) = STABLE_MASTER.collateralMap(_poolManager);
+        (IERC20 token, address sanToken,,,,,,,) = STABLE_MASTER.collateralMap(_poolManager);
 
         uint256 allowance = token.allowance(address(this), ROLLUP_PROCESSOR);
         if (allowance != type(uint256).max) {

--- a/src/bridges/base/BridgeBase.sol
+++ b/src/bridges/base/BridgeBase.sol
@@ -39,17 +39,7 @@ abstract contract BridgeBase is IDefiBridge {
         uint256,
         uint64,
         address
-    )
-        external
-        payable
-        virtual
-        override(IDefiBridge)
-        returns (
-            uint256,
-            uint256,
-            bool
-        )
-    {
+    ) external payable virtual override (IDefiBridge) returns (uint256, uint256, bool) {
         revert MissingImplementation();
     }
 
@@ -60,17 +50,7 @@ abstract contract BridgeBase is IDefiBridge {
         AztecTypes.AztecAsset calldata,
         uint256,
         uint64
-    )
-        external
-        payable
-        virtual
-        override(IDefiBridge)
-        returns (
-            uint256,
-            uint256,
-            bool
-        )
-    {
+    ) external payable virtual override (IDefiBridge) returns (uint256, uint256, bool) {
         revert ErrorLib.AsyncDisabled();
     }
 

--- a/src/bridges/curve/CurveStEthBridge.sol
+++ b/src/bridges/curve/CurveStEthBridge.sol
@@ -71,20 +71,10 @@ contract CurveStEthBridge is BridgeBase {
         uint256 _interactionNonce,
         uint64 _auxData,
         address
-    )
-        external
-        payable
-        override(BridgeBase)
-        onlyRollup
-        returns (
-            uint256 outputValueA,
-            uint256,
-            bool
-        )
-    {
+    ) external payable override (BridgeBase) onlyRollup returns (uint256 outputValueA, uint256, bool) {
         bool isETHInput = _inputAssetA.assetType == AztecTypes.AztecAssetType.ETH;
-        bool isWstETHInput = _inputAssetA.assetType == AztecTypes.AztecAssetType.ERC20 &&
-            _inputAssetA.erc20Address == address(WRAPPED_STETH);
+        bool isWstETHInput = _inputAssetA.assetType == AztecTypes.AztecAssetType.ERC20
+            && _inputAssetA.erc20Address == address(WRAPPED_STETH);
 
         if (!(isETHInput || isWstETHInput)) {
             revert ErrorLib.InvalidInputA();
@@ -103,14 +93,13 @@ contract CurveStEthBridge is BridgeBase {
      * @param _minStEthPerEth Smallest acceptable amount of steth for each eth
      * @return outputValue The amount of wstEth received from the interaction
      */
-    function _wrapETH(
-        uint256 _totalInputValue,
-        AztecTypes.AztecAsset calldata _outputAsset,
-        uint256 _minStEthPerEth
-    ) private returns (uint256 outputValue) {
+    function _wrapETH(uint256 _totalInputValue, AztecTypes.AztecAsset calldata _outputAsset, uint256 _minStEthPerEth)
+        private
+        returns (uint256 outputValue)
+    {
         if (
-            _outputAsset.assetType != AztecTypes.AztecAssetType.ERC20 ||
-            _outputAsset.erc20Address != address(WRAPPED_STETH)
+            _outputAsset.assetType != AztecTypes.AztecAssetType.ERC20
+                || _outputAsset.erc20Address != address(WRAPPED_STETH)
         ) {
             revert ErrorLib.InvalidOutputA();
         }
@@ -118,12 +107,8 @@ contract CurveStEthBridge is BridgeBase {
         uint256 minDy = (_totalInputValue * _minStEthPerEth) / PRECISION;
 
         // Swap eth -> stEth on curve
-        uint256 dy = CURVE_POOL.exchange{value: _totalInputValue}(
-            CURVE_ETH_INDEX,
-            CURVE_STETH_INDEX,
-            _totalInputValue,
-            minDy
-        );
+        uint256 dy =
+            CURVE_POOL.exchange{value: _totalInputValue}(CURVE_ETH_INDEX, CURVE_STETH_INDEX, _totalInputValue, minDy);
 
         // wrap stEth
         outputValue = WRAPPED_STETH.wrap(dy);

--- a/src/bridges/dca/UniswapDCABridge.sol
+++ b/src/bridges/dca/UniswapDCABridge.sol
@@ -36,11 +36,9 @@ contract UniswapDCABridge is BiDCABridge {
 
     IChainlinkOracle public constant ORACLE = IChainlinkOracle(0x773616E4d11A78F511299002da57A0a94577F1f4);
 
-    constructor(
-        address _rollupProcessor,
-        uint256 _tickSize,
-        uint256 _fee
-    ) BiDCABridge(_rollupProcessor, DAI, address(WETH), _tickSize, _fee) {
+    constructor(address _rollupProcessor, uint256 _tickSize, uint256 _fee)
+        BiDCABridge(_rollupProcessor, DAI, address(WETH), _tickSize, _fee)
+    {
         IERC20(DAI).safeApprove(address(UNI_ROUTER), type(uint256).max);
         IERC20(address(WETH)).safeApprove(address(UNI_ROUTER), type(uint256).max);
     }
@@ -82,7 +80,7 @@ contract UniswapDCABridge is BiDCABridge {
             // Rounding DOWN ensures that B received / price >= A available
             uint256 price = (bOffer * 1e18) / a;
 
-            (aFlow, bFlow, , ) = _rebalanceAndFill(0, bOffer, price, _upperTick, true);
+            (aFlow, bFlow,,) = _rebalanceAndFill(0, bOffer, price, _upperTick, true);
         }
 
         if (b > 0) {
@@ -100,7 +98,7 @@ contract UniswapDCABridge is BiDCABridge {
             // Rounding UP to ensure that A received * price >= B available
             uint256 price = (b * 1e18 + aOffer - 1) / aOffer;
 
-            (aFlow, bFlow, , ) = _rebalanceAndFill(aOffer, 0, price, _upperTick, true);
+            (aFlow, bFlow,,) = _rebalanceAndFill(aOffer, 0, price, _upperTick, true);
         }
 
         return (aFlow, bFlow);
@@ -111,8 +109,8 @@ contract UniswapDCABridge is BiDCABridge {
      * @dev Reverts if the price is stale or negative
      * @return Price
      */
-    function getPrice() public virtual override(BiDCABridge) returns (uint256) {
-        (, int256 answer, , , ) = ORACLE.latestRoundData();
+    function getPrice() public virtual override (BiDCABridge) returns (uint256) {
+        (, int256 answer,,,) = ORACLE.latestRoundData();
         if (answer < 0) {
             revert NegativePrice();
         }

--- a/src/bridges/donation/DonationBridge.sol
+++ b/src/bridges/donation/DonationBridge.sol
@@ -57,17 +57,7 @@ contract DonationBridge is BridgeBase {
         uint256,
         uint64 _auxData,
         address
-    )
-        external
-        payable
-        override(BridgeBase)
-        onlyRollup
-        returns (
-            uint256,
-            uint256,
-            bool
-        )
-    {
+    ) external payable override (BridgeBase) onlyRollup returns (uint256, uint256, bool) {
         address receiver = donees[_auxData];
 
         if (receiver == address(0)) {
@@ -76,7 +66,7 @@ contract DonationBridge is BridgeBase {
 
         if (_inputAssetA.assetType == AztecTypes.AztecAssetType.ETH) {
             //solhint-disable-next-line
-            (bool success, ) = payable(receiver).call{gas: 30000, value: _totalInputValue}("");
+            (bool success,) = payable(receiver).call{gas: 30000, value: _totalInputValue}("");
             if (!success) revert EthTransferFailed();
         } else if (_inputAssetA.assetType == AztecTypes.AztecAssetType.ERC20) {
             IERC20(_inputAssetA.erc20Address).safeTransfer(receiver, _totalInputValue);

--- a/src/bridges/element/ElementBridge.sol
+++ b/src/bridges/element/ElementBridge.sol
@@ -199,11 +199,9 @@ contract ElementBridge is BridgeBase {
     /// @param _convergentPool The pool's address
     /// @param _wrappedPosition The element wrapped position contract's address
     /// @param _expiry The expiry of the tranche being configured
-    function registerConvergentPoolAddress(
-        address _convergentPool,
-        address _wrappedPosition,
-        uint64 _expiry
-    ) external {
+    function registerConvergentPoolAddress(address _convergentPool, address _wrappedPosition, uint64 _expiry)
+        external
+    {
         checkAndStorePoolSpecification(_convergentPool, _wrappedPosition, _expiry);
     }
 
@@ -233,11 +231,9 @@ contract ElementBridge is BridgeBase {
     /// @param poolAddress The pool's address
     /// @param wrappedPositionAddress The element wrapped position contract's address
     /// @param expiry The expiry of the tranche being configured
-    function checkAndStorePoolSpecification(
-        address poolAddress,
-        address wrappedPositionAddress,
-        uint64 expiry
-    ) internal {
+    function checkAndStorePoolSpecification(address poolAddress, address wrappedPositionAddress, uint64 expiry)
+        internal
+    {
         PoolSpec memory poolSpec;
         IWrappedPosition wrappedPosition = IWrappedPosition(wrappedPositionAddress);
         // this underlying asset should be the real asset i.e. DAI stablecoin etc
@@ -317,7 +313,7 @@ contract ElementBridge is BridgeBase {
         // retrieve the pool address for the given pool id from balancer
         // then test it against that given to us
         IVault balancerVault = IVault(balancerAddress);
-        (address balancersPoolAddress, ) = balancerVault.getPool(poolSpec.poolId);
+        (address balancersPoolAddress,) = balancerVault.getPool(poolSpec.poolId);
         if (poolAddress != balancersPoolAddress) {
             revert VAULT_ADDRESS_MISMATCH();
         }
@@ -432,13 +428,9 @@ contract ElementBridge is BridgeBase {
     )
         external
         payable
-        override(BridgeBase)
+        override (BridgeBase)
         onlyRollup
-        returns (
-            uint256 outputValueA,
-            uint256 outputValueB,
-            bool isAsync
-        )
+        returns (uint256 outputValueA, uint256 outputValueB, bool isAsync)
     {
         int64 gasAtStart = int64(int256(gasleft()));
         int64 gasUsed = 0;
@@ -484,11 +476,8 @@ contract ElementBridge is BridgeBase {
         }
 
         // execute the swap on balancer
-        uint256 principalTokensAmount = exchangeAssetForTrancheTokens(
-            convertArgs.inputAssetAddress,
-            pool,
-            convertArgs.totalInputValue
-        );
+        uint256 principalTokensAmount =
+            exchangeAssetForTrancheTokens(convertArgs.inputAssetAddress, pool, convertArgs.totalInputValue);
         // store the tranche that underpins our interaction, the expiry and the number of received tokens against the nonce
         Interaction storage newInteraction = interactions[convertArgs.interactionNonce];
         newInteraction.quantityPT = principalTokensAmount;
@@ -517,11 +506,10 @@ contract ElementBridge is BridgeBase {
      * @param inputQuantity the quantity of the input asset we wish to swap
      * @return quantityReceived amount of tokens recieved
      */
-    function exchangeAssetForTrancheTokens(
-        address inputAsset,
-        Pool storage pool,
-        uint256 inputQuantity
-    ) internal returns (uint256 quantityReceived) {
+    function exchangeAssetForTrancheTokens(address inputAsset, Pool storage pool, uint256 inputQuantity)
+        internal
+        returns (uint256 quantityReceived)
+    {
         IVault.SingleSwap memory singleSwap = IVault.SingleSwap({
             poolId: pool.poolId, // the id of the pool we want to use
             kind: IVault.SwapKind.GIVEN_IN, // We are exchanging a given number of input tokens
@@ -614,13 +602,9 @@ contract ElementBridge is BridgeBase {
     )
         external
         payable
-        override(BridgeBase)
+        override (BridgeBase)
         onlyRollup
-        returns (
-            uint256 outputValueA,
-            uint256 outputValueB,
-            bool interactionCompleted
-        )
+        returns (uint256 outputValueA, uint256 outputValueB, bool interactionCompleted)
     {
         int64 gasAtStart = int64(int256(gasleft()));
         int64 gasUsed = 0;
@@ -687,15 +671,12 @@ contract ElementBridge is BridgeBase {
             // apportion the output asset based on the interaction's holding of the principle token
             // protects against phantom overflow in the operation of
             // amountToAllocate = (trancheAccount.quantityAssetRedeemed * interaction.quantityPT) / trancheTokensHeld;
-            amountToAllocate = FullMath.mulDiv(
-                trancheAccount.quantityAssetRedeemed,
-                interaction.quantityPT,
-                trancheTokensHeld
-            );
+            amountToAllocate =
+                FullMath.mulDiv(trancheAccount.quantityAssetRedeemed, interaction.quantityPT, trancheTokensHeld);
         }
         // numDeposits and numFinalised are uint32 types, so easily within range for an int256
-        int256 numRemainingInteractionsForTranche = int256(uint256(numDepositsIntoTranche)) -
-            int256(uint256(trancheAccount.numFinalised));
+        int256 numRemainingInteractionsForTranche =
+            int256(uint256(numDepositsIntoTranche)) - int256(uint256(trancheAccount.numFinalised));
         // the number of remaining interactions should never be less than 1 here, but test for <= 1 to ensure we catch all possibilities
         if (numRemainingInteractionsForTranche <= 1 || amountToAllocate > trancheAccount.quantityAssetRemaining) {
             // if there are no more interactions to finalise after this then allocate all the remaining

--- a/src/bridges/erc4626/ERC4626Bridge.sol
+++ b/src/bridges/erc4626/ERC4626Bridge.sol
@@ -87,17 +87,7 @@ contract ERC4626Bridge is BridgeBase {
         uint256 _interactionNonce,
         uint64 _auxData,
         address _rollupBeneficiary
-    )
-        external
-        payable
-        override(BridgeBase)
-        onlyRollup
-        returns (
-            uint256 outputValueA,
-            uint256,
-            bool
-        )
-    {
+    ) external payable override (BridgeBase) onlyRollup returns (uint256 outputValueA, uint256, bool) {
         address inputToken = _inputAssetA.erc20Address;
         address outputToken = _outputAssetA.erc20Address;
 
@@ -141,7 +131,7 @@ contract ERC4626Bridge is BridgeBase {
         AztecTypes.AztecAsset calldata _outputAssetA,
         AztecTypes.AztecAsset calldata,
         uint64
-    ) public pure override(BridgeBase) returns (uint256) {
+    ) public pure override (BridgeBase) returns (uint256) {
         return _computeCriteria(_inputAssetA.erc20Address, _outputAssetA.erc20Address);
     }
 

--- a/src/bridges/example/ExampleBridge.sol
+++ b/src/bridges/example/ExampleBridge.sol
@@ -59,17 +59,7 @@ contract ExampleBridgeContract is BridgeBase {
         uint256,
         uint64 _auxData,
         address _rollupBeneficiary
-    )
-        external
-        payable
-        override(BridgeBase)
-        onlyRollup
-        returns (
-            uint256 outputValueA,
-            uint256,
-            bool
-        )
-    {
+    ) external payable override (BridgeBase) onlyRollup returns (uint256 outputValueA, uint256, bool) {
         // Check the input asset is ERC20
         if (_inputAssetA.assetType != AztecTypes.AztecAssetType.ERC20) revert ErrorLib.InvalidInputA();
         if (_outputAssetA.erc20Address != _inputAssetA.erc20Address) revert ErrorLib.InvalidOutputA();
@@ -80,8 +70,7 @@ contract ExampleBridgeContract is BridgeBase {
 
         // Pay out subsidy to the rollupBeneficiary
         SUBSIDY.claimSubsidy(
-            computeCriteria(_inputAssetA, _inputAssetB, _outputAssetA, _outputAssetB, _auxData),
-            _rollupBeneficiary
+            computeCriteria(_inputAssetA, _inputAssetB, _outputAssetA, _outputAssetB, _auxData), _rollupBeneficiary
         );
     }
 
@@ -97,7 +86,7 @@ contract ExampleBridgeContract is BridgeBase {
         AztecTypes.AztecAsset calldata _outputAssetA,
         AztecTypes.AztecAsset calldata,
         uint64
-    ) public view override(BridgeBase) returns (uint256) {
+    ) public view override (BridgeBase) returns (uint256) {
         return uint256(keccak256(abi.encodePacked(_inputAssetA.erc20Address, _outputAssetA.erc20Address)));
     }
 }

--- a/src/bridges/lido/LidoBridge.sol
+++ b/src/bridges/lido/LidoBridge.sol
@@ -56,20 +56,10 @@ contract LidoBridge is BridgeBase {
         uint256 _interactionNonce,
         uint64,
         address
-    )
-        external
-        payable
-        override(BridgeBase)
-        onlyRollup
-        returns (
-            uint256 outputValueA,
-            uint256,
-            bool isAsync
-        )
-    {
+    ) external payable override (BridgeBase) onlyRollup returns (uint256 outputValueA, uint256, bool isAsync) {
         bool isETHInput = _inputAssetA.assetType == AztecTypes.AztecAssetType.ETH;
-        bool isWstETHInput = _inputAssetA.assetType == AztecTypes.AztecAssetType.ERC20 &&
-            _inputAssetA.erc20Address == address(WRAPPED_STETH);
+        bool isWstETHInput = _inputAssetA.assetType == AztecTypes.AztecAssetType.ERC20
+            && _inputAssetA.erc20Address == address(WRAPPED_STETH);
 
         if (!(isETHInput || isWstETHInput)) {
             revert ErrorLib.InvalidInputA();
@@ -82,15 +72,15 @@ contract LidoBridge is BridgeBase {
     }
 
     /**
-        Convert ETH -> wstETH
+     * Convert ETH -> wstETH
      */
     function _wrapETH(uint256 _totalInputValue, AztecTypes.AztecAsset calldata _outputAsset)
         private
         returns (uint256 outputValue)
     {
         if (
-            _outputAsset.assetType != AztecTypes.AztecAssetType.ERC20 ||
-            _outputAsset.erc20Address != address(WRAPPED_STETH)
+            _outputAsset.assetType != AztecTypes.AztecAssetType.ERC20
+                || _outputAsset.erc20Address != address(WRAPPED_STETH)
         ) {
             revert ErrorLib.InvalidOutputA();
         }
@@ -113,7 +103,7 @@ contract LidoBridge is BridgeBase {
     }
 
     /**
-        Convert wstETH to ETH
+     * Convert wstETH to ETH
      */
     function _unwrapETH(
         uint256 _totalInputValue,

--- a/src/bridges/liquity/StakingBridge.sol
+++ b/src/bridges/liquity/StakingBridge.sol
@@ -104,17 +104,7 @@ contract StakingBridge is BridgeBase, ERC20("StakingBridge", "SB") {
         uint256,
         uint64 _auxData,
         address
-    )
-        external
-        payable
-        override(BridgeBase)
-        onlyRollup
-        returns (
-            uint256 outputValueA,
-            uint256,
-            bool
-        )
-    {
+    ) external payable override (BridgeBase) onlyRollup returns (uint256 outputValueA, uint256, bool) {
         if (_inputAssetA.erc20Address == LQTY && _outputAssetA.erc20Address == address(this)) {
             // Deposit
             // Stake and claim rewards
@@ -151,7 +141,7 @@ contract StakingBridge is BridgeBase, ERC20("StakingBridge", "SB") {
     /**
      * @dev See {IERC20-totalSupply}.
      */
-    function totalSupply() public view override(ERC20) returns (uint256) {
+    function totalSupply() public view override (ERC20) returns (uint256) {
         return super.totalSupply() - DUST;
     }
 
@@ -165,17 +155,15 @@ contract StakingBridge is BridgeBase, ERC20("StakingBridge", "SB") {
     function _swapRewardsToLQTYAndStake(bool _isUrgentWithdrawalMode) internal {
         uint256 lusdBalance = IERC20(LUSD).balanceOf(address(this));
         if (lusdBalance > MIN_LUSD_SWAP_AMT) {
-            try
-                UNI_ROUTER.exactInput(
-                    ISwapRouter.ExactInputParams({
-                        path: abi.encodePacked(LUSD, uint24(500), USDC, uint24(500), WETH),
-                        recipient: address(this),
-                        deadline: block.timestamp,
-                        amountIn: lusdBalance - DUST,
-                        amountOutMinimum: 0
-                    })
-                )
-            {} catch (bytes memory) {
+            try UNI_ROUTER.exactInput(
+                ISwapRouter.ExactInputParams({
+                    path: abi.encodePacked(LUSD, uint24(500), USDC, uint24(500), WETH),
+                    recipient: address(this),
+                    deadline: block.timestamp,
+                    amountIn: lusdBalance - DUST,
+                    amountOutMinimum: 0
+                })
+            ) {} catch (bytes memory) {
                 if (!_isUrgentWithdrawalMode) {
                     revert SwapFailed();
                 }
@@ -190,20 +178,11 @@ contract StakingBridge is BridgeBase, ERC20("StakingBridge", "SB") {
 
         uint256 wethBalance = IERC20(WETH).balanceOf(address(this));
         if (wethBalance > MIN_ETH_SWAP_AMT) {
-            try
-                UNI_ROUTER.exactInputSingle(
-                    ISwapRouter.ExactInputSingleParams(
-                        WETH,
-                        LQTY,
-                        3000,
-                        address(this),
-                        block.timestamp,
-                        wethBalance - DUST,
-                        0,
-                        0
-                    )
+            try UNI_ROUTER.exactInputSingle(
+                ISwapRouter.ExactInputSingleParams(
+                    WETH, LQTY, 3000, address(this), block.timestamp, wethBalance - DUST, 0, 0
                 )
-            returns (uint256 amountLQTYOut) {
+            ) returns (uint256 amountLQTYOut) {
                 if (amountLQTYOut != 0) {
                     STAKING_CONTRACT.stake(amountLQTYOut);
                 }

--- a/src/bridges/yearn/YearnBridge.sol
+++ b/src/bridges/yearn/YearnBridge.sol
@@ -56,7 +56,7 @@ contract YearnBridge is BridgeBase {
      */
     function preApproveAll() external {
         uint256 numTokens = YEARN_REGISTRY.numTokens();
-        for (uint256 i; i < numTokens; ) {
+        for (uint256 i; i < numTokens;) {
             address token = YEARN_REGISTRY.tokens(i);
             address vault = YEARN_REGISTRY.latestVault(token);
             _preApprove(vault, token);
@@ -75,7 +75,7 @@ contract YearnBridge is BridgeBase {
     function preApprove(address _vault) external {
         address token = IYearnVault(_vault).token();
         uint256 numVaultsForToken = YEARN_REGISTRY.numVaults(token);
-        for (uint256 i; i < numVaultsForToken; ) {
+        for (uint256 i; i < numVaultsForToken;) {
             address vault = YEARN_REGISTRY.vaults(token, i);
             if (vault == _vault) {
                 _preApprove(vault, token);
@@ -109,17 +109,7 @@ contract YearnBridge is BridgeBase {
         uint256 _interactionNonce,
         uint64 _auxData,
         address _rollupBeneficiary
-    )
-        external
-        payable
-        override(BridgeBase)
-        onlyRollup
-        returns (
-            uint256 outputValueA,
-            uint256,
-            bool
-        )
-    {
+    ) external payable override (BridgeBase) onlyRollup returns (uint256 outputValueA, uint256, bool) {
         if (_auxData == 0) {
             if (_outputAssetA.assetType != AztecTypes.AztecAssetType.ERC20) {
                 revert ErrorLib.InvalidOutputA();
@@ -169,11 +159,10 @@ contract YearnBridge is BridgeBase {
      * @param _inputValue - Amount of shares to withdraw
      * @param _interactionNonce - Aztec nonce of the interaction
      */
-    function _unzapETH(
-        uint256 _inputValue,
-        uint256 _interactionNonce,
-        AztecTypes.AztecAsset memory _inputAssetA
-    ) private returns (uint256 outputValue) {
+    function _unzapETH(uint256 _inputValue, uint256 _interactionNonce, AztecTypes.AztecAsset memory _inputAssetA)
+        private
+        returns (uint256 outputValue)
+    {
         IYearnVault yVault = IYearnVault(_inputAssetA.erc20Address);
         if (yVault.token() != WETH) {
             revert ErrorLib.InvalidInputA();
@@ -203,7 +192,7 @@ contract YearnBridge is BridgeBase {
         AztecTypes.AztecAsset calldata,
         AztecTypes.AztecAsset calldata,
         uint64 _auxData
-    ) public pure override(BridgeBase) returns (uint256) {
+    ) public pure override (BridgeBase) returns (uint256) {
         if (_auxData > 1) {
             revert ErrorLib.InvalidAuxData();
         }

--- a/src/deployment/AggregateDeployment.s.sol
+++ b/src/deployment/AggregateDeployment.s.sol
@@ -219,7 +219,7 @@ contract AggregateDeployment is BaseDeployment {
             emit log_named_string(
                 string(abi.encodePacked("  Asset ", Strings.toString(i))),
                 string(abi.encodePacked(symbol, ", ", Strings.toString(gas)))
-            );
+                );
         }
 
         uint256 bridgeCount = bridgesLength();
@@ -230,7 +230,7 @@ contract AggregateDeployment is BaseDeployment {
             emit log_named_string(
                 string(abi.encodePacked("  Bridge ", Strings.toString(i))),
                 string(abi.encodePacked(Strings.toHexString(bridge), ", ", Strings.toString(gas)))
-            );
+                );
         }
     }
 }

--- a/src/deployment/base/BaseDeployment.s.sol
+++ b/src/deployment/base/BaseDeployment.s.sol
@@ -11,6 +11,7 @@ abstract contract BaseDeployment is Test {
     /**
      * @notice Enum used as part of the configuration, defines what network and addresses to use.
      */
+
     enum Network {
         INVALID,
         MAINNET,

--- a/src/deployment/dataprovider/DataProviderDeployment.s.sol
+++ b/src/deployment/dataprovider/DataProviderDeployment.s.sol
@@ -61,7 +61,7 @@ contract DataProviderDeployment is BaseDeployment {
                             " gas)"
                         )
                     )
-                );
+                    );
             }
         }
         emit log(" - Bridges");
@@ -84,7 +84,7 @@ contract DataProviderDeployment is BaseDeployment {
                             " gas)"
                         )
                     )
-                );
+                    );
             }
         }
     }
@@ -141,21 +141,13 @@ contract DataProviderDeployment is BaseDeployment {
         readProvider(_provider);
     }
 
-    function _listBridge(
-        address _provider,
-        uint256 _bridgeAddressId,
-        string memory _tag
-    ) internal {
+    function _listBridge(address _provider, uint256 _bridgeAddressId, string memory _tag) internal {
         vm.broadcast();
         DataProvider(_provider).addBridge(_bridgeAddressId, _tag);
         emit log_named_uint(string(abi.encodePacked("[Bridge] Listed ", _tag, " at")), _bridgeAddressId);
     }
 
-    function _listAsset(
-        address _provider,
-        uint256 _assetId,
-        string memory _tag
-    ) internal {
+    function _listAsset(address _provider, uint256 _assetId, string memory _tag) internal {
         vm.broadcast();
         DataProvider(_provider).addAsset(_assetId, _tag);
         emit log_named_uint(string(abi.encodePacked("[Asset]  Listed ", _tag, " at")), _assetId);

--- a/src/deployment/liquity/LiquityTroveDeployment.s.sol
+++ b/src/deployment/liquity/LiquityTroveDeployment.s.sol
@@ -53,7 +53,7 @@ contract LiquityTroveDeployment is BaseDeployment {
         // The following is Solidity implementation of https://github.com/liquity/dev#opening-a-trove
         uint256 numTrials = 15;
         uint256 randomSeed = 42;
-        (address approxHint, , ) = HINT_HELPERS.getApproxHint(nicr, numTrials, randomSeed);
+        (address approxHint,,) = HINT_HELPERS.getApproxHint(nicr, numTrials, randomSeed);
         (address upperHint, address lowerHint) = SORTED_TROVES.findInsertPosition(nicr, approxHint, approxHint);
 
         // Open the trove

--- a/src/gas/angle/AngleSLPGas.s.sol
+++ b/src/gas/angle/AngleSLPGas.s.sol
@@ -28,7 +28,7 @@ contract AngleMeasure is AngleSLPDeployment {
     AztecTypes.AztecAsset internal wethAsset;
     AztecTypes.AztecAsset internal sanWethAsset;
 
-    function setUp() public override(BaseDeployment) {
+    function setUp() public override (BaseDeployment) {
         super.setUp();
 
         address defiProxy = IRead(ROLLUP_PROCESSOR).defiBridgeProxy();
@@ -45,16 +45,10 @@ contract AngleMeasure is AngleSLPDeployment {
         weth = bridge.WETH();
 
         ethAsset = AztecTypes.AztecAsset({id: 0, erc20Address: address(0), assetType: AztecTypes.AztecAssetType.ETH});
-        wethAsset = AztecTypes.AztecAsset({
-            id: 1,
-            erc20Address: address(weth),
-            assetType: AztecTypes.AztecAssetType.ERC20
-        });
-        sanWethAsset = AztecTypes.AztecAsset({
-            id: 1,
-            erc20Address: bridge.SANWETH(),
-            assetType: AztecTypes.AztecAssetType.ERC20
-        });
+        wethAsset =
+            AztecTypes.AztecAsset({id: 1, erc20Address: address(weth), assetType: AztecTypes.AztecAssetType.ERC20});
+        sanWethAsset =
+            AztecTypes.AztecAsset({id: 1, erc20Address: bridge.SANWETH(), assetType: AztecTypes.AztecAssetType.ERC20});
 
         // Fund subsidy
         vm.startBroadcast();
@@ -76,16 +70,7 @@ contract AngleMeasure is AngleSLPDeployment {
         {
             vm.broadcast();
             gasBase.convert(
-                address(bridge),
-                ethAsset,
-                emptyAsset,
-                sanWethAsset,
-                emptyAsset,
-                1 ether,
-                0,
-                0,
-                BENEFICIARY,
-                200000
+                address(bridge), ethAsset, emptyAsset, sanWethAsset, emptyAsset, 1 ether, 0, 0, BENEFICIARY, 200000
             );
         }
 
@@ -114,16 +99,13 @@ contract AngleMeasure is AngleSLPDeployment {
                 210000
             );
             emit log_named_uint(
-                "sanWeth balance of gasBase",
-                IERC20(sanWethAsset.erc20Address).balanceOf(address(gasBase))
-            );
+                "sanWeth balance of gasBase", IERC20(sanWethAsset.erc20Address).balanceOf(address(gasBase))
+                );
         }
 
         uint256 claimableSubsidyAfterWithdrawal = SUBSIDY.claimableAmount(BENEFICIARY);
         assertGt(
-            claimableSubsidyAfterWithdrawal,
-            claimableSubsidyAfterDeposit,
-            "Subsidy was not claimed during withdrawal"
+            claimableSubsidyAfterWithdrawal, claimableSubsidyAfterDeposit, "Subsidy was not claimed during withdrawal"
         );
         emit log_named_uint("Claimable subsidy after withdrawal", claimableSubsidyAfterWithdrawal);
     }
@@ -139,16 +121,7 @@ contract AngleMeasure is AngleSLPDeployment {
         {
             vm.broadcast();
             gasBase.convert(
-                address(bridge),
-                wethAsset,
-                emptyAsset,
-                sanWethAsset,
-                emptyAsset,
-                1 ether,
-                0,
-                0,
-                BENEFICIARY,
-                170000
+                address(bridge), wethAsset, emptyAsset, sanWethAsset, emptyAsset, 1 ether, 0, 0, BENEFICIARY, 170000
             );
         }
 
@@ -177,16 +150,13 @@ contract AngleMeasure is AngleSLPDeployment {
                 180000
             );
             emit log_named_uint(
-                "sanWeth balance of gasBase",
-                IERC20(sanWethAsset.erc20Address).balanceOf(address(gasBase))
-            );
+                "sanWeth balance of gasBase", IERC20(sanWethAsset.erc20Address).balanceOf(address(gasBase))
+                );
         }
 
         uint256 claimableSubsidyAfterWithdrawal = SUBSIDY.claimableAmount(BENEFICIARY);
         assertGt(
-            claimableSubsidyAfterWithdrawal,
-            claimableSubsidyAfterDeposit,
-            "Subsidy was not claimed during withdrawal"
+            claimableSubsidyAfterWithdrawal, claimableSubsidyAfterDeposit, "Subsidy was not claimed during withdrawal"
         );
         emit log_named_uint("Claimable subsidy after withdrawal", claimableSubsidyAfterWithdrawal);
     }

--- a/src/gas/curve/CurveGas.s.sol
+++ b/src/gas/curve/CurveGas.s.sol
@@ -31,16 +31,10 @@ contract CurveMeasure is CurveDeployment {
         ROLLUP_PROCESSOR = temp;
 
         AztecTypes.AztecAsset memory empty;
-        AztecTypes.AztecAsset memory eth = AztecTypes.AztecAsset({
-            id: 0,
-            erc20Address: address(0),
-            assetType: AztecTypes.AztecAssetType.ETH
-        });
-        AztecTypes.AztecAsset memory wstEthAsset = AztecTypes.AztecAsset({
-            id: 1,
-            erc20Address: wstEth,
-            assetType: AztecTypes.AztecAssetType.ERC20
-        });
+        AztecTypes.AztecAsset memory eth =
+            AztecTypes.AztecAsset({id: 0, erc20Address: address(0), assetType: AztecTypes.AztecAssetType.ETH});
+        AztecTypes.AztecAsset memory wstEthAsset =
+            AztecTypes.AztecAsset({id: 1, erc20Address: wstEth, assetType: AztecTypes.AztecAssetType.ERC20});
 
         vm.broadcast();
         address(gasBase).call{value: 2 ether}("");

--- a/src/gas/curve/CurveLpGas.s.sol
+++ b/src/gas/curve/CurveLpGas.s.sol
@@ -31,21 +31,12 @@ contract CurveLpMeasure is CurveStethLpDeployment {
         ROLLUP_PROCESSOR = temp;
 
         AztecTypes.AztecAsset memory empty;
-        AztecTypes.AztecAsset memory eth = AztecTypes.AztecAsset({
-            id: 0,
-            erc20Address: address(0),
-            assetType: AztecTypes.AztecAssetType.ETH
-        });
-        AztecTypes.AztecAsset memory wstEth = AztecTypes.AztecAsset({
-            id: 0,
-            erc20Address: address(WSTETH),
-            assetType: AztecTypes.AztecAssetType.ERC20
-        });
-        AztecTypes.AztecAsset memory lpAsset = AztecTypes.AztecAsset({
-            id: 1,
-            erc20Address: lpToken,
-            assetType: AztecTypes.AztecAssetType.ERC20
-        });
+        AztecTypes.AztecAsset memory eth =
+            AztecTypes.AztecAsset({id: 0, erc20Address: address(0), assetType: AztecTypes.AztecAssetType.ETH});
+        AztecTypes.AztecAsset memory wstEth =
+            AztecTypes.AztecAsset({id: 0, erc20Address: address(WSTETH), assetType: AztecTypes.AztecAssetType.ERC20});
+        AztecTypes.AztecAsset memory lpAsset =
+            AztecTypes.AztecAsset({id: 1, erc20Address: lpToken, assetType: AztecTypes.AztecAssetType.ERC20});
 
         // Fund with WSTETH
         vm.startBroadcast();

--- a/src/gas/dca/DCAGas.s.sol
+++ b/src/gas/dca/DCAGas.s.sol
@@ -31,11 +31,8 @@ contract DCAMeasure is DCADeployment {
         ROLLUP_PROCESSOR = temp;
 
         AztecTypes.AztecAsset memory empty;
-        AztecTypes.AztecAsset memory eth = AztecTypes.AztecAsset({
-            id: 0,
-            erc20Address: address(0),
-            assetType: AztecTypes.AztecAssetType.ETH
-        });
+        AztecTypes.AztecAsset memory eth =
+            AztecTypes.AztecAsset({id: 0, erc20Address: address(0), assetType: AztecTypes.AztecAssetType.ETH});
         AztecTypes.AztecAsset memory daiAsset = AztecTypes.AztecAsset({
             id: 1,
             erc20Address: 0x6B175474E89094C44Da98b954EedeAC495271d0F,

--- a/src/gas/erc4626/ERC4626Gas.s.sol
+++ b/src/gas/erc4626/ERC4626Gas.s.sol
@@ -32,7 +32,7 @@ contract ERC4626Measure is ERC4626Deployment {
     AztecTypes.AztecAsset internal wstethAsset;
     AztecTypes.AztecAsset internal wewstethAsset; // ERC4626-Wrapped Euler wstETH (wewstETH)
 
-    function setUp() public override(BaseDeployment) {
+    function setUp() public override (BaseDeployment) {
         super.setUp();
 
         address defiProxy = IRead(ROLLUP_PROCESSOR).defiBridgeProxy();
@@ -47,22 +47,16 @@ contract ERC4626Measure is ERC4626Deployment {
         ROLLUP_PROCESSOR = temp;
 
         ethAsset = AztecTypes.AztecAsset({id: 0, erc20Address: address(0), assetType: AztecTypes.AztecAssetType.ETH});
-        wethAsset = AztecTypes.AztecAsset({
-            id: 1,
-            erc20Address: address(WETH),
-            assetType: AztecTypes.AztecAssetType.ERC20
-        });
+        wethAsset =
+            AztecTypes.AztecAsset({id: 1, erc20Address: address(WETH), assetType: AztecTypes.AztecAssetType.ERC20});
         wewethAsset = AztecTypes.AztecAsset({
             id: 3,
             erc20Address: 0x3c66B18F67CA6C1A71F829E2F6a0c987f97462d0,
             assetType: AztecTypes.AztecAssetType.ERC20
         });
 
-        wstethAsset = AztecTypes.AztecAsset({
-            id: 4,
-            erc20Address: address(WSTETH),
-            assetType: AztecTypes.AztecAssetType.ERC20
-        });
+        wstethAsset =
+            AztecTypes.AztecAsset({id: 4, erc20Address: address(WSTETH), assetType: AztecTypes.AztecAssetType.ERC20});
         wewstethAsset = AztecTypes.AztecAsset({
             id: 5,
             erc20Address: 0x60897720AA966452e8706e74296B018990aEc527,
@@ -74,24 +68,16 @@ contract ERC4626Measure is ERC4626Deployment {
         bridge.listVault(wewethAsset.erc20Address);
         bridge.listVault(wewstethAsset.erc20Address);
         SUBSIDY.subsidize{value: 1e17}(
-            address(bridge),
-            bridge.computeCriteria(wethAsset, emptyAsset, wewethAsset, emptyAsset, 0),
-            500
+            address(bridge), bridge.computeCriteria(wethAsset, emptyAsset, wewethAsset, emptyAsset, 0), 500
         );
         SUBSIDY.subsidize{value: 1e17}(
-            address(bridge),
-            bridge.computeCriteria(wewethAsset, emptyAsset, wethAsset, emptyAsset, 0),
-            500
+            address(bridge), bridge.computeCriteria(wewethAsset, emptyAsset, wethAsset, emptyAsset, 0), 500
         );
         SUBSIDY.subsidize{value: 1e17}(
-            address(bridge),
-            bridge.computeCriteria(wstethAsset, emptyAsset, wewstethAsset, emptyAsset, 0),
-            500
+            address(bridge), bridge.computeCriteria(wstethAsset, emptyAsset, wewstethAsset, emptyAsset, 0), 500
         );
         SUBSIDY.subsidize{value: 1e17}(
-            address(bridge),
-            bridge.computeCriteria(wewstethAsset, emptyAsset, wstethAsset, emptyAsset, 0),
-            500
+            address(bridge), bridge.computeCriteria(wewstethAsset, emptyAsset, wstethAsset, emptyAsset, 0), 500
         );
         SUBSIDY.registerBeneficiary(BENEFICIARY);
         vm.stopBroadcast();
@@ -109,16 +95,7 @@ contract ERC4626Measure is ERC4626Deployment {
         {
             vm.broadcast();
             gasBase.convert(
-                address(bridge),
-                ethAsset,
-                emptyAsset,
-                wewethAsset,
-                emptyAsset,
-                1 ether,
-                0,
-                0,
-                BENEFICIARY,
-                280000
+                address(bridge), ethAsset, emptyAsset, wewethAsset, emptyAsset, 1 ether, 0, 0, BENEFICIARY, 280000
             );
         }
 
@@ -147,16 +124,13 @@ contract ERC4626Measure is ERC4626Deployment {
                 260000
             );
             emit log_named_uint(
-                "weweth balance of gasBase",
-                IERC20(wewethAsset.erc20Address).balanceOf(address(gasBase))
-            );
+                "weweth balance of gasBase", IERC20(wewethAsset.erc20Address).balanceOf(address(gasBase))
+                );
         }
 
         uint256 claimableSubsidyAfterWithdrawal = SUBSIDY.claimableAmount(BENEFICIARY);
         assertGt(
-            claimableSubsidyAfterWithdrawal,
-            claimableSubsidyAfterDeposit,
-            "Subsidy was not claimed during withdrawal"
+            claimableSubsidyAfterWithdrawal, claimableSubsidyAfterDeposit, "Subsidy was not claimed during withdrawal"
         );
         emit log_named_uint("Claimable subsidy after withdrawal", claimableSubsidyAfterWithdrawal);
     }
@@ -172,16 +146,7 @@ contract ERC4626Measure is ERC4626Deployment {
         {
             vm.broadcast();
             gasBase.convert(
-                address(bridge),
-                wethAsset,
-                emptyAsset,
-                wewethAsset,
-                emptyAsset,
-                1 ether,
-                0,
-                0,
-                BENEFICIARY,
-                260000
+                address(bridge), wethAsset, emptyAsset, wewethAsset, emptyAsset, 1 ether, 0, 0, BENEFICIARY, 260000
             );
         }
 
@@ -210,16 +175,13 @@ contract ERC4626Measure is ERC4626Deployment {
                 220000
             );
             emit log_named_uint(
-                "weweth balance of gasBase",
-                IERC20(wewethAsset.erc20Address).balanceOf(address(gasBase))
-            );
+                "weweth balance of gasBase", IERC20(wewethAsset.erc20Address).balanceOf(address(gasBase))
+                );
         }
 
         uint256 claimableSubsidyAfterWithdrawal = SUBSIDY.claimableAmount(BENEFICIARY);
         assertGt(
-            claimableSubsidyAfterWithdrawal,
-            claimableSubsidyAfterDeposit,
-            "Subsidy was not claimed during withdrawal"
+            claimableSubsidyAfterWithdrawal, claimableSubsidyAfterDeposit, "Subsidy was not claimed during withdrawal"
         );
         emit log_named_uint("Claimable subsidy after withdrawal", claimableSubsidyAfterWithdrawal);
     }
@@ -273,16 +235,13 @@ contract ERC4626Measure is ERC4626Deployment {
                 240000
             );
             emit log_named_uint(
-                "wewstethBalance balance of gasBase",
-                IERC20(wewstethAsset.erc20Address).balanceOf(address(gasBase))
-            );
+                "wewstethBalance balance of gasBase", IERC20(wewstethAsset.erc20Address).balanceOf(address(gasBase))
+                );
         }
 
         uint256 claimableSubsidyAfterWithdrawal = SUBSIDY.claimableAmount(BENEFICIARY);
         assertGt(
-            claimableSubsidyAfterWithdrawal,
-            claimableSubsidyAfterDeposit,
-            "Subsidy was not claimed during withdrawal"
+            claimableSubsidyAfterWithdrawal, claimableSubsidyAfterDeposit, "Subsidy was not claimed during withdrawal"
         );
         emit log_named_uint("Claimable subsidy after withdrawal", claimableSubsidyAfterWithdrawal);
     }

--- a/src/gas/liquity/TroveBridgeGas.s.sol
+++ b/src/gas/liquity/TroveBridgeGas.s.sol
@@ -26,7 +26,7 @@ contract TroveBridgeMeasure is LiquityTroveDeployment {
     AztecTypes.AztecAsset internal lusdAsset;
     AztecTypes.AztecAsset internal tbAsset; // Accounting token
 
-    function setUp() public override(BaseDeployment) {
+    function setUp() public override (BaseDeployment) {
         super.setUp();
 
         address defiProxy = IRead(ROLLUP_PROCESSOR).defiBridgeProxy();
@@ -46,11 +46,8 @@ contract TroveBridgeMeasure is LiquityTroveDeployment {
             erc20Address: 0x5f98805A4E8be255a32880FDeC7F6728C6568bA0,
             assetType: AztecTypes.AztecAssetType.ERC20
         });
-        tbAsset = AztecTypes.AztecAsset({
-            id: 2,
-            erc20Address: address(bridge),
-            assetType: AztecTypes.AztecAssetType.ERC20
-        });
+        tbAsset =
+            AztecTypes.AztecAsset({id: 2, erc20Address: address(bridge), assetType: AztecTypes.AztecAssetType.ERC20});
 
         vm.label(lusdAsset.erc20Address, "LUSD");
         vm.label(tbAsset.erc20Address, "TB");
@@ -77,16 +74,7 @@ contract TroveBridgeMeasure is LiquityTroveDeployment {
         {
             vm.broadcast();
             gasBase.convert(
-                address(bridge),
-                ethAsset,
-                emptyAsset,
-                tbAsset,
-                lusdAsset,
-                1 ether,
-                0,
-                MAX_FEE,
-                BENEFICIARY,
-                520000
+                address(bridge), ethAsset, emptyAsset, tbAsset, lusdAsset, 1 ether, 0, MAX_FEE, BENEFICIARY, 520000
             );
         }
 
@@ -104,24 +92,13 @@ contract TroveBridgeMeasure is LiquityTroveDeployment {
 
             vm.broadcast();
             gasBase.convert(
-                address(bridge),
-                tbAsset,
-                lusdAsset,
-                ethAsset,
-                lusdAsset,
-                lusdBalance / 2,
-                0,
-                0,
-                BENEFICIARY,
-                410000
+                address(bridge), tbAsset, lusdAsset, ethAsset, lusdAsset, lusdBalance / 2, 0, 0, BENEFICIARY, 410000
             );
         }
 
         uint256 claimableSubsidyAfterRepayment = SUBSIDY.claimableAmount(BENEFICIARY);
         assertGt(
-            claimableSubsidyAfterRepayment,
-            claimableSubsidyAfterDeposit,
-            "Subsidy was not claimed during repayment"
+            claimableSubsidyAfterRepayment, claimableSubsidyAfterDeposit, "Subsidy was not claimed during repayment"
         );
         emit log_named_uint("Claimable subsidy after repayment", claimableSubsidyAfterRepayment);
     }

--- a/src/gas/yearn/YearnGas.s.sol
+++ b/src/gas/yearn/YearnGas.s.sol
@@ -33,11 +33,8 @@ contract YearnMeasure is YearnDeployment {
         ROLLUP_PROCESSOR = temp;
 
         AztecTypes.AztecAsset memory empty;
-        AztecTypes.AztecAsset memory eth = AztecTypes.AztecAsset({
-            id: 0,
-            erc20Address: address(0),
-            assetType: AztecTypes.AztecAssetType.ETH
-        });
+        AztecTypes.AztecAsset memory eth =
+            AztecTypes.AztecAsset({id: 0, erc20Address: address(0), assetType: AztecTypes.AztecAssetType.ETH});
         AztecTypes.AztecAsset memory vyAsset = AztecTypes.AztecAsset({
             id: 1,
             erc20Address: YEARN_REGISTRY.latestVault(WETH),
@@ -79,11 +76,8 @@ contract YearnMeasure is YearnDeployment {
         subsidy = ISubsidy(YearnBridge(payable(bridge)).SUBSIDY());
 
         AztecTypes.AztecAsset memory empty;
-        AztecTypes.AztecAsset memory eth = AztecTypes.AztecAsset({
-            id: 0,
-            erc20Address: address(0),
-            assetType: AztecTypes.AztecAssetType.ETH
-        });
+        AztecTypes.AztecAsset memory eth =
+            AztecTypes.AztecAsset({id: 0, erc20Address: address(0), assetType: AztecTypes.AztecAssetType.ETH});
         AztecTypes.AztecAsset memory vyAsset = AztecTypes.AztecAsset({
             id: 1,
             erc20Address: YEARN_REGISTRY.latestVault(WETH),
@@ -143,11 +137,8 @@ contract YearnMeasure is YearnDeployment {
         ROLLUP_PROCESSOR = temp;
 
         AztecTypes.AztecAsset memory empty;
-        AztecTypes.AztecAsset memory wethAsset = AztecTypes.AztecAsset({
-            id: 0,
-            erc20Address: address(WETH),
-            assetType: AztecTypes.AztecAssetType.ERC20
-        });
+        AztecTypes.AztecAsset memory wethAsset =
+            AztecTypes.AztecAsset({id: 0, erc20Address: address(WETH), assetType: AztecTypes.AztecAssetType.ERC20});
         AztecTypes.AztecAsset memory vyAsset = AztecTypes.AztecAsset({
             id: 1,
             erc20Address: YEARN_REGISTRY.latestVault(WETH),

--- a/src/interfaces/angle/IStableMaster.sol
+++ b/src/interfaces/angle/IStableMaster.sol
@@ -27,18 +27,9 @@ interface IStableMaster {
         uint64 interestsForSLPs;
     }
 
-    function deposit(
-        uint256 amount,
-        address user,
-        address poolManager
-    ) external;
+    function deposit(uint256 amount, address user, address poolManager) external;
 
-    function withdraw(
-        uint256 amount,
-        address burner,
-        address dest,
-        address poolManager
-    ) external;
+    function withdraw(uint256 amount, address burner, address dest, address poolManager) external;
 
     function agToken() external returns (address);
 

--- a/src/interfaces/chainlink/IChainlinkOracle.sol
+++ b/src/interfaces/chainlink/IChainlinkOracle.sol
@@ -3,14 +3,5 @@
 pragma solidity >=0.8.4;
 
 interface IChainlinkOracle {
-    function latestRoundData()
-        external
-        view
-        returns (
-            uint80,
-            int256,
-            uint256,
-            uint256,
-            uint80
-        );
+    function latestRoundData() external view returns (uint80, int256, uint256, uint256, uint80);
 }

--- a/src/interfaces/curve/ICurvePool.sol
+++ b/src/interfaces/curve/ICurvePool.sol
@@ -4,16 +4,7 @@ pragma solidity >=0.8.4;
 interface ICurvePool {
     function coins(uint256) external view returns (address);
 
-    function get_dy(
-        int128 i,
-        int128 j,
-        uint256 dx
-    ) external view returns (uint256);
+    function get_dy(int128 i, int128 j, uint256 dx) external view returns (uint256);
 
-    function exchange(
-        int128 i,
-        int128 j,
-        uint256 dx,
-        uint256 min_dy
-    ) external payable returns (uint256);
+    function exchange(int128 i, int128 j, uint256 dx, uint256 min_dy) external payable returns (uint256);
 }

--- a/src/interfaces/element/IVault.sol
+++ b/src/interfaces/element/IVault.sol
@@ -4,7 +4,7 @@ pragma solidity >=0.8.4;
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 interface IAsset {
-    // solhint-disable-previous-line no-empty-blocks
+// solhint-disable-previous-line no-empty-blocks
 }
 
 enum PoolSpecialization {
@@ -32,12 +32,10 @@ interface IVault {
      *
      * Emits a `Swap` event.
      */
-    function swap(
-        SingleSwap memory singleSwap,
-        FundManagement memory funds,
-        uint256 limit,
-        uint256 deadline
-    ) external payable returns (uint256);
+    function swap(SingleSwap memory singleSwap, FundManagement memory funds, uint256 limit, uint256 deadline)
+        external
+        payable
+        returns (uint256);
 
     /**
      * @dev Data for a single swap executed by `swap`. `amount` is either `amountIn` or `amountOut` depending on
@@ -133,9 +131,5 @@ interface IVault {
     function getPoolTokens(bytes32 poolId)
         external
         view
-        returns (
-            IERC20[] memory tokens,
-            uint256[] memory balances,
-            uint256 lastChangeBlock
-        );
+        returns (IERC20[] memory tokens, uint256[] memory balances, uint256 lastChangeBlock);
 }

--- a/src/interfaces/element/IWrappedPosition.sol
+++ b/src/interfaces/element/IWrappedPosition.sol
@@ -15,23 +15,11 @@ interface IWrappedPosition is IERC20, IERC20Permit {
 
     function deposit(address sender, uint256 amount) external returns (uint256);
 
-    function withdraw(
-        address sender,
-        uint256 _shares,
-        uint256 _minUnderlying
-    ) external returns (uint256);
+    function withdraw(address sender, uint256 _shares, uint256 _minUnderlying) external returns (uint256);
 
-    function withdrawUnderlying(
-        address _destination,
-        uint256 _amount,
-        uint256 _minUnderlying
-    ) external returns (uint256, uint256);
-
-    function prefundedDeposit(address _destination)
+    function withdrawUnderlying(address _destination, uint256 _amount, uint256 _minUnderlying)
         external
-        returns (
-            uint256,
-            uint256,
-            uint256
-        );
+        returns (uint256, uint256);
+
+    function prefundedDeposit(address _destination) external returns (uint256, uint256, uint256);
 }

--- a/src/interfaces/lido/ILidoOracle.sol
+++ b/src/interfaces/lido/ILidoOracle.sol
@@ -5,9 +5,5 @@ interface ILidoOracle {
     function getLastCompletedReportDelta()
         external
         view
-        returns (
-            uint256 postTotalPooledEther,
-            uint256 preTotalPooledEther,
-            uint256 timeElapsed
-        );
+        returns (uint256 postTotalPooledEther, uint256 preTotalPooledEther, uint256 timeElapsed);
 }

--- a/src/interfaces/liquity/IBorrowerOperations.sol
+++ b/src/interfaces/liquity/IBorrowerOperations.sol
@@ -2,12 +2,7 @@
 pragma solidity >=0.8.4;
 
 interface IBorrowerOperations {
-    function openTrove(
-        uint256 _maxFee,
-        uint256 _LUSDAmount,
-        address _upperHint,
-        address _lowerHint
-    ) external payable;
+    function openTrove(uint256 _maxFee, uint256 _LUSDAmount, address _upperHint, address _lowerHint) external payable;
 
     function closeTrove() external;
 
@@ -20,11 +15,7 @@ interface IBorrowerOperations {
         address _lowerHint
     ) external payable;
 
-    function withdrawColl(
-        uint256 _amount,
-        address _upperHint,
-        address _lowerHint
-    ) external;
+    function withdrawColl(uint256 _amount, address _upperHint, address _lowerHint) external;
 
     function claimCollateral() external;
 }

--- a/src/interfaces/liquity/IHintHelpers.sol
+++ b/src/interfaces/liquity/IHintHelpers.sol
@@ -2,29 +2,13 @@
 pragma solidity >=0.8.4;
 
 interface IHintHelpers {
-    function getRedemptionHints(
-        uint256 _LUSDamount,
-        uint256 _price,
-        uint256 _maxIterations
-    )
+    function getRedemptionHints(uint256 _LUSDamount, uint256 _price, uint256 _maxIterations)
         external
         view
-        returns (
-            address firstRedemptionHint,
-            uint256 partialRedemptionHintNICR,
-            uint256 truncatedLUSDamount
-        );
+        returns (address firstRedemptionHint, uint256 partialRedemptionHintNICR, uint256 truncatedLUSDamount);
 
-    function getApproxHint(
-        uint256 _CR,
-        uint256 _numTrials,
-        uint256 _inputRandomSeed
-    )
+    function getApproxHint(uint256 _CR, uint256 _numTrials, uint256 _inputRandomSeed)
         external
         view
-        returns (
-            address hintAddress,
-            uint256 diff,
-            uint256 latestRandomSeed
-        );
+        returns (address hintAddress, uint256 diff, uint256 latestRandomSeed);
 }

--- a/src/interfaces/liquity/ISortedTroves.sol
+++ b/src/interfaces/liquity/ISortedTroves.sol
@@ -8,9 +8,8 @@ interface ISortedTroves {
 
     function getPrev(address _id) external view returns (address);
 
-    function findInsertPosition(
-        uint256 _ICR,
-        address _prevId,
-        address _nextId
-    ) external view returns (address, address);
+    function findInsertPosition(uint256 _ICR, address _prevId, address _nextId)
+        external
+        view
+        returns (address, address);
 }

--- a/src/interfaces/liquity/ITroveManager.sol
+++ b/src/interfaces/liquity/ITroveManager.sol
@@ -24,12 +24,7 @@ interface ITroveManager is ILiquityBase {
     function getEntireDebtAndColl(address _borrower)
         external
         view
-        returns (
-            uint256 debt,
-            uint256 coll,
-            uint256 pendingLUSDDebtReward,
-            uint256 pendingETHReward
-        );
+        returns (uint256 debt, uint256 coll, uint256 pendingLUSDDebtReward, uint256 pendingETHReward);
 
     function closeTrove(address _borrower) external;
 

--- a/src/interfaces/set/IExchangeIssuance.sol
+++ b/src/interfaces/set/IExchangeIssuance.sol
@@ -39,9 +39,7 @@ interface IExchangeIssuance {
 
     // Redeems an exact amount of SetTokens for ETH.
     // The SetToken must be approved by the sender to this contract.
-    function redeemExactSetForETH(
-        ISetToken _setToken,
-        uint256 _amountSetToken,
-        uint256 _minEthOut
-    ) external returns (uint256);
+    function redeemExactSetForETH(ISetToken _setToken, uint256 _amountSetToken, uint256 _minEthOut)
+        external
+        returns (uint256);
 }

--- a/src/interfaces/set/ISetToken.sol
+++ b/src/interfaces/set/ISetToken.sol
@@ -73,23 +73,11 @@ interface ISetToken is IERC20 {
 
     function removeExternalPositionModule(address _component, address _positionModule) external;
 
-    function editExternalPositionUnit(
-        address _component,
-        address _positionModule,
-        int256 _realUnit
-    ) external;
+    function editExternalPositionUnit(address _component, address _positionModule, int256 _realUnit) external;
 
-    function editExternalPositionData(
-        address _component,
-        address _positionModule,
-        bytes calldata _data
-    ) external;
+    function editExternalPositionData(address _component, address _positionModule, bytes calldata _data) external;
 
-    function invoke(
-        address _target,
-        uint256 _value,
-        bytes calldata _data
-    ) external returns (bytes memory);
+    function invoke(address _target, uint256 _value, bytes calldata _data) external returns (bytes memory);
 
     function editPositionMultiplier(int256 _newMultiplier) external;
 
@@ -123,7 +111,10 @@ interface ISetToken is IERC20 {
 
     function getExternalPositionModules(address _component) external view returns (address[] memory);
 
-    function getExternalPositionData(address _component, address _positionModule) external view returns (bytes memory);
+    function getExternalPositionData(address _component, address _positionModule)
+        external
+        view
+        returns (bytes memory);
 
     function isExternalPositionModule(address _component, address _module) external view returns (bool);
 

--- a/src/interfaces/uniswapv3/callback/IUniswapV3SwapCallback.sol
+++ b/src/interfaces/uniswapv3/callback/IUniswapV3SwapCallback.sol
@@ -13,9 +13,5 @@ interface IUniswapV3SwapCallback {
     /// @param amount1Delta The amount of token1 that was sent (negative) or must be received (positive) by the pool by
     /// the end of the swap. If positive, the callback must send that amount of token1 to the pool.
     /// @param data Any data passed through by the caller via the IUniswapV3PoolActions#swap call
-    function uniswapV3SwapCallback(
-        int256 amount0Delta,
-        int256 amount1Delta,
-        bytes calldata data
-    ) external;
+    function uniswapV3SwapCallback(int256 amount0Delta, int256 amount1Delta, bytes calldata data) external;
 }

--- a/src/interfaces/uniswapv3/pool/IUniswapV3PoolActions.sol
+++ b/src/interfaces/uniswapv3/pool/IUniswapV3PoolActions.sol
@@ -20,13 +20,9 @@ interface IUniswapV3PoolActions {
     /// @param data Any data that should be passed through to the callback
     /// @return amount0 The amount of token0 that was paid to mint the given amount of liquidity. Matches the value in the callback
     /// @return amount1 The amount of token1 that was paid to mint the given amount of liquidity. Matches the value in the callback
-    function mint(
-        address recipient,
-        int24 tickLower,
-        int24 tickUpper,
-        uint128 amount,
-        bytes calldata data
-    ) external returns (uint256 amount0, uint256 amount1);
+    function mint(address recipient, int24 tickLower, int24 tickUpper, uint128 amount, bytes calldata data)
+        external
+        returns (uint256 amount0, uint256 amount1);
 
     /// @notice Collects tokens owed to a position
     /// @dev Does not recompute fees earned, which must be done either via mint or burn of any amount of liquidity.
@@ -56,11 +52,9 @@ interface IUniswapV3PoolActions {
     /// @param amount How much liquidity to burn
     /// @return amount0 The amount of token0 sent to the recipient
     /// @return amount1 The amount of token1 sent to the recipient
-    function burn(
-        int24 tickLower,
-        int24 tickUpper,
-        uint128 amount
-    ) external returns (uint256 amount0, uint256 amount1);
+    function burn(int24 tickLower, int24 tickUpper, uint128 amount)
+        external
+        returns (uint256 amount0, uint256 amount1);
 
     /// @notice Swap token0 for token1, or token1 for token0
     /// @dev The caller of this method receives a callback in the form of IUniswapV3SwapCallback#uniswapV3SwapCallback
@@ -88,12 +82,7 @@ interface IUniswapV3PoolActions {
     /// @param amount0 The amount of token0 to send
     /// @param amount1 The amount of token1 to send
     /// @param data Any data to be passed through to the callback
-    function flash(
-        address recipient,
-        uint256 amount0,
-        uint256 amount1,
-        bytes calldata data
-    ) external;
+    function flash(address recipient, uint256 amount0, uint256 amount1, bytes calldata data) external;
 
     /// @notice Increase the maximum number of price and liquidity observations that this pool will store
     /// @dev This method is no-op if the pool already has an observationCardinalityNext greater than or equal to

--- a/src/interfaces/uniswapv3/pool/IUniswapV3PoolDerivedState.sol
+++ b/src/interfaces/uniswapv3/pool/IUniswapV3PoolDerivedState.sol
@@ -32,9 +32,5 @@ interface IUniswapV3PoolDerivedState {
     function snapshotCumulativesInside(int24 tickLower, int24 tickUpper)
         external
         view
-        returns (
-            int56 tickCumulativeInside,
-            uint160 secondsPerLiquidityInsideX128,
-            uint32 secondsInside
-        );
+        returns (int56 tickCumulativeInside, uint160 secondsPerLiquidityInsideX128, uint32 secondsInside);
 }

--- a/src/libraries/aave/WadRayMath.sol
+++ b/src/libraries/aave/WadRayMath.sol
@@ -8,7 +8,8 @@ pragma solidity >=0.6.10;
  * @dev Provides mul and div function for wads (decimal numbers with 18 digits of precision) and rays (decimal numbers
  * with 27 digits of precision)
  * @dev Operations are rounded. If a value is >=.5, will be rounded up, otherwise rounded down.
- **/
+ *
+ */
 library WadRayMath {
     // HALF_WAD and HALF_RAY expressed with extended notation as constant with operations are not supported in Yul assembly
     uint256 internal constant WAD = 1e18;
@@ -25,13 +26,12 @@ library WadRayMath {
      * @param a Wad
      * @param b Wad
      * @return c = a*b, in wad
-     **/
+     *
+     */
     function wadMul(uint256 a, uint256 b) internal pure returns (uint256 c) {
         // to avoid overflow, a <= (type(uint256).max - HALF_WAD) / b
         assembly {
-            if iszero(or(iszero(b), iszero(gt(a, div(sub(not(0), HALF_WAD), b))))) {
-                revert(0, 0)
-            }
+            if iszero(or(iszero(b), iszero(gt(a, div(sub(not(0), HALF_WAD), b))))) { revert(0, 0) }
 
             c := div(add(mul(a, b), HALF_WAD), WAD)
         }
@@ -43,13 +43,12 @@ library WadRayMath {
      * @param a Wad
      * @param b Wad
      * @return c = a/b, in wad
-     **/
+     *
+     */
     function wadDiv(uint256 a, uint256 b) internal pure returns (uint256 c) {
         // to avoid overflow, a <= (type(uint256).max - halfB) / WAD
         assembly {
-            if or(iszero(b), iszero(iszero(gt(a, div(sub(not(0), div(b, 2)), WAD))))) {
-                revert(0, 0)
-            }
+            if or(iszero(b), iszero(iszero(gt(a, div(sub(not(0), div(b, 2)), WAD))))) { revert(0, 0) }
 
             c := div(add(mul(a, WAD), div(b, 2)), b)
         }
@@ -61,13 +60,12 @@ library WadRayMath {
      * @param a Ray
      * @param b Ray
      * @return c = a raymul b
-     **/
+     *
+     */
     function rayMul(uint256 a, uint256 b) internal pure returns (uint256 c) {
         // to avoid overflow, a <= (type(uint256).max - HALF_RAY) / b
         assembly {
-            if iszero(or(iszero(b), iszero(gt(a, div(sub(not(0), HALF_RAY), b))))) {
-                revert(0, 0)
-            }
+            if iszero(or(iszero(b), iszero(gt(a, div(sub(not(0), HALF_RAY), b))))) { revert(0, 0) }
 
             c := div(add(mul(a, b), HALF_RAY), RAY)
         }
@@ -79,13 +77,12 @@ library WadRayMath {
      * @param a Ray
      * @param b Ray
      * @return c = a raydiv b
-     **/
+     *
+     */
     function rayDiv(uint256 a, uint256 b) internal pure returns (uint256 c) {
         // to avoid overflow, a <= (type(uint256).max - halfB) / RAY
         assembly {
-            if or(iszero(b), iszero(iszero(gt(a, div(sub(not(0), div(b, 2)), RAY))))) {
-                revert(0, 0)
-            }
+            if or(iszero(b), iszero(iszero(gt(a, div(sub(not(0), div(b, 2)), RAY))))) { revert(0, 0) }
 
             c := div(add(mul(a, RAY), div(b, 2)), b)
         }
@@ -96,14 +93,13 @@ library WadRayMath {
      * @dev assembly optimized for improved gas savings, see https://twitter.com/transmissions11/status/1451131036377571328
      * @param a Ray
      * @return b = a converted to wad, rounded half up to the nearest wad
-     **/
+     *
+     */
     function rayToWad(uint256 a) internal pure returns (uint256 b) {
         assembly {
             b := div(a, WAD_RAY_RATIO)
             let remainder := mod(a, WAD_RAY_RATIO)
-            if iszero(lt(remainder, div(WAD_RAY_RATIO, 2))) {
-                b := add(b, 1)
-            }
+            if iszero(lt(remainder, div(WAD_RAY_RATIO, 2))) { b := add(b, 1) }
         }
     }
 
@@ -112,15 +108,14 @@ library WadRayMath {
      * @dev assembly optimized for improved gas savings, see https://twitter.com/transmissions11/status/1451131036377571328
      * @param a Wad
      * @return b = a converted in ray
-     **/
+     *
+     */
     function wadToRay(uint256 a) internal pure returns (uint256 b) {
         // to avoid overflow, b/WAD_RAY_RATIO == a
         assembly {
             b := mul(a, WAD_RAY_RATIO)
 
-            if iszero(eq(div(b, WAD_RAY_RATIO), a)) {
-                revert(0, 0)
-            }
+            if iszero(eq(div(b, WAD_RAY_RATIO), a)) { revert(0, 0) }
         }
     }
 }

--- a/src/libraries/uniswapv3/FullMath.sol
+++ b/src/libraries/uniswapv3/FullMath.sol
@@ -21,11 +21,7 @@ library FullMath {
     /// @param denominator The divisor
     /// @return result The 256-bit result
     /// @dev Credit to Remco Bloemen under MIT license https://xn--2-umb.com/21/muldiv
-    function mulDiv(
-        uint256 a,
-        uint256 b,
-        uint256 denominator
-    ) internal pure returns (uint256 result) {
+    function mulDiv(uint256 a, uint256 b, uint256 denominator) internal pure returns (uint256 result) {
         // 512-bit multiply [prod1 prod0] = a * b
         // Compute the product mod 2**256 and mod 2**256 - 1
         // then use the Chinese Remainder Theorem to reconstruct
@@ -123,11 +119,7 @@ library FullMath {
     /// @param b The multiplier
     /// @param denominator The divisor
     /// @return result The 256-bit result
-    function mulDivRoundingUp(
-        uint256 a,
-        uint256 b,
-        uint256 denominator
-    ) internal pure returns (uint256 result) {
+    function mulDivRoundingUp(uint256 a, uint256 b, uint256 denominator) internal pure returns (uint256 result) {
         result = mulDiv(a, b, denominator);
         if (mulmod(a, b, denominator) > 0) {
             require(result < type(uint256).max);

--- a/src/test/aztec/dataprovider/DataProvider.t.sol
+++ b/src/test/aztec/dataprovider/DataProvider.t.sol
@@ -182,9 +182,8 @@ contract DataProviderTest is BridgeTestBase {
     function testHappySubsidyHelper() public {
         AztecTypes.AztecAsset memory empty;
         AztecTypes.AztecAsset memory eth = ROLLUP_ENCODER.getRealAztecAsset(address(0));
-        AztecTypes.AztecAsset memory vyvault = ROLLUP_ENCODER.getRealAztecAsset(
-            0xa258C4606Ca8206D8aA700cE2143D7db854D168c
-        );
+        AztecTypes.AztecAsset memory vyvault =
+            ROLLUP_ENCODER.getRealAztecAsset(0xa258C4606Ca8206D8aA700cE2143D7db854D168c);
 
         vm.warp(block.timestamp + 1 days);
 
@@ -197,9 +196,7 @@ contract DataProviderTest is BridgeTestBase {
 
         {
             uint256 bridgeCallData = ROLLUP_ENCODER.encodeBridgeCallData(7, vyvault, empty, eth, empty, 1);
-            (uint256 criteria, uint256 subsidy, uint256 gasUnits) = provider.getAccumulatedSubsidyAmount(
-                bridgeCallData
-            );
+            (uint256 criteria, uint256 subsidy, uint256 gasUnits) = provider.getAccumulatedSubsidyAmount(bridgeCallData);
             assertEq(criteria, 1, "Wrong criteria");
             assertGe(subsidy, 0, "Subsidy accrued");
             assertGe(subsidy, gasUnits * block.basefee, "Invalid gas units accrued");
@@ -220,11 +217,8 @@ contract DataProviderTest is BridgeTestBase {
 
     function testHappySubsidyHelperVirtual() public {
         AztecTypes.AztecAsset memory eth = ROLLUP_ENCODER.getRealAztecAsset(address(0));
-        AztecTypes.AztecAsset memory virtualAsset = AztecTypes.AztecAsset({
-            id: 0,
-            erc20Address: address(0),
-            assetType: AztecTypes.AztecAssetType.VIRTUAL
-        });
+        AztecTypes.AztecAsset memory virtualAsset =
+            AztecTypes.AztecAsset({id: 0, erc20Address: address(0), assetType: AztecTypes.AztecAssetType.VIRTUAL});
 
         uint256 bridgeCallData = ROLLUP_ENCODER.encodeBridgeCallData(7, virtualAsset, eth, virtualAsset, eth, 0);
         (uint256 criteria, uint256 subsidy, uint256 gasUnits) = provider.getAccumulatedSubsidyAmount(bridgeCallData);

--- a/src/test/bridges/angle/AngleSLPE2E.t.sol
+++ b/src/test/bridges/angle/AngleSLPE2E.t.sol
@@ -91,9 +91,9 @@ contract AngleSLPE2ETest is BridgeTestBase {
         uint256 balanceRollupBeforeSanWETH = IERC20(sanWethAsset.erc20Address).balanceOf(address(ROLLUP_PROCESSOR));
 
         ROLLUP_ENCODER.defiInteractionL2(id, ethAsset, emptyAsset, sanWethAsset, emptyAsset, 0, amount);
-        (uint256 outputValueA, , ) = ROLLUP_ENCODER.processRollupAndGetBridgeResult();
+        (uint256 outputValueA,,) = ROLLUP_ENCODER.processRollupAndGetBridgeResult();
 
-        (, , , , , uint256 sanRate, , , ) = bridge.STABLE_MASTER().collateralMap(bridge.POOLMANAGER_WETH());
+        (,,,,, uint256 sanRate,,,) = bridge.STABLE_MASTER().collateralMap(bridge.POOLMANAGER_WETH());
 
         assertEq(outputValueA, (amount * 1e18) / sanRate);
         assertEq(address(bridge).balance, 0);
@@ -125,9 +125,9 @@ contract AngleSLPE2ETest is BridgeTestBase {
         uint256 balanceRollupBeforeETH = address(ROLLUP_PROCESSOR).balance;
 
         ROLLUP_ENCODER.defiInteractionL2(id, sanWethAsset, emptyAsset, ethAsset, emptyAsset, 1, amount);
-        (uint256 outputValueA, , ) = ROLLUP_ENCODER.processRollupAndGetBridgeResult();
+        (uint256 outputValueA,,) = ROLLUP_ENCODER.processRollupAndGetBridgeResult();
 
-        (, , , , , uint256 sanRate, , , ) = bridge.STABLE_MASTER().collateralMap(bridge.POOLMANAGER_WETH());
+        (,,,,, uint256 sanRate,,,) = bridge.STABLE_MASTER().collateralMap(bridge.POOLMANAGER_WETH());
 
         assertEq(outputValueA, (amount * sanRate) / 1e18);
         assertEq(address(bridge).balance, 0);
@@ -167,9 +167,9 @@ contract AngleSLPE2ETest is BridgeTestBase {
         uint256 balanceRollupBeforeOutput = IERC20(_outputAsset.erc20Address).balanceOf(address(ROLLUP_PROCESSOR));
 
         ROLLUP_ENCODER.defiInteractionL2(id, _inputAsset, emptyAsset, _outputAsset, emptyAsset, 0, amount);
-        (uint256 outputValueA, , ) = ROLLUP_ENCODER.processRollupAndGetBridgeResult();
+        (uint256 outputValueA,,) = ROLLUP_ENCODER.processRollupAndGetBridgeResult();
 
-        (, , , , , uint256 sanRate, , , ) = bridge.STABLE_MASTER().collateralMap(_poolManager);
+        (,,,,, uint256 sanRate,,,) = bridge.STABLE_MASTER().collateralMap(_poolManager);
 
         assertEq(outputValueA, (amount * 1e18) / sanRate);
         assertEq(IERC20(_inputAsset.erc20Address).balanceOf(address(bridge)), DUST);
@@ -194,9 +194,9 @@ contract AngleSLPE2ETest is BridgeTestBase {
         uint256 balanceRollupBeforeInput = IERC20(_inputAsset.erc20Address).balanceOf(address(ROLLUP_PROCESSOR));
 
         ROLLUP_ENCODER.defiInteractionL2(id, _inputAsset, emptyAsset, _outputAsset, emptyAsset, 1, _amount);
-        (uint256 outputValueA, , ) = ROLLUP_ENCODER.processRollupAndGetBridgeResult();
+        (uint256 outputValueA,,) = ROLLUP_ENCODER.processRollupAndGetBridgeResult();
 
-        (, , , , , uint256 sanRate, , , ) = bridge.STABLE_MASTER().collateralMap(_poolManager);
+        (,,,,, uint256 sanRate,,,) = bridge.STABLE_MASTER().collateralMap(_poolManager);
 
         assertApproxEqAbs(outputValueA, (_amount * sanRate) / 1e18, 2);
         assertEq(IERC20(_outputAsset.erc20Address).balanceOf(address(bridge)), DUST);

--- a/src/test/bridges/angle/AngleSLPUnit.t.sol
+++ b/src/test/bridges/angle/AngleSLPUnit.t.sol
@@ -161,20 +161,12 @@ contract AngleSLPUnitTest is BridgeTestBase {
         deal(daiAsset.erc20Address, address(bridge), amount + balance);
 
         vm.prank(address(ROLLUP_PROCESSOR));
-        (uint256 outputValueA, , ) = bridge.convert(
-            daiAsset,
-            emptyAsset,
-            sanDaiAsset,
-            emptyAsset,
-            amount,
-            0,
-            0,
-            address(0)
-        );
+        (uint256 outputValueA,,) =
+            bridge.convert(daiAsset, emptyAsset, sanDaiAsset, emptyAsset, amount, 0, 0, address(0));
 
         assertEq(IERC20(daiAsset.erc20Address).balanceOf(address(bridge)), DUST);
         assertEq(IERC20(sanDaiAsset.erc20Address).balanceOf(address(bridge)), outputValueA + DUST);
-        (, , , , , uint256 sanRate, , , ) = bridge.STABLE_MASTER().collateralMap(bridge.POOLMANAGER_DAI());
+        (,,,,, uint256 sanRate,,,) = bridge.STABLE_MASTER().collateralMap(bridge.POOLMANAGER_DAI());
         assertEq(outputValueA, (amount * 1e18) / sanRate);
     }
 
@@ -184,20 +176,12 @@ contract AngleSLPUnitTest is BridgeTestBase {
         vm.deal(address(bridge), amount);
 
         vm.prank(address(ROLLUP_PROCESSOR));
-        (uint256 outputValueA, , ) = bridge.convert(
-            ethAsset,
-            emptyAsset,
-            sanWethAsset,
-            emptyAsset,
-            amount,
-            0,
-            0,
-            address(0)
-        );
+        (uint256 outputValueA,,) =
+            bridge.convert(ethAsset, emptyAsset, sanWethAsset, emptyAsset, amount, 0, 0, address(0));
 
         assertEq(IERC20(wethAsset.erc20Address).balanceOf(address(bridge)), DUST);
         assertEq(IERC20(sanWethAsset.erc20Address).balanceOf(address(bridge)), outputValueA + DUST);
-        (, , , , , uint256 sanRate, , , ) = bridge.STABLE_MASTER().collateralMap(bridge.POOLMANAGER_WETH());
+        (,,,,, uint256 sanRate,,,) = bridge.STABLE_MASTER().collateralMap(bridge.POOLMANAGER_WETH());
         assertEq(outputValueA, (amount * 1e18) / sanRate);
     }
 
@@ -208,20 +192,12 @@ contract AngleSLPUnitTest is BridgeTestBase {
         deal(daiAsset.erc20Address, address(bridge), _amount + balance);
 
         vm.prank(address(ROLLUP_PROCESSOR));
-        (uint256 outputValueA, , ) = bridge.convert(
-            daiAsset,
-            emptyAsset,
-            sanDaiAsset,
-            emptyAsset,
-            uint256(_amount),
-            0,
-            0,
-            address(0)
-        );
+        (uint256 outputValueA,,) =
+            bridge.convert(daiAsset, emptyAsset, sanDaiAsset, emptyAsset, uint256(_amount), 0, 0, address(0));
 
         assertEq(IERC20(daiAsset.erc20Address).balanceOf(address(bridge)), DUST);
         assertEq(IERC20(sanDaiAsset.erc20Address).balanceOf(address(bridge)), outputValueA + DUST);
-        (, , , , , uint256 sanRate, , , ) = bridge.STABLE_MASTER().collateralMap(bridge.POOLMANAGER_DAI());
+        (,,,,, uint256 sanRate,,,) = bridge.STABLE_MASTER().collateralMap(bridge.POOLMANAGER_DAI());
         assertEq(outputValueA, (uint256(_amount) * 1e18) / sanRate);
     }
 
@@ -234,19 +210,11 @@ contract AngleSLPUnitTest is BridgeTestBase {
         deal(sanDaiAsset.erc20Address, address(bridge), amount + balance);
 
         vm.prank(address(ROLLUP_PROCESSOR));
-        (uint256 outputValueA, , ) = bridge.convert(
-            sanDaiAsset,
-            emptyAsset,
-            daiAsset,
-            emptyAsset,
-            amount,
-            0,
-            1,
-            address(0)
-        );
+        (uint256 outputValueA,,) =
+            bridge.convert(sanDaiAsset, emptyAsset, daiAsset, emptyAsset, amount, 0, 1, address(0));
         assertEq(IERC20(sanDaiAsset.erc20Address).balanceOf(address(bridge)), DUST);
         assertEq(IERC20(daiAsset.erc20Address).balanceOf(address(bridge)), outputValueA + DUST);
-        (, , , , , uint256 sanRate, , , ) = bridge.STABLE_MASTER().collateralMap(bridge.POOLMANAGER_DAI());
+        (,,,,, uint256 sanRate,,,) = bridge.STABLE_MASTER().collateralMap(bridge.POOLMANAGER_DAI());
         assertApproxEqAbs(outputValueA, (amount * sanRate) / 1e18, 2); // due to the harvest there might be a really small difference
     }
 
@@ -268,19 +236,11 @@ contract AngleSLPUnitTest is BridgeTestBase {
         deal(sanDaiAsset.erc20Address, address(bridge), amount + balance);
 
         vm.prank(address(ROLLUP_PROCESSOR));
-        (uint256 outputValueA, , ) = bridge.convert(
-            sanDaiAsset,
-            emptyAsset,
-            daiAsset,
-            emptyAsset,
-            amount,
-            0,
-            1,
-            address(0)
-        );
+        (uint256 outputValueA,,) =
+            bridge.convert(sanDaiAsset, emptyAsset, daiAsset, emptyAsset, amount, 0, 1, address(0));
         assertEq(IERC20(sanDaiAsset.erc20Address).balanceOf(address(bridge)), DUST);
         assertEq(IERC20(daiAsset.erc20Address).balanceOf(address(bridge)), outputValueA + DUST);
-        (, , , , , uint256 sanRate, , , ) = bridge.STABLE_MASTER().collateralMap(bridge.POOLMANAGER_DAI());
+        (,,,,, uint256 sanRate,,,) = bridge.STABLE_MASTER().collateralMap(bridge.POOLMANAGER_DAI());
         assertApproxEqAbs(outputValueA, (amount * sanRate) / 1e18, 2);
     }
 
@@ -291,20 +251,12 @@ contract AngleSLPUnitTest is BridgeTestBase {
         deal(sanWethAsset.erc20Address, address(bridge), amount + balance);
 
         vm.prank(address(ROLLUP_PROCESSOR));
-        (uint256 outputValueA, , ) = bridge.convert(
-            sanWethAsset,
-            emptyAsset,
-            ethAsset,
-            emptyAsset,
-            amount,
-            0,
-            1,
-            address(0)
-        );
+        (uint256 outputValueA,,) =
+            bridge.convert(sanWethAsset, emptyAsset, ethAsset, emptyAsset, amount, 0, 1, address(0));
         assertEq(IERC20(sanWethAsset.erc20Address).balanceOf(address(bridge)), DUST);
         assertEq(IERC20(wethAsset.erc20Address).balanceOf(address(bridge)), DUST);
         assertEq(address(bridge).balance, 0);
-        (, , , , , uint256 sanRate, , , ) = bridge.STABLE_MASTER().collateralMap(bridge.POOLMANAGER_WETH());
+        (,,,,, uint256 sanRate,,,) = bridge.STABLE_MASTER().collateralMap(bridge.POOLMANAGER_WETH());
         assertEq(outputValueA, (amount * sanRate) / 1e18);
     }
 
@@ -316,20 +268,12 @@ contract AngleSLPUnitTest is BridgeTestBase {
         deal(usdcAsset.erc20Address, address(bridge), amount + balance);
 
         vm.prank(address(ROLLUP_PROCESSOR));
-        (uint256 outputValueA, , ) = bridge.convert(
-            usdcAsset,
-            emptyAsset,
-            sanUsdcAsset,
-            emptyAsset,
-            amount,
-            0,
-            0,
-            address(0)
-        );
+        (uint256 outputValueA,,) =
+            bridge.convert(usdcAsset, emptyAsset, sanUsdcAsset, emptyAsset, amount, 0, 0, address(0));
 
         assertEq(IERC20(usdcAsset.erc20Address).balanceOf(address(bridge)), DUST);
         assertEq(IERC20(sanUsdcAsset.erc20Address).balanceOf(address(bridge)), outputValueA + DUST);
-        (, , , , , uint256 sanRate, , , ) = bridge.STABLE_MASTER().collateralMap(bridge.POOLMANAGER_USDC());
+        (,,,,, uint256 sanRate,,,) = bridge.STABLE_MASTER().collateralMap(bridge.POOLMANAGER_USDC());
         assertEq(outputValueA, (amount * 1e18) / sanRate);
     }
 
@@ -341,19 +285,11 @@ contract AngleSLPUnitTest is BridgeTestBase {
         deal(sanUsdcAsset.erc20Address, address(bridge), amount + balance);
 
         vm.prank(address(ROLLUP_PROCESSOR));
-        (uint256 outputValueA, , ) = bridge.convert(
-            sanUsdcAsset,
-            emptyAsset,
-            usdcAsset,
-            emptyAsset,
-            amount,
-            0,
-            1,
-            address(0)
-        );
+        (uint256 outputValueA,,) =
+            bridge.convert(sanUsdcAsset, emptyAsset, usdcAsset, emptyAsset, amount, 0, 1, address(0));
         assertEq(IERC20(sanUsdcAsset.erc20Address).balanceOf(address(bridge)), DUST);
         assertEq(IERC20(usdcAsset.erc20Address).balanceOf(address(bridge)), outputValueA + DUST);
-        (, , , , , uint256 sanRate, , , ) = bridge.STABLE_MASTER().collateralMap(bridge.POOLMANAGER_USDC());
+        (,,,,, uint256 sanRate,,,) = bridge.STABLE_MASTER().collateralMap(bridge.POOLMANAGER_USDC());
         assertApproxEqAbs(outputValueA, (amount * sanRate) / 1e18, 2);
     }
 

--- a/src/test/bridges/curve/CurveStEthBridge.t.sol
+++ b/src/test/bridges/curve/CurveStEthBridge.t.sol
@@ -133,11 +133,11 @@ contract CurveStEthBridgeTest is BridgeTestBase {
     }
 
     /**
-        Testing flow:
-        1. Send ETH to bridge
-        2. Get back wstETH
-        3. Send wstETH to bridge
-        4. Get back ETH
+     * Testing flow:
+     *     1. Send ETH to bridge
+     *     2. Get back wstETH
+     *     3. Send wstETH to bridge
+     *     4. Get back ETH
      */
     function validateCurveBridge(uint256 _balance, uint256 _depositAmount) public {
         // Send ETH to bridge
@@ -160,23 +160,11 @@ contract CurveStEthBridgeTest is BridgeTestBase {
         uint256 wstEthIncrease = _computeEthToWST(_depositAmount);
 
         uint256 bridgeCallData = ROLLUP_ENCODER.defiInteractionL2(
-            id,
-            ethAsset,
-            emptyAsset,
-            wstETHAsset,
-            emptyAsset,
-            minPrice,
-            _depositAmount
+            id, ethAsset, emptyAsset, wstETHAsset, emptyAsset, minPrice, _depositAmount
         );
 
         ROLLUP_ENCODER.registerEventToBeChecked(
-            bridgeCallData,
-            ROLLUP_ENCODER.getNextNonce(),
-            _depositAmount,
-            wstEthIncrease,
-            0,
-            true,
-            ""
+            bridgeCallData, ROLLUP_ENCODER.getNextNonce(), _depositAmount, wstEthIncrease, 0, true, ""
         );
         ROLLUP_ENCODER.processRollup();
 
@@ -200,23 +188,11 @@ contract CurveStEthBridgeTest is BridgeTestBase {
         uint256 expectedEth = _computeWSTHToEth(_depositAmount);
 
         uint256 bridgeCallData = ROLLUP_ENCODER.defiInteractionL2(
-            id,
-            wstETHAsset,
-            emptyAsset,
-            ethAsset,
-            emptyAsset,
-            minPrice,
-            _depositAmount
+            id, wstETHAsset, emptyAsset, ethAsset, emptyAsset, minPrice, _depositAmount
         );
 
         ROLLUP_ENCODER.registerEventToBeChecked(
-            bridgeCallData,
-            ROLLUP_ENCODER.getNextNonce(),
-            _depositAmount,
-            expectedEth,
-            0,
-            true,
-            ""
+            bridgeCallData, ROLLUP_ENCODER.getNextNonce(), _depositAmount, expectedEth, 0, true, ""
         );
         ROLLUP_ENCODER.processRollupAndGetBridgeResult();
 

--- a/src/test/bridges/curve/CurveStEthLPUnit.t.sol
+++ b/src/test/bridges/curve/CurveStEthLPUnit.t.sol
@@ -142,11 +142,7 @@ contract CurveLpUnitTest is BridgeTestBase {
         }
     }
 
-    function testDepositAndWithdrawal(
-        bool _isEth,
-        uint72 _depositAmount,
-        uint72 _withdrawAmount
-    ) public {
+    function testDepositAndWithdrawal(bool _isEth, uint72 _depositAmount, uint72 _withdrawAmount) public {
         testDeposit(_isEth, _depositAmount);
 
         uint256 lpBalance = LP_TOKEN.balanceOf(address(ROLLUP_PROCESSOR));
@@ -156,14 +152,14 @@ contract CurveLpUnitTest is BridgeTestBase {
     }
 
     function testReceiveTooLittleLpFromEth() public {
-        uint64 minReceived = 2**32 - 1; // Want to receive ~4K tokens for every input token
+        uint64 minReceived = 2 ** 32 - 1; // Want to receive ~4K tokens for every input token
         vm.prank(address(ROLLUP_PROCESSOR));
         vm.expectRevert("Slippage screwed you");
         bridge.convert{value: 1 ether}(ethAsset, emptyAsset, lpAsset, emptyAsset, 1 ether, 0, minReceived, BENEFICIARY);
     }
 
     function testReceiveTooLittleLpFromWstEth() public {
-        uint64 minReceived = 2**32 - 1; // Want to receive ~4K tokens for every input token
+        uint64 minReceived = 2 ** 32 - 1; // Want to receive ~4K tokens for every input token
         deal(address(WRAPPED_STETH), address(bridge), 1 ether);
         vm.prank(address(ROLLUP_PROCESSOR));
         vm.expectRevert("Slippage screwed you");
@@ -171,7 +167,7 @@ contract CurveLpUnitTest is BridgeTestBase {
     }
 
     function testReceiveTooLittleEthFromLp() public {
-        uint64 minEthReceived = 2**31 - 1;
+        uint64 minEthReceived = 2 ** 31 - 1;
         uint64 minWstReceived = 0;
 
         uint64 minReceived = minEthReceived + (minWstReceived << 32);
@@ -184,7 +180,7 @@ contract CurveLpUnitTest is BridgeTestBase {
 
     function testReceiveTooLittleWstEthFromLp() public {
         uint64 minEthReceived = 0;
-        uint64 minWstReceived = 2**31 - 1;
+        uint64 minWstReceived = 2 ** 31 - 1;
 
         uint64 minReceived = minEthReceived + (minWstReceived << 32);
 
@@ -194,17 +190,14 @@ contract CurveLpUnitTest is BridgeTestBase {
         bridge.convert(lpAsset, emptyAsset, ethAsset, wstETHAsset, 1 ether, 0, minReceived, BENEFICIARY);
     }
 
-    function _deposit(
-        AztecTypes.AztecAsset memory _inputAsset,
-        uint256 _depositAmount,
-        uint256 _interactionNonce
-    ) internal {
+    function _deposit(AztecTypes.AztecAsset memory _inputAsset, uint256 _depositAmount, uint256 _interactionNonce)
+        internal
+    {
         bool isEth = _inputAsset.assetType == AztecTypes.AztecAssetType.ETH;
 
         uint256 rollupLpBalance = LP_TOKEN.balanceOf(address(ROLLUP_PROCESSOR));
-        uint256 rollupInputBalance = isEth
-            ? address(ROLLUP_PROCESSOR).balance
-            : WRAPPED_STETH.balanceOf(address(ROLLUP_PROCESSOR));
+        uint256 rollupInputBalance =
+            isEth ? address(ROLLUP_PROCESSOR).balance : WRAPPED_STETH.balanceOf(address(ROLLUP_PROCESSOR));
 
         vm.startPrank(address(ROLLUP_PROCESSOR));
 
@@ -213,14 +206,7 @@ contract CurveLpUnitTest is BridgeTestBase {
         }
 
         (uint256 outputValueA, uint256 outputValueB, bool isAsync) = bridge.convert{value: isEth ? _depositAmount : 0}(
-            _inputAsset,
-            emptyAsset,
-            lpAsset,
-            emptyAsset,
-            _depositAmount,
-            _interactionNonce,
-            0,
-            BENEFICIARY
+            _inputAsset, emptyAsset, lpAsset, emptyAsset, _depositAmount, _interactionNonce, 0, BENEFICIARY
         );
 
         LP_TOKEN.transferFrom(address(bridge), address(ROLLUP_PROCESSOR), outputValueA);
@@ -228,9 +214,8 @@ contract CurveLpUnitTest is BridgeTestBase {
         vm.stopPrank();
 
         uint256 rollupLpBalanceAfter = LP_TOKEN.balanceOf(address(ROLLUP_PROCESSOR));
-        uint256 rollupInputBalanceAfter = isEth
-            ? address(ROLLUP_PROCESSOR).balance
-            : WRAPPED_STETH.balanceOf(address(ROLLUP_PROCESSOR));
+        uint256 rollupInputBalanceAfter =
+            isEth ? address(ROLLUP_PROCESSOR).balance : WRAPPED_STETH.balanceOf(address(ROLLUP_PROCESSOR));
 
         assertEq(rollupLpBalanceAfter, rollupLpBalance + outputValueA, "Did not receive sufficient lptokens");
         assertEq(rollupInputBalanceAfter, rollupInputBalance - _depositAmount, "Did not pay sufficient input");
@@ -247,16 +232,8 @@ contract CurveLpUnitTest is BridgeTestBase {
 
         LP_TOKEN.transfer(address(bridge), _inputAmount);
 
-        (uint256 outputValueA, uint256 outputValueB, bool isAsync) = bridge.convert(
-            lpAsset,
-            emptyAsset,
-            ethAsset,
-            wstETHAsset,
-            _inputAmount,
-            _interactionNonce,
-            0,
-            BENEFICIARY
-        );
+        (uint256 outputValueA, uint256 outputValueB, bool isAsync) =
+            bridge.convert(lpAsset, emptyAsset, ethAsset, wstETHAsset, _inputAmount, _interactionNonce, 0, BENEFICIARY);
 
         WRAPPED_STETH.transferFrom(address(bridge), address(ROLLUP_PROCESSOR), outputValueB);
 

--- a/src/test/bridges/curve/CurveStEthLpE2E.t.sol
+++ b/src/test/bridges/curve/CurveStEthLpE2E.t.sol
@@ -109,11 +109,7 @@ contract CurveLpE2ETest is BridgeTestBase {
         }
     }
 
-    function testDepositAndWithdrawal(
-        bool _isEth,
-        uint72 _depositAmount,
-        uint72 _withdrawAmount
-    ) public {
+    function testDepositAndWithdrawal(bool _isEth, uint72 _depositAmount, uint72 _withdrawAmount) public {
         testDeposit(_isEth, _depositAmount);
 
         uint256 lpBalance = LP_TOKEN.balanceOf(address(ROLLUP_PROCESSOR));
@@ -126,18 +122,11 @@ contract CurveLpE2ETest is BridgeTestBase {
         bool isEth = _inputAsset.assetType == AztecTypes.AztecAssetType.ETH;
 
         uint256 rollupLpBalance = LP_TOKEN.balanceOf(address(ROLLUP_PROCESSOR));
-        uint256 rollupInputBalance = isEth
-            ? address(ROLLUP_PROCESSOR).balance
-            : WRAPPED_STETH.balanceOf(address(ROLLUP_PROCESSOR));
+        uint256 rollupInputBalance =
+            isEth ? address(ROLLUP_PROCESSOR).balance : WRAPPED_STETH.balanceOf(address(ROLLUP_PROCESSOR));
 
         ROLLUP_ENCODER.defiInteractionL2(
-            bridgeAddressId,
-            _inputAsset,
-            emptyAsset,
-            lpAsset,
-            emptyAsset,
-            0,
-            _depositAmount
+            bridgeAddressId, _inputAsset, emptyAsset, lpAsset, emptyAsset, 0, _depositAmount
         );
 
         uint256 claimableBefore = SUBSIDY.claimableAmount(BENEFICIARY);
@@ -147,9 +136,8 @@ contract CurveLpE2ETest is BridgeTestBase {
         assertGt(SUBSIDY.claimableAmount(BENEFICIARY), claimableBefore, "No subsidy accumulated");
 
         uint256 rollupLpBalanceAfter = LP_TOKEN.balanceOf(address(ROLLUP_PROCESSOR));
-        uint256 rollupInputBalanceAfter = isEth
-            ? address(ROLLUP_PROCESSOR).balance
-            : WRAPPED_STETH.balanceOf(address(ROLLUP_PROCESSOR));
+        uint256 rollupInputBalanceAfter =
+            isEth ? address(ROLLUP_PROCESSOR).balance : WRAPPED_STETH.balanceOf(address(ROLLUP_PROCESSOR));
 
         assertEq(rollupLpBalanceAfter, rollupLpBalance + outputValueA, "Did not receive sufficient lptokens");
         assertEq(rollupInputBalanceAfter, rollupInputBalance - _depositAmount, "Did not pay sufficient input");

--- a/src/test/bridges/dca/BiDCABridge.t.sol
+++ b/src/test/bridges/dca/BiDCABridge.t.sol
@@ -51,16 +51,10 @@ contract BiDCATestUnit is Test {
         assetA = IERC20(address(0x6B175474E89094C44Da98b954EedeAC495271d0F));
         assetB = IERC20(address(WETH));
         bridge = new UniswapDCABridge(address(this), 1 days, 0);
-        aztecAssetA = AztecTypes.AztecAsset({
-            id: 1,
-            erc20Address: address(assetA),
-            assetType: AztecTypes.AztecAssetType.ERC20
-        });
-        aztecAssetB = AztecTypes.AztecAsset({
-            id: 2,
-            erc20Address: address(assetB),
-            assetType: AztecTypes.AztecAssetType.ERC20
-        });
+        aztecAssetA =
+            AztecTypes.AztecAsset({id: 1, erc20Address: address(assetA), assetType: AztecTypes.AztecAssetType.ERC20});
+        aztecAssetB =
+            AztecTypes.AztecAsset({id: 2, erc20Address: address(assetB), assetType: AztecTypes.AztecAssetType.ERC20});
         vm.label(address(assetA), "DAI");
         vm.label(address(assetB), "WETH");
 
@@ -163,14 +157,8 @@ contract BiDCATestUnit is Test {
         bridge.rebalanceAndFillUniswap(dca.start + 2);
 
         (, bool ready) = bridge.getAccumulated(0);
-        (uint256 outputValueA, uint256 outputValueB, bool interactionComplete) = bridge.finalise(
-            aztecAssetA,
-            emptyAsset,
-            aztecAssetB,
-            emptyAsset,
-            0,
-            0
-        );
+        (uint256 outputValueA, uint256 outputValueB, bool interactionComplete) =
+            bridge.finalise(aztecAssetA, emptyAsset, aztecAssetB, emptyAsset, 0, 0);
 
         assertFalse(ready, "Ready to finalise 0");
         assertEq(outputValueA, 0, "outputValueA not zero");
@@ -280,12 +268,7 @@ contract BiDCATestUnit is Test {
             // Finalise DCA position 0
             (uint256 acc, bool ready) = bridge.getAccumulated(0);
             (uint256 outputValueA, uint256 outputValueB, bool interactionComplete) = bridge.finalise(
-                _aFirst ? aztecAssetA : aztecAssetB,
-                emptyAsset,
-                _aFirst ? aztecAssetB : aztecAssetA,
-                emptyAsset,
-                0,
-                0
+                _aFirst ? aztecAssetA : aztecAssetB, emptyAsset, _aFirst ? aztecAssetB : aztecAssetA, emptyAsset, 0, 0
             );
             if (bridge.getDCA(0).end <= (block.timestamp / bridge.TICK_SIZE())) {
                 assertTrue(ready, "Not ready to finalise 0");
@@ -313,12 +296,7 @@ contract BiDCATestUnit is Test {
             // Finalise DCA position 1
             (uint256 acc, bool ready) = bridge.getAccumulated(1);
             (uint256 outputValueA, uint256 outputValueB, bool interactionComplete) = bridge.finalise(
-                _aFirst ? aztecAssetB : aztecAssetA,
-                emptyAsset,
-                _aFirst ? aztecAssetA : aztecAssetB,
-                emptyAsset,
-                1,
-                0
+                _aFirst ? aztecAssetB : aztecAssetA, emptyAsset, _aFirst ? aztecAssetA : aztecAssetB, emptyAsset, 1, 0
             );
             if (bridge.getDCA(1).end <= (block.timestamp / bridge.TICK_SIZE())) {
                 assertTrue(ready, "Not ready to finalise 1");
@@ -351,20 +329,12 @@ contract BiDCATestUnit is Test {
         }
     }
 
-    function testFuzzUniswapForceFillEth(
-        uint256 _deposit1,
-        uint256 _deposit2,
-        bool _aFirst
-    ) public {
+    function testFuzzUniswapForceFillEth(uint256 _deposit1, uint256 _deposit2, bool _aFirst) public {
         uint256 deposit1 = bound(_deposit1, 0.1e18, 1e21);
         uint256 deposit2 = bound(_deposit2, 0.1e18, 1e21);
         uint256 priceBefore = bridge.getPrice();
 
-        aztecAssetB = AztecTypes.AztecAsset({
-            id: 0,
-            erc20Address: address(0),
-            assetType: AztecTypes.AztecAssetType.ETH
-        });
+        aztecAssetB = AztecTypes.AztecAsset({id: 0, erc20Address: address(0), assetType: AztecTypes.AztecAssetType.ETH});
 
         {
             refreshTs();
@@ -412,12 +382,7 @@ contract BiDCATestUnit is Test {
             (uint256 acc, bool ready) = bridge.getAccumulated(0);
             uint256 ethBalBefore = address(this).balance;
             (uint256 outputValueA, uint256 outputValueB, bool interactionComplete) = bridge.finalise(
-                _aFirst ? aztecAssetA : aztecAssetB,
-                emptyAsset,
-                _aFirst ? aztecAssetB : aztecAssetA,
-                emptyAsset,
-                0,
-                0
+                _aFirst ? aztecAssetA : aztecAssetB, emptyAsset, _aFirst ? aztecAssetB : aztecAssetA, emptyAsset, 0, 0
             );
             assertTrue(ready);
             assertEq(outputValueA, acc, "outputValueA not matching");
@@ -439,12 +404,7 @@ contract BiDCATestUnit is Test {
             (uint256 acc, bool ready) = bridge.getAccumulated(1);
             uint256 ethBalBefore = address(this).balance;
             (uint256 outputValueA, uint256 outputValueB, bool interactionComplete) = bridge.finalise(
-                _aFirst ? aztecAssetB : aztecAssetA,
-                emptyAsset,
-                _aFirst ? aztecAssetA : aztecAssetB,
-                emptyAsset,
-                1,
-                0
+                _aFirst ? aztecAssetB : aztecAssetA, emptyAsset, _aFirst ? aztecAssetA : aztecAssetB, emptyAsset, 1, 0
             );
             assertTrue(ready);
             assertEq(outputValueA, acc, "outputValueA not matching");
@@ -644,9 +604,7 @@ contract BiDCATestUnit is Test {
             // Check the accumulated value of DCA(0)
             (uint256 accumulated, bool ready) = bridge.getAccumulated(0);
             assertEq(
-                accumulated,
-                bridge.denominateAssetBInA((depositUser1 / 7), price, true) * 2,
-                "Accumulated not matching"
+                accumulated, bridge.denominateAssetBInA((depositUser1 / 7), price, true) * 2, "Accumulated not matching"
             );
             assertFalse(ready, "Is ready");
         }
@@ -722,9 +680,7 @@ contract BiDCATestUnit is Test {
             assertEq(tick.priceOfAInB, price, "Price not matching");
             assertEq(tick.bToASubTick.sold, userBought, "BToA sold not matching");
             assertEq(
-                tick.bToASubTick.bought,
-                bridge.denominateAssetBInA(userBought, price, true),
-                "BToA bought not matching"
+                tick.bToASubTick.bought, bridge.denominateAssetBInA(userBought, price, true), "BToA bought not matching"
             );
             assertEq(tick.aToBSubTick.sold, 0, "AToB sold not matching");
             assertEq(tick.aToBSubTick.bought, 0, "BToA bought not matching");
@@ -751,9 +707,7 @@ contract BiDCATestUnit is Test {
             // Check the accumulated value of DCA(0)
             (uint256 accumulated, bool ready) = bridge.getAccumulated(0);
             assertEq(
-                accumulated,
-                bridge.denominateAssetBInA((depositUser1 / 7), price, true),
-                "Accumulated not matching"
+                accumulated, bridge.denominateAssetBInA((depositUser1 / 7), price, true), "Accumulated not matching"
             );
             assertFalse(ready, "Is ready");
         }
@@ -838,9 +792,7 @@ contract BiDCATestUnit is Test {
                 assertEq(tick.priceOfAInB, price, "Price not matching");
                 assertEq(tick.aToBSubTick.sold, 100e18, "AToB sold not matching");
                 assertEq(
-                    tick.aToBSubTick.bought,
-                    bridge.denominateAssetAInB(100e18, price, true),
-                    "AToB bought not matching"
+                    tick.aToBSubTick.bought, bridge.denominateAssetAInB(100e18, price, true), "AToB bought not matching"
                 );
                 assertEq(tick.bToASubTick.sold, 0, "BToA sold not matching");
                 assertEq(tick.bToASubTick.bought, 0, "AToB bought not matching");
@@ -853,9 +805,7 @@ contract BiDCATestUnit is Test {
                 assertEq(tick.priceOfAInB, i == 3 ? price : 0, "Price not matching");
                 assertEq(tick.aToBSubTick.sold, 300e18, "AToB sold not matching");
                 assertEq(
-                    tick.aToBSubTick.bought,
-                    bridge.denominateAssetAInB(300e18, price, true),
-                    "AToB bought not matching"
+                    tick.aToBSubTick.bought, bridge.denominateAssetAInB(300e18, price, true), "AToB bought not matching"
                 );
                 assertEq(tick.bToASubTick.sold, 0, "BToA sold not matching");
                 assertEq(tick.bToASubTick.bought, 0, "AToB bought not matching");
@@ -938,9 +888,7 @@ contract BiDCATestUnit is Test {
                 assertEq(tick.priceOfAInB, 0, "Price not matching");
                 assertEq(tick.aToBSubTick.sold, 100e18, "AToB sold not matching");
                 assertEq(
-                    tick.aToBSubTick.bought,
-                    bridge.denominateAssetAInB(100e18, price, true),
-                    "AToB bought not matching"
+                    tick.aToBSubTick.bought, bridge.denominateAssetAInB(100e18, price, true), "AToB bought not matching"
                 );
                 assertEq(tick.bToASubTick.sold, 0, "BToA sold not matching");
                 assertEq(tick.bToASubTick.bought, 0, "AToB bought not matching");
@@ -1023,9 +971,7 @@ contract BiDCATestUnit is Test {
             assertEq(tick.priceOfAInB, 0, "Price not matching");
             assertEq(tick.aToBSubTick.sold, 100 ether, "AToB sold not matching");
             assertEq(
-                tick.aToBSubTick.bought,
-                bridge.denominateAssetAInB(100e18, price, true),
-                "AToB bought not matching"
+                tick.aToBSubTick.bought, bridge.denominateAssetAInB(100e18, price, true), "AToB bought not matching"
             );
             assertEq(tick.bToASubTick.sold, 0, "BToA sold not matching");
             assertEq(tick.bToASubTick.bought, 0, "AToB bought not matching");
@@ -1168,14 +1114,8 @@ contract BiDCATestUnit is Test {
 
         {
             // Finalise DCA(0)
-            (uint256 outputValueA, uint256 outputValueB, bool interactionComplete) = bridge.finalise(
-                aztecAssetA,
-                emptyAsset,
-                aztecAssetB,
-                emptyAsset,
-                0,
-                0
-            );
+            (uint256 outputValueA, uint256 outputValueB, bool interactionComplete) =
+                bridge.finalise(aztecAssetA, emptyAsset, aztecAssetB, emptyAsset, 0, 0);
             assertEq(outputValueA, bridge.denominateAssetAInB(700e18, price, true), "OutputValue A not matching");
             assertEq(outputValueB, 0, "Outputvalue B not zero");
             assertTrue(interactionComplete, "Interaction failed");
@@ -1184,14 +1124,8 @@ contract BiDCATestUnit is Test {
         }
         {
             // Finalise DCA(1)
-            (uint256 outputValueA, uint256 outputValueB, bool interactionComplete) = bridge.finalise(
-                aztecAssetB,
-                emptyAsset,
-                aztecAssetA,
-                emptyAsset,
-                1,
-                0
-            );
+            (uint256 outputValueA, uint256 outputValueB, bool interactionComplete) =
+                bridge.finalise(aztecAssetB, emptyAsset, aztecAssetA, emptyAsset, 1, 0);
             assertEq(outputValueA, 700e18, "OutputValue A not matching");
             assertEq(outputValueB, 0, "Outputvalue B not zero");
             assertTrue(interactionComplete, "Interaction failed");
@@ -1204,11 +1138,7 @@ contract BiDCATestUnit is Test {
         uint256 price = bridge.getPrice();
         uint256 _b = bridge.denominateAssetAInB(700e18, price, true);
 
-        aztecAssetB = AztecTypes.AztecAsset({
-            id: 0,
-            erc20Address: address(0),
-            assetType: AztecTypes.AztecAssetType.ETH
-        });
+        aztecAssetB = AztecTypes.AztecAsset({id: 0, erc20Address: address(0), assetType: AztecTypes.AztecAssetType.ETH});
 
         bridge.pokeNextTicks(10);
         uint256 startTick = block.timestamp / bridge.TICK_SIZE();
@@ -1276,9 +1206,7 @@ contract BiDCATestUnit is Test {
                     "AToB bought not matching"
                 );
                 assertEq(
-                    tick.bToASubTick.sold,
-                    bridge.denominateAssetAInB(100e18, price, false),
-                    "BToA sold not matching"
+                    tick.bToASubTick.sold, bridge.denominateAssetAInB(100e18, price, false), "BToA sold not matching"
                 );
                 assertEq(tick.bToASubTick.bought, 100e18, "AToB bought not matching");
             }
@@ -1300,14 +1228,8 @@ contract BiDCATestUnit is Test {
         {
             // Finalise DCA(0)
             uint256 ethBalBefore = address(this).balance;
-            (uint256 outputValueA, uint256 outputValueB, bool interactionComplete) = bridge.finalise(
-                aztecAssetA,
-                emptyAsset,
-                aztecAssetB,
-                emptyAsset,
-                0,
-                0
-            );
+            (uint256 outputValueA, uint256 outputValueB, bool interactionComplete) =
+                bridge.finalise(aztecAssetA, emptyAsset, aztecAssetB, emptyAsset, 0, 0);
             assertEq(outputValueA, _b, "OutputValue A not matching");
             assertEq(outputValueB, 0, "Outputvalue B not zero");
             assertTrue(interactionComplete, "Interaction failed");
@@ -1316,14 +1238,8 @@ contract BiDCATestUnit is Test {
         }
         {
             // Finalise DCA(1)
-            (uint256 outputValueA, uint256 outputValueB, bool interactionComplete) = bridge.finalise(
-                aztecAssetB,
-                emptyAsset,
-                aztecAssetA,
-                emptyAsset,
-                1,
-                0
-            );
+            (uint256 outputValueA, uint256 outputValueB, bool interactionComplete) =
+                bridge.finalise(aztecAssetB, emptyAsset, aztecAssetA, emptyAsset, 1, 0);
             assertEq(outputValueA, 700e18, "OutputValue A not matching");
             assertEq(outputValueB, 0, "Outputvalue B not zero");
             assertTrue(interactionComplete, "Interaction failed");
@@ -1424,13 +1340,9 @@ contract BiDCATestUnit is Test {
                 uint256 interpolatedPrice;
                 {
                     UniswapDCABridge.Tick memory tick = bridge.getTick(startTick + 1);
-                    int256 slope = (int256(bridge.getPrice()) - int256(uint256(tick.priceOfAInB))) /
-                        int256(block.timestamp - uint256(tick.priceTime));
-                    uint256 dt = (startTick + i) *
-                        bridge.TICK_SIZE() +
-                        bridge.TICK_SIZE() /
-                        2 -
-                        uint256(tick.priceTime);
+                    int256 slope = (int256(bridge.getPrice()) - int256(uint256(tick.priceOfAInB)))
+                        / int256(block.timestamp - uint256(tick.priceTime));
+                    uint256 dt = (startTick + i) * bridge.TICK_SIZE() + bridge.TICK_SIZE() / 2 - uint256(tick.priceTime);
                     interpolatedPrice = uint256(int256(uint256(tick.priceOfAInB)) + slope * int256(dt));
                 }
                 uint256 _a = bridge.denominateAssetBInA(0.1e18, interpolatedPrice, false);
@@ -1480,14 +1392,8 @@ contract BiDCATestUnit is Test {
 
         {
             // Finalise DCA(0)
-            (uint256 outputValueA, uint256 outputValueB, bool interactionComplete) = bridge.finalise(
-                aztecAssetA,
-                emptyAsset,
-                aztecAssetB,
-                emptyAsset,
-                0,
-                0
-            );
+            (uint256 outputValueA, uint256 outputValueB, bool interactionComplete) =
+                bridge.finalise(aztecAssetA, emptyAsset, aztecAssetB, emptyAsset, 0, 0);
             uint256 _b = bridge.denominateAssetAInB(200e18, price, true);
             uint256 expectedOutputA = sums.summedB + sums.summedBInv + _b;
 
@@ -1499,14 +1405,8 @@ contract BiDCATestUnit is Test {
         }
         {
             // Finalise DCA(1)
-            (uint256 outputValueA, uint256 outputValueB, bool interactionComplete) = bridge.finalise(
-                aztecAssetB,
-                emptyAsset,
-                aztecAssetA,
-                emptyAsset,
-                1,
-                0
-            );
+            (uint256 outputValueA, uint256 outputValueB, bool interactionComplete) =
+                bridge.finalise(aztecAssetB, emptyAsset, aztecAssetA, emptyAsset, 1, 0);
             // Values are zero because interaction is not ready.
             assertEq(outputValueA, 0, "OutputValue A not zero");
             assertEq(outputValueB, 0, "Outputvalue B not zero");
@@ -1555,7 +1455,7 @@ contract BiDCATestUnit is Test {
     }
 
     function refreshTs() public {
-        (, int256 answer, , , ) = bridge.ORACLE().latestRoundData();
+        (, int256 answer,,,) = bridge.ORACLE().latestRoundData();
         bytes memory returnValue = abi.encode(uint80(0), answer, uint256(0), block.timestamp, uint80(0));
         vm.mockCall(ORACLE, "", returnValue);
     }

--- a/src/test/bridges/dca/BiDCABridgeArber.t.sol
+++ b/src/test/bridges/dca/BiDCABridgeArber.t.sol
@@ -53,16 +53,10 @@ contract BiDCABridgeArberTest is Test {
         assetA = IERC20(address(0x6B175474E89094C44Da98b954EedeAC495271d0F));
         assetB = IERC20(address(WETH));
         bridge = new UniswapDCABridge(address(this), 1 days, 10);
-        aztecAssetA = AztecTypes.AztecAsset({
-            id: 1,
-            erc20Address: address(assetA),
-            assetType: AztecTypes.AztecAssetType.ERC20
-        });
-        aztecAssetB = AztecTypes.AztecAsset({
-            id: 2,
-            erc20Address: address(assetB),
-            assetType: AztecTypes.AztecAssetType.ERC20
-        });
+        aztecAssetA =
+            AztecTypes.AztecAsset({id: 1, erc20Address: address(assetA), assetType: AztecTypes.AztecAssetType.ERC20});
+        aztecAssetB =
+            AztecTypes.AztecAsset({id: 2, erc20Address: address(assetB), assetType: AztecTypes.AztecAssetType.ERC20});
         vm.label(address(assetA), "DAI");
         vm.label(address(assetB), "WETH");
 
@@ -90,12 +84,12 @@ contract BiDCABridgeArberTest is Test {
         vm.warp(block.timestamp + 3 days); // next tick + 2 days
 
         bridge.rebalanceAndFillUniswap(type(uint256).max);
-        (uint256 acc, ) = bridge.getAccumulated(nonce);
+        (uint256 acc,) = bridge.getAccumulated(nonce);
 
         uint256 balanceBefore = WETH.balanceOf(SEARCHER);
 
         vm.prank(address(this), SEARCHER); // msg.sender = this, tx.origin = SEARCHER
-        (uint256 outA, , ) = bridge.finalise(aztecAssetA, emptyAsset, aztecAssetB, emptyAsset, nonce, 0);
+        (uint256 outA,,) = bridge.finalise(aztecAssetA, emptyAsset, aztecAssetB, emptyAsset, nonce, 0);
 
         assertEq(acc, outA + WETH.balanceOf(SEARCHER), "Bal matches");
 

--- a/src/test/bridges/dca/BiDCABridgeE2E.t.sol
+++ b/src/test/bridges/dca/BiDCABridgeE2E.t.sol
@@ -272,7 +272,7 @@ contract BiDCATestE2E is BridgeTestBase {
             uint256 unaccountedB = assetB.balanceOf(address(bridge)) - availableB;
             {
                 if (bridge.getDCA(0).start != 0) {
-                    (uint256 acc, ) = bridge.getAccumulated(0);
+                    (uint256 acc,) = bridge.getAccumulated(0);
                     if (_aFirst) {
                         unaccountedB -= acc;
                     } else {
@@ -280,7 +280,7 @@ contract BiDCATestE2E is BridgeTestBase {
                     }
                 }
                 if (bridge.getDCA(32).start != 0) {
-                    (uint256 acc, ) = bridge.getAccumulated(32);
+                    (uint256 acc,) = bridge.getAccumulated(32);
                     if (_aFirst) {
                         unaccountedA -= acc;
                     } else {
@@ -296,7 +296,7 @@ contract BiDCATestE2E is BridgeTestBase {
     }
 
     function refreshTs() public {
-        (, int256 answer, , , ) = bridge.ORACLE().latestRoundData();
+        (, int256 answer,,,) = bridge.ORACLE().latestRoundData();
         bytes memory returnValue = abi.encode(uint80(0), answer, uint256(0), block.timestamp, uint80(0));
         vm.mockCall(ORACLE, "", returnValue);
     }

--- a/src/test/bridges/donation/DonateBridgeE2E.t.sol
+++ b/src/test/bridges/donation/DonateBridgeE2E.t.sol
@@ -61,15 +61,8 @@ contract DonationBridgeE2ETest is BridgeTestBase {
 
         uint256 doneeBalanceBefore = DONEE.balance;
 
-        uint256 bridgeCallData = ROLLUP_ENCODER.defiInteractionL2(
-            bridgeAddressId,
-            ethAsset,
-            emptyAsset,
-            emptyAsset,
-            emptyAsset,
-            1,
-            _amount
-        );
+        uint256 bridgeCallData =
+            ROLLUP_ENCODER.defiInteractionL2(bridgeAddressId, ethAsset, emptyAsset, emptyAsset, emptyAsset, 1, _amount);
 
         ROLLUP_ENCODER.registerEventToBeChecked(bridgeCallData, ROLLUP_ENCODER.getNextNonce(), _amount, 0, 0, true, "");
         ROLLUP_ENCODER.processRollup();
@@ -81,7 +74,7 @@ contract DonationBridgeE2ETest is BridgeTestBase {
         for (uint256 i = 0; i < tokens.length; i++) {
             IERC20Metadata token = IERC20Metadata(tokens[i]);
             uint8 decimals = token.decimals();
-            uint256 amount = bound(_amount, 10**decimals, 1e6 * 10**decimals);
+            uint256 amount = bound(_amount, 10 ** decimals, 1e6 * 10 ** decimals);
 
             if (!ROLLUP_ENCODER.isSupportedAsset(address(token))) {
                 vm.prank(address(MULTI_SIG));
@@ -103,13 +96,7 @@ contract DonationBridgeE2ETest is BridgeTestBase {
             );
 
             ROLLUP_ENCODER.registerEventToBeChecked(
-                bridgeCallData,
-                ROLLUP_ENCODER.getNextNonce(),
-                _amount,
-                0,
-                0,
-                true,
-                ""
+                bridgeCallData, ROLLUP_ENCODER.getNextNonce(), _amount, 0, 0, true, ""
             );
             ROLLUP_ENCODER.processRollup();
 
@@ -121,26 +108,13 @@ contract DonationBridgeE2ETest is BridgeTestBase {
         vm.assume(_amount > 0);
         vm.deal(address(ROLLUP_PROCESSOR), _amount);
 
-        uint256 bridgeCallData = ROLLUP_ENCODER.defiInteractionL2(
-            bridgeAddressId,
-            ethAsset,
-            emptyAsset,
-            emptyAsset,
-            emptyAsset,
-            2,
-            _amount
-        );
+        uint256 bridgeCallData =
+            ROLLUP_ENCODER.defiInteractionL2(bridgeAddressId, ethAsset, emptyAsset, emptyAsset, emptyAsset, 2, _amount);
 
         bytes memory err = abi.encodePacked(ErrorLib.InvalidAuxData.selector);
 
         ROLLUP_ENCODER.registerEventToBeChecked(
-            bridgeCallData,
-            ROLLUP_ENCODER.getNextNonce(),
-            _amount,
-            0,
-            0,
-            false,
-            err
+            bridgeCallData, ROLLUP_ENCODER.getNextNonce(), _amount, 0, 0, false, err
         );
         ROLLUP_ENCODER.processRollup();
     }
@@ -152,25 +126,13 @@ contract DonationBridgeE2ETest is BridgeTestBase {
         uint256 doneeId = bridge.listDonee(address(this));
 
         uint256 bridgeCallData = ROLLUP_ENCODER.defiInteractionL2(
-            bridgeAddressId,
-            ethAsset,
-            emptyAsset,
-            emptyAsset,
-            emptyAsset,
-            uint64(doneeId),
-            _amount
+            bridgeAddressId, ethAsset, emptyAsset, emptyAsset, emptyAsset, uint64(doneeId), _amount
         );
 
         bytes memory err = abi.encodePacked(EthTransferFailed.selector);
 
         ROLLUP_ENCODER.registerEventToBeChecked(
-            bridgeCallData,
-            ROLLUP_ENCODER.getNextNonce(),
-            _amount,
-            0,
-            0,
-            false,
-            err
+            bridgeCallData, ROLLUP_ENCODER.getNextNonce(), _amount, 0, 0, false, err
         );
         ROLLUP_ENCODER.processRollup();
     }
@@ -188,23 +150,11 @@ contract DonationBridgeE2ETest is BridgeTestBase {
         });
 
         uint256 bridgeCallData = ROLLUP_ENCODER.defiInteractionL2(
-            bridgeAddressId,
-            fakeAsset,
-            emptyAsset,
-            emptyAsset,
-            emptyAsset,
-            uint64(doneeId),
-            _amount
+            bridgeAddressId, fakeAsset, emptyAsset, emptyAsset, emptyAsset, uint64(doneeId), _amount
         );
         bytes memory err = abi.encodePacked(ErrorLib.InvalidInputA.selector);
         ROLLUP_ENCODER.registerEventToBeChecked(
-            bridgeCallData,
-            ROLLUP_ENCODER.getNextNonce(),
-            _amount,
-            0,
-            0,
-            false,
-            err
+            bridgeCallData, ROLLUP_ENCODER.getNextNonce(), _amount, 0, 0, false, err
         );
         ROLLUP_ENCODER.processRollup();
     }

--- a/src/test/bridges/element/Element.t.sol
+++ b/src/test/bridges/element/Element.t.sol
@@ -145,43 +145,25 @@ contract ElementTest is Test {
         quantities["EURSCRV"] = 1e15;
 
         _addTrancheConfig(
-            "USDC",
-            0x8a2228705ec979961F0e16df311dEbcf097A2766,
-            0x10a2F8bd81Ee2898D7eD18fb8f114034a549FA59,
-            1643382476
+            "USDC", 0x8a2228705ec979961F0e16df311dEbcf097A2766, 0x10a2F8bd81Ee2898D7eD18fb8f114034a549FA59, 1643382476
         );
 
         _addTrancheConfig(
-            "DAI",
-            0x449D7C2e096E9f867339078535b15440d42F78E8,
-            0xA47D1251CF21AD42685Cc6B8B3a186a73Dbd06cf,
-            1643382446
+            "DAI", 0x449D7C2e096E9f867339078535b15440d42F78E8, 0xA47D1251CF21AD42685Cc6B8B3a186a73Dbd06cf, 1643382446
         );
         _addTrancheConfig(
-            "DAI",
-            0x2c72692E94E757679289aC85d3556b2c0f717E0E,
-            0xEdf085f65b4F6c155e13155502Ef925c9a756003,
-            1651275535
+            "DAI", 0x2c72692E94E757679289aC85d3556b2c0f717E0E, 0xEdf085f65b4F6c155e13155502Ef925c9a756003, 1651275535
         );
 
         _addTrancheConfig(
-            "STECRV",
-            0x720465A4AE6547348056885060EEB51F9CAdb571,
-            0x544c823194218f0640daE8291c1f59752d25faE3,
-            1643382514
+            "STECRV", 0x720465A4AE6547348056885060EEB51F9CAdb571, 0x544c823194218f0640daE8291c1f59752d25faE3, 1643382514
         );
         _addTrancheConfig(
-            "STECRV",
-            0x2361102893CCabFb543bc55AC4cC8d6d0824A67E,
-            0xb03C6B351A283bc1Cd26b9cf6d7B0c4556013bDb,
-            1650025565
+            "STECRV", 0x2361102893CCabFb543bc55AC4cC8d6d0824A67E, 0xb03C6B351A283bc1Cd26b9cf6d7B0c4556013bDb, 1650025565
         );
 
         _addTrancheConfig(
-            "WBTC",
-            0x49e9e169f0B661Ea0A883f490564F4CC275123Ed,
-            0x4bd6D86dEBdB9F5413e631Ad386c4427DC9D01B2,
-            1651265241
+            "WBTC", 0x49e9e169f0B661Ea0A883f490564F4CC275123Ed, 0x4bd6D86dEBdB9F5413e631Ad386c4427DC9D01B2, 1651265241
         );
 
         _addTrancheConfig(
@@ -274,27 +256,19 @@ contract ElementTest is Test {
 
         vm.expectEmit(false, false, false, true);
         emit LogPoolAdded(
-            trancheConfigs["USDC"][0].poolAddress,
-            wrappedPositions["USDC"],
-            trancheConfigs["USDC"][0].expiry
+            trancheConfigs["USDC"][0].poolAddress, wrappedPositions["USDC"], trancheConfigs["USDC"][0].expiry
+            );
+
+        elementBridge.registerConvergentPoolAddress(
+            trancheConfigs["USDC"][0].poolAddress, wrappedPositions["USDC"], trancheConfigs["USDC"][0].expiry
         );
 
         elementBridge.registerConvergentPoolAddress(
-            trancheConfigs["USDC"][0].poolAddress,
-            wrappedPositions["USDC"],
-            trancheConfigs["USDC"][0].expiry
+            trancheConfigs["DAI"][0].poolAddress, wrappedPositions["DAI"], trancheConfigs["DAI"][0].expiry
         );
 
         elementBridge.registerConvergentPoolAddress(
-            trancheConfigs["DAI"][0].poolAddress,
-            wrappedPositions["DAI"],
-            trancheConfigs["DAI"][0].expiry
-        );
-
-        elementBridge.registerConvergentPoolAddress(
-            trancheConfigs["DAI"][1].poolAddress,
-            wrappedPositions["DAI"],
-            trancheConfigs["DAI"][1].expiry
+            trancheConfigs["DAI"][1].poolAddress, wrappedPositions["DAI"], trancheConfigs["DAI"][1].expiry
         );
     }
 
@@ -310,27 +284,21 @@ contract ElementTest is Test {
     function testRejectsIncorrectWrappedPositionForPool() public {
         vm.expectRevert(bytes(""));
         elementBridge.registerConvergentPoolAddress(
-            trancheConfigs["DAI"][0].poolAddress,
-            wrappedPositions["USDC"],
-            trancheConfigs["DAI"][0].expiry
+            trancheConfigs["DAI"][0].poolAddress, wrappedPositions["USDC"], trancheConfigs["DAI"][0].expiry
         );
     }
 
     function testRejectsInvalidWrappedPosition() public {
         vm.expectRevert(bytes(""));
         elementBridge.registerConvergentPoolAddress(
-            trancheConfigs["DAI"][0].poolAddress,
-            _randomAddress(),
-            trancheConfigs["DAI"][0].expiry
+            trancheConfigs["DAI"][0].poolAddress, _randomAddress(), trancheConfigs["DAI"][0].expiry
         );
     }
 
     function testRejectsInvalidPoolAddress() public {
         vm.expectRevert(bytes(""));
         elementBridge.registerConvergentPoolAddress(
-            _randomAddress(),
-            wrappedPositions["DAI"],
-            trancheConfigs["DAI"][0].expiry
+            _randomAddress(), wrappedPositions["DAI"], trancheConfigs["DAI"][0].expiry
         );
     }
 
@@ -339,9 +307,7 @@ contract ElementTest is Test {
         elementDeploymentValidator.validateWPAddress(wrappedPositions["DAI"]);
         vm.expectRevert(abi.encodeWithSelector(ElementBridge.UNREGISTERED_POOL.selector));
         elementBridge.registerConvergentPoolAddress(
-            trancheConfigs["DAI"][0].poolAddress,
-            wrappedPositions["DAI"],
-            trancheConfigs["DAI"][0].expiry
+            trancheConfigs["DAI"][0].poolAddress, wrappedPositions["DAI"], trancheConfigs["DAI"][0].expiry
         );
     }
 
@@ -350,9 +316,7 @@ contract ElementTest is Test {
         elementDeploymentValidator.validatePoolAddress(trancheConfigs["DAI"][0].poolAddress);
         vm.expectRevert(abi.encodeWithSelector(ElementBridge.UNREGISTERED_POSITION.selector));
         elementBridge.registerConvergentPoolAddress(
-            trancheConfigs["DAI"][0].poolAddress,
-            wrappedPositions["DAI"],
-            trancheConfigs["DAI"][0].expiry
+            trancheConfigs["DAI"][0].poolAddress, wrappedPositions["DAI"], trancheConfigs["DAI"][0].expiry
         );
     }
 
@@ -360,9 +324,7 @@ contract ElementTest is Test {
         // register neither address, pool is validated first
         vm.expectRevert(abi.encodeWithSelector(ElementBridge.UNREGISTERED_POOL.selector));
         elementBridge.registerConvergentPoolAddress(
-            trancheConfigs["DAI"][0].poolAddress,
-            wrappedPositions["DAI"],
-            trancheConfigs["DAI"][0].expiry
+            trancheConfigs["DAI"][0].poolAddress, wrappedPositions["DAI"], trancheConfigs["DAI"][0].expiry
         );
     }
 
@@ -372,9 +334,7 @@ contract ElementTest is Test {
         elementDeploymentValidator.validateWPAddress(wrappedPositions["DAI"]);
         vm.expectRevert(abi.encodeWithSelector(ElementBridge.UNREGISTERED_PAIR.selector));
         elementBridge.registerConvergentPoolAddress(
-            trancheConfigs["DAI"][0].poolAddress,
-            wrappedPositions["DAI"],
-            trancheConfigs["DAI"][0].expiry
+            trancheConfigs["DAI"][0].poolAddress, wrappedPositions["DAI"], trancheConfigs["DAI"][0].expiry
         );
     }
 
@@ -391,9 +351,7 @@ contract ElementTest is Test {
         // the first DAI pair isn't registered and should revert
         vm.expectRevert(abi.encodeWithSelector(ElementBridge.UNREGISTERED_PAIR.selector));
         elementBridge.registerConvergentPoolAddress(
-            trancheConfigs["DAI"][0].poolAddress,
-            wrappedPositions["DAI"],
-            trancheConfigs["DAI"][0].expiry
+            trancheConfigs["DAI"][0].poolAddress, wrappedPositions["DAI"], trancheConfigs["DAI"][0].expiry
         );
     }
 
@@ -410,9 +368,7 @@ contract ElementTest is Test {
         // the second DAI pair isn't registered and should revert
         vm.expectRevert(abi.encodeWithSelector(ElementBridge.UNREGISTERED_PAIR.selector));
         elementBridge.registerConvergentPoolAddress(
-            trancheConfigs["DAI"][1].poolAddress,
-            wrappedPositions["DAI"],
-            trancheConfigs["DAI"][1].expiry
+            trancheConfigs["DAI"][1].poolAddress, wrappedPositions["DAI"], trancheConfigs["DAI"][1].expiry
         );
     }
 
@@ -849,12 +805,7 @@ contract ElementTest is Test {
         vm.warp(interactionConfig.tranche.expiry + 1);
         vm.prank(address(rollupProcessor));
         elementBridge.finalise(
-            asset,
-            emptyAsset,
-            asset,
-            emptyAsset,
-            interactionConfig.nonce,
-            interactionConfig.tranche.expiry
+            asset, emptyAsset, asset, emptyAsset, interactionConfig.nonce, interactionConfig.tranche.expiry
         );
         _assertZeroBalance(address(elementBridge), interactionConfig.tranche.trancheAddress);
         _assertBalanceGt(address(elementBridge), address(tokens["DAI"]), interactionConfig.depositAmount);
@@ -879,12 +830,7 @@ contract ElementTest is Test {
         vm.warp(interactionConfig.tranche.expiry + 1);
         vm.prank(address(rollupProcessor));
         elementBridge.finalise(
-            asset,
-            emptyAsset,
-            asset,
-            emptyAsset,
-            interactionConfig.nonce,
-            interactionConfig.tranche.expiry
+            asset, emptyAsset, asset, emptyAsset, interactionConfig.nonce, interactionConfig.tranche.expiry
         );
         _assertZeroBalance(address(elementBridge), interactionConfig.tranche.trancheAddress);
         _assertBalanceGt(address(elementBridge), address(tokens["DAI"]), interactionConfig.depositAmount);
@@ -930,18 +876,11 @@ contract ElementTest is Test {
             for (uint256 configIndex = 0; configIndex < configs.length; configIndex++) {
                 for (uint256 interactionCount = 0; interactionCount < numInteractionsPerExpiry; interactionCount++) {
                     TrancheConfig storage config = configs[configIndex];
-                    Interaction memory interaction = Interaction(
-                        config,
-                        depositAmount * depositMultipliers[interactionCount],
-                        nonce,
-                        0
-                    );
+                    Interaction memory interaction =
+                        Interaction(config, depositAmount * depositMultipliers[interactionCount], nonce, 0);
                     interactions[nonce - 1] = interaction;
                     Balances memory balancesBefore = _getBalances(interaction, address(elementBridge));
-                    (uint256 outputValueA, uint256 outputValueB, bool isAsync) = _callElementConvert(
-                        asset,
-                        interaction
-                    );
+                    (uint256 outputValueA, uint256 outputValueB, bool isAsync) = _callElementConvert(asset, interaction);
                     assertEq(isAsync, true);
                     assertEq(outputValueA, 0);
                     assertEq(outputValueB, 0);
@@ -1018,18 +957,11 @@ contract ElementTest is Test {
             for (uint256 configIndex = 0; configIndex < configs.length; configIndex++) {
                 for (uint256 interactionCount = 0; interactionCount < numInteractionsPerExpiry; interactionCount++) {
                     TrancheConfig storage config = configs[configIndex];
-                    Interaction memory interaction = Interaction(
-                        config,
-                        depositAmount * depositMultipliers[interactionCount],
-                        nonce,
-                        0
-                    );
+                    Interaction memory interaction =
+                        Interaction(config, depositAmount * depositMultipliers[interactionCount], nonce, 0);
                     interactions[nonce - 1] = interaction;
                     Balances memory balancesBefore = _getBalances(interaction, address(elementBridge));
-                    (uint256 outputValueA, uint256 outputValueB, bool isAsync) = _callElementConvert(
-                        asset,
-                        interaction
-                    );
+                    (uint256 outputValueA, uint256 outputValueB, bool isAsync) = _callElementConvert(asset, interaction);
                     assertEq(isAsync, true);
                     assertEq(outputValueA, 0);
                     assertEq(outputValueB, 0);
@@ -1095,9 +1027,8 @@ contract ElementTest is Test {
                 numInteractions--;
                 // now finalise this interaction
                 Balances memory balancesBefore = _getBalances(currentInteraction, address(elementBridge));
-                (uint256 outputValueA, uint256 outputValueB, bool interactionCompleted) = _callElementFinalise(
-                    currentInteraction
-                );
+                (uint256 outputValueA, uint256 outputValueB, bool interactionCompleted) =
+                    _callElementFinalise(currentInteraction);
                 assertEq(interactionCompleted, true);
                 assertEq(outputValueB, 0);
                 assertGt(outputValueA, currentInteraction.depositAmount);
@@ -1261,23 +1192,19 @@ contract ElementTest is Test {
         uint256 totalReceived = 0;
         for (uint256 i = 0; i < numEurInteractions; i++) {
             Interaction memory interaction = interactions[i];
-            Balances memory balancesRollupBeforeManualFinalise = _getBalances(
-                interactions[i],
-                address(rollupProcessor)
-            );
+            Balances memory balancesRollupBeforeManualFinalise = _getBalances(interactions[i], address(rollupProcessor));
             Balances memory balancesBridgeBeforeManualFinalise = _getBalances(interactions[i], address(elementBridge));
             bool interactionCompleted = rollupProcessor.processAsyncDefiInteraction(interaction.nonce);
             assertEq(interactionCompleted, true);
             Balances memory balancesRollupAfterManualFinalise = _getBalances(interactions[i], address(rollupProcessor));
             Balances memory balancesBridgeAfterManualFinalise = _getBalances(interactions[i], address(elementBridge));
-            uint256 outputValue = balancesRollupAfterManualFinalise.startingAsset -
-                balancesRollupBeforeManualFinalise.startingAsset;
+            uint256 outputValue =
+                balancesRollupAfterManualFinalise.startingAsset - balancesRollupBeforeManualFinalise.startingAsset;
             totalReceived += outputValue;
             assertGt(outputValue, 0);
             assertEq(balancesBridgeAfterManualFinalise.bridgeTranche, 0);
             assertEq(
-                balancesBridgeBeforeManualFinalise.bridgeTranche,
-                i == 0 ? balancesBridgeAfterConvert.bridgeTranche : 0
+                balancesBridgeBeforeManualFinalise.bridgeTranche, i == 0 ? balancesBridgeAfterConvert.bridgeTranche : 0
             );
         }
         assertGt(totalReceived, eurDepositAmount * 15);
@@ -1307,12 +1234,8 @@ contract ElementTest is Test {
                     continue;
                 }
                 for (uint256 interactionCount = 0; interactionCount < numInteractionsPerTranche; interactionCount++) {
-                    Interaction memory interaction = Interaction(
-                        config,
-                        depositAmount * depositMultipliers[interactionCount],
-                        nonce,
-                        0
-                    );
+                    Interaction memory interaction =
+                        Interaction(config, depositAmount * depositMultipliers[interactionCount], nonce, 0);
                     interactions[nonce - 1] = interaction;
                     Balances memory balancesBefore = _getBalances(interaction, address(rollupProcessor));
                     (uint256 outputValueA, uint256 outputValueB, bool isAsync) = _callRollupConvert(asset, interaction);
@@ -1330,8 +1253,7 @@ contract ElementTest is Test {
                     );
                     // accumulate the tranche tokens collected by the bridge contract
                     bridgeBalanceByTranche[config.trancheAddress] +=
-                        balancesAfter.bridgeTranche -
-                        balancesBefore.bridgeTranche;
+                        balancesAfter.bridgeTranche - balancesBefore.bridgeTranche;
                     nonce++;
                 }
             }
@@ -1408,12 +1330,8 @@ contract ElementTest is Test {
                     continue;
                 }
                 for (uint256 interactionCount = 0; interactionCount < numInteractionsPerTranche; interactionCount++) {
-                    Interaction memory interaction = Interaction(
-                        config,
-                        depositAmount * depositMultipliers[interactionCount],
-                        nonce,
-                        0
-                    );
+                    Interaction memory interaction =
+                        Interaction(config, depositAmount * depositMultipliers[interactionCount], nonce, 0);
                     interactions[nonce - 1] = interaction;
                     Balances memory balancesBefore = _getBalances(interaction, address(rollupProcessor));
                     (uint256 outputValueA, uint256 outputValueB, bool isAsync) = _callRollupConvert(asset, interaction);
@@ -1431,8 +1349,7 @@ contract ElementTest is Test {
                     );
                     // accumulate the tranche tokens collected by the bridge contract
                     bridgeBalanceByTranche[config.trancheAddress] +=
-                        balancesAfter.bridgeTranche -
-                        balancesBefore.bridgeTranche;
+                        balancesAfter.bridgeTranche - balancesBefore.bridgeTranche;
                     nonce++;
                 }
             }
@@ -1450,18 +1367,14 @@ contract ElementTest is Test {
             for (uint256 configIndex = 0; configIndex < configs.length; configIndex++) {
                 TrancheConfig storage config = configs[configIndex];
                 if (
-                    config.expiry < expiries[numTranchesPerBatch] ||
-                    config.expiry > expiries[numTranchesPerBatch * 2 - 1]
+                    config.expiry < expiries[numTranchesPerBatch]
+                        || config.expiry > expiries[numTranchesPerBatch * 2 - 1]
                 ) {
                     continue;
                 }
                 for (uint256 interactionCount = 0; interactionCount < numInteractionsPerTranche; interactionCount++) {
-                    Interaction memory interaction = Interaction(
-                        config,
-                        depositAmount * depositMultipliers[interactionCount],
-                        nonce,
-                        0
-                    );
+                    Interaction memory interaction =
+                        Interaction(config, depositAmount * depositMultipliers[interactionCount], nonce, 0);
                     interactions[nonce - 1] = interaction;
                     Balances memory balancesBefore = _getBalances(interaction, address(rollupProcessor));
                     (uint256 outputValueA, uint256 outputValueB, bool isAsync) = _callRollupConvert(asset, interaction);
@@ -1475,8 +1388,7 @@ contract ElementTest is Test {
                     );
                     // accumulate the tranche tokens collected by the bridge contract
                     bridgeBalanceByTranche[config.trancheAddress] +=
-                        balancesAfter.bridgeTranche -
-                        balancesBefore.bridgeTranche;
+                        balancesAfter.bridgeTranche - balancesBefore.bridgeTranche;
                     nonce++;
                 }
             }
@@ -1489,8 +1401,8 @@ contract ElementTest is Test {
             Interaction memory interaction = interactions[interactionIndex];
             (bool finalised, uint256 interactionOutputValue) = rollupProcessor.getDefiResult(interaction.nonce);
             if (interactionIndex < numInteractionsInFirstBatch) {
-                uint256 percentOfDeposit = (interaction.depositAmount * 100) /
-                    (15 * quantities[interaction.tranche.asset]);
+                uint256 percentOfDeposit =
+                    (interaction.depositAmount * 100) / (15 * quantities[interaction.tranche.asset]);
                 // this is the amount of tranche tokens collected by the bridge contract. These should have been withdrawn pretty much one for one into the end asset
                 uint256 totalReceipt = bridgeBalanceByTranche[interaction.tranche.trancheAddress];
                 _assertWithinOnePercentagePoint(interactionOutputValue, totalReceipt, percentOfDeposit);
@@ -1613,23 +1525,19 @@ contract ElementTest is Test {
         uint256 totalReceived = 0;
         for (uint256 i = 0; i < numEurInteractions; i++) {
             Interaction memory interaction = interactions[i];
-            Balances memory balancesRollupBeforeManualFinalise = _getBalances(
-                interactions[i],
-                address(rollupProcessor)
-            );
+            Balances memory balancesRollupBeforeManualFinalise = _getBalances(interactions[i], address(rollupProcessor));
             Balances memory balancesBridgeBeforeManualFinalise = _getBalances(interactions[i], address(elementBridge));
             bool interactionCompleted = rollupProcessor.processAsyncDefiInteraction(interaction.nonce);
             assertEq(interactionCompleted, true);
             Balances memory balancesRollupAfterManualFinalise = _getBalances(interactions[i], address(rollupProcessor));
             Balances memory balancesBridgeAfterManualFinalise = _getBalances(interactions[i], address(elementBridge));
-            uint256 outputValue = balancesRollupAfterManualFinalise.startingAsset -
-                balancesRollupBeforeManualFinalise.startingAsset;
+            uint256 outputValue =
+                balancesRollupAfterManualFinalise.startingAsset - balancesRollupBeforeManualFinalise.startingAsset;
             totalReceived += outputValue;
             assertGt(outputValue, 0);
             assertEq(balancesBridgeAfterManualFinalise.bridgeTranche, 0);
             assertEq(
-                balancesBridgeBeforeManualFinalise.bridgeTranche,
-                i == 0 ? balancesBridgeAfterConvert.bridgeTranche : 0
+                balancesBridgeBeforeManualFinalise.bridgeTranche, i == 0 ? balancesBridgeAfterConvert.bridgeTranche : 0
             );
         }
         assertGt(totalReceived, eurDepositAmount * 15);
@@ -1691,9 +1599,7 @@ contract ElementTest is Test {
         assertLt(balancesRollupAfter.startingAsset, usdcDepositAmount * 2);
         // rollup balance of asset should be 20%
         _assertWithinOnePercentagePoint(
-            balancesRollupAfter.startingAsset,
-            balancesRollupAfter.startingAsset + balancesBridgeAfter.startingAsset,
-            20
+            balancesRollupAfter.startingAsset, balancesRollupAfter.startingAsset + balancesBridgeAfter.startingAsset, 20
         );
 
         for (uint256 i = 0; i < numUsdcInteractions; i++) {
@@ -1766,9 +1672,7 @@ contract ElementTest is Test {
             assertEq(finalised, i < numExpectedFinalisedInteractions);
             if (i < numExpectedFinalisedInteractions) {
                 _assertWithinOnePercentagePoint(
-                    outputValueA,
-                    balancesRollupAfter.startingAsset + balancesBridgeAfter.startingAsset,
-                    20
+                    outputValueA, balancesRollupAfter.startingAsset + balancesBridgeAfter.startingAsset, 20
                 );
             } else {
                 assertEq(outputValueA, 0);
@@ -1840,9 +1744,7 @@ contract ElementTest is Test {
             assertEq(finalised, i < numExpectedFinalisedInteractions);
             if (i < numExpectedFinalisedInteractions) {
                 _assertWithinOnePercentagePoint(
-                    outputValueA,
-                    balancesRollupAfter.startingAsset + balancesBridgeAfter.startingAsset,
-                    20
+                    outputValueA, balancesRollupAfter.startingAsset + balancesBridgeAfter.startingAsset, 20
                 );
             } else {
                 assertEq(outputValueA, 0);
@@ -1900,11 +1802,7 @@ contract ElementTest is Test {
 
     function _callElementConvert(string memory _asset, Interaction memory _interaction)
         private
-        returns (
-            uint256 outputValueA,
-            uint256 outputValueB,
-            bool isAsync
-        )
+        returns (uint256 outputValueA, uint256 outputValueB, bool isAsync)
     {
         AztecTypes.AztecAsset memory assetData = AztecTypes.AztecAsset({
             id: 1,
@@ -1929,11 +1827,7 @@ contract ElementTest is Test {
 
     function _callElementFinalise(Interaction memory _interaction)
         private
-        returns (
-            uint256 outputValueA,
-            uint256 outputValueB,
-            bool interactionCompleted
-        )
+        returns (uint256 outputValueA, uint256 outputValueB, bool interactionCompleted)
     {
         AztecTypes.AztecAsset memory asset = AztecTypes.AztecAsset({
             id: 1,
@@ -1942,12 +1836,7 @@ contract ElementTest is Test {
         });
         vm.prank(address(rollupProcessor));
         (uint256 outputValueALocal, uint256 outputValueBLocal, bool interactionCompletedLocal) = elementBridge.finalise(
-            asset,
-            emptyAsset,
-            asset,
-            emptyAsset,
-            _interaction.nonce,
-            _interaction.tranche.expiry
+            asset, emptyAsset, asset, emptyAsset, _interaction.nonce, _interaction.tranche.expiry
         );
         outputValueA = outputValueALocal;
         outputValueB = outputValueBLocal;
@@ -1956,11 +1845,7 @@ contract ElementTest is Test {
 
     function _callRollupConvert(string memory _asset, Interaction memory _interaction)
         private
-        returns (
-            uint256 outputValueA,
-            uint256 outputValueB,
-            bool isAsync
-        )
+        returns (uint256 outputValueA, uint256 outputValueB, bool isAsync)
     {
         AztecTypes.AztecAsset memory assetData = AztecTypes.AztecAsset({
             id: 1,
@@ -1972,14 +1857,7 @@ contract ElementTest is Test {
         uint256 deposit = _interaction.depositAmount;
         vm.prank(address(rollupProcessor));
         (uint256 outputValueALocal, uint256 outputValueBLocal, bool isAsyncLocal) = rollupProcessor.convert(
-            address(elementBridge),
-            assetData,
-            emptyAsset,
-            assetData,
-            emptyAsset,
-            deposit,
-            nonce,
-            expiry
+            address(elementBridge), assetData, emptyAsset, assetData, emptyAsset, deposit, nonce, expiry
         );
         outputValueA = outputValueALocal;
         outputValueB = outputValueBLocal;
@@ -1994,41 +1872,25 @@ contract ElementTest is Test {
         _assertBalanceGt(_owner, _erc20, 0);
     }
 
-    function _assertBalanceGt(
-        address _owner,
-        address _erc20,
-        uint256 _value
-    ) private {
+    function _assertBalanceGt(address _owner, address _erc20, uint256 _value) private {
         assertGt(IERC20(_erc20).balanceOf(_owner), _value);
     }
 
-    function _assertWithinOnePercentagePoint(
-        uint256 _quantity,
-        uint256 _total,
-        uint256 _targetPercent
-    ) private {
+    function _assertWithinOnePercentagePoint(uint256 _quantity, uint256 _total, uint256 _targetPercent) private {
         uint256 percent = (_quantity * 100) / _total;
         int256 diff = int256(percent) - int256(_targetPercent);
         uint256 absDiff = diff >= 0 ? uint256(diff) : uint256(-diff);
         assertLt(absDiff, 2);
     }
 
-    function _setTokenBalance(
-        string memory _asset,
-        address _account,
-        uint256 _balance
-    ) private {
+    function _setTokenBalance(string memory _asset, address _account, uint256 _balance) private {
         address tokenAddress = address(tokens[_asset]);
         deal(tokenAddress, _account, _balance);
 
         assertEq(tokens[_asset].balanceOf(_account), _balance, "wrong balance");
     }
 
-    function _increaseTokenBalance(
-        string memory _asset,
-        address _account,
-        uint256 _additionalBalance
-    ) private {
+    function _increaseTokenBalance(string memory _asset, address _account, uint256 _additionalBalance) private {
         address tokenAddress = address(tokens[_asset]);
         uint256 currentBalance = tokens[_asset].balanceOf(_account);
         uint256 newBalance = currentBalance + _additionalBalance;
@@ -2044,11 +1906,10 @@ contract ElementTest is Test {
         slot = bytes32(foundSlot);
     }
 
-    function _setSpeedbumpSlot(
-        string memory _asset,
-        uint256 _expiry,
-        uint256 _speedbump
-    ) private returns (uint256 newSpeedbump) {
+    function _setSpeedbumpSlot(string memory _asset, uint256 _expiry, uint256 _speedbump)
+        private
+        returns (uint256 newSpeedbump)
+    {
         address trancheAddress = _deriveTranche(_asset, _expiry);
         bytes32 slot = _findSpeedbumpSlot(_asset, _expiry);
         vm.store(trancheAddress, slot, bytes32(_speedbump));
@@ -2088,12 +1949,9 @@ contract ElementTest is Test {
         }
     }
 
-    function _addTrancheConfig(
-        string memory _asset,
-        address _trancheAddress,
-        address _poolAddress,
-        uint64 _expiry
-    ) private {
+    function _addTrancheConfig(string memory _asset, address _trancheAddress, address _poolAddress, uint64 _expiry)
+        private
+    {
         TrancheConfig[] storage configs = trancheConfigs[_asset];
         configs.push(TrancheConfig(_asset, _trancheAddress, _poolAddress, _expiry));
         if (configs.length == 1) {

--- a/src/test/bridges/element/Heap.t.sol
+++ b/src/test/bridges/element/Heap.t.sol
@@ -92,38 +92,8 @@ contract HeapTest is Test {
     }
 
     function testWorksWithDuplicateValues() public {
-        uint8[30] memory values = [
-            1,
-            1,
-            1,
-            2,
-            2,
-            2,
-            3,
-            3,
-            3,
-            4,
-            4,
-            4,
-            5,
-            5,
-            5,
-            6,
-            6,
-            6,
-            7,
-            7,
-            7,
-            8,
-            8,
-            8,
-            9,
-            9,
-            9,
-            10,
-            10,
-            10
-        ];
+        uint8[30] memory values =
+            [1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 5, 5, 5, 6, 6, 6, 7, 7, 7, 8, 8, 8, 9, 9, 9, 10, 10, 10];
         for (uint256 i = 0; i < values.length; i++) {
             heap.add(values[i]);
         }

--- a/src/test/bridges/element/aztecmocks/DefiBridgeProxy.sol
+++ b/src/test/bridges/element/aztecmocks/DefiBridgeProxy.sol
@@ -63,7 +63,7 @@ contract DefiBridgeProxy {
      * @param auxInputData Optional custom data to be sent to the bridge (defined in the L2 SNARK circuits when creating claim notes)
      * @param ethPaymentsSlot The slot value of the `ethPayments` storage mapping in RollupProcessor.sol!
      * @param rollupBeneficiary The address that should be payed any fees / subsidy for executing this bridge.
-
+     *
      * We assume this contract is called from the RollupProcessor via `delegateCall`,
      * if not... this contract behaviour is undefined! So don't do that.
      * The idea here is that, if the defi bridge has returned native ETH, they will do so via calling
@@ -96,14 +96,7 @@ contract DefiBridgeProxy {
         uint256 auxInputData, // (auxData)
         uint256 ethPaymentsSlot,
         address rollupBeneficiary
-    )
-        external
-        returns (
-            uint256 outputValueA,
-            uint256 outputValueB,
-            bool isAsync
-        )
-    {
+    ) external returns (uint256 outputValueA, uint256 outputValueB, bool isAsync) {
         if (inputAssetA.assetType == AztecTypes.AztecAssetType.ERC20) {
             // Transfer totalInputValue to the bridge contract if erc20. ETH is sent on call to convert.
             TokenTransfers.safeTransferTo(inputAssetA.erc20Address, bridgeAddress, totalInputValue);
@@ -114,10 +107,10 @@ contract DefiBridgeProxy {
         }
         // Call bridge.convert(), which will return output values for the two output assets.
         // If input is ETH, send it along with call to convert.
-        uint256 ethValue = (inputAssetA.assetType == AztecTypes.AztecAssetType.ETH ||
-            inputAssetB.assetType == AztecTypes.AztecAssetType.ETH)
-            ? totalInputValue
-            : 0;
+        uint256 ethValue = (
+            inputAssetA.assetType == AztecTypes.AztecAssetType.ETH
+                || inputAssetB.assetType == AztecTypes.AztecAssetType.ETH
+        ) ? totalInputValue : 0;
         (outputValueA, outputValueB, isAsync) = IDefiBridge(bridgeAddress).convert{value: ethValue}(
             inputAssetA,
             inputAssetB,

--- a/src/test/bridges/element/aztecmocks/RollupProcessor.sol
+++ b/src/test/bridges/element/aztecmocks/RollupProcessor.sol
@@ -121,13 +121,13 @@ contract RollupProcessor {
 
         (uint256 outputValueA, uint256 outputValueB, bool interactionComplete) = IDefiBridge(interaction.bridgeAddress)
             .finalise(
-                interaction.inputAssetA,
-                interaction.inputAssetB,
-                interaction.outputAssetA,
-                interaction.outputAssetB,
-                interaction.interactionNonce,
-                uint64(interaction.auxInputData)
-            );
+            interaction.inputAssetA,
+            interaction.inputAssetB,
+            interaction.outputAssetA,
+            interaction.outputAssetB,
+            interaction.interactionNonce,
+            uint64(interaction.auxInputData)
+        );
         completed = interactionComplete;
 
         if (outputValueB > 0 && interaction.outputAssetB.assetType == AztecTypes.AztecAssetType.NOT_USED) {
@@ -144,27 +144,16 @@ contract RollupProcessor {
         } else {
             // transfer output tokens to rollup contract
             transferTokensAsync(
-                address(interaction.bridgeAddress),
-                interaction.outputAssetA,
-                outputValueA,
-                interaction.interactionNonce
+                address(interaction.bridgeAddress), interaction.outputAssetA, outputValueA, interaction.interactionNonce
             );
             transferTokensAsync(
-                address(interaction.bridgeAddress),
-                interaction.outputAssetB,
-                outputValueB,
-                interaction.interactionNonce
+                address(interaction.bridgeAddress), interaction.outputAssetB, outputValueB, interaction.interactionNonce
             );
         }
 
         emit DefiBridgeProcessed(
-            0,
-            interaction.interactionNonce,
-            interaction.totalInputValue,
-            outputValueA,
-            outputValueB,
-            true
-        );
+            0, interaction.interactionNonce, interaction.totalInputValue, outputValueA, outputValueB, true
+            );
         interaction.finalised = true;
         interaction.outputValueA = outputValueA;
         interaction.outputValueB = outputValueB;
@@ -227,13 +216,8 @@ contract RollupProcessor {
             (uint256 outputValueA, uint256 outputValueB, bool isAsync) = abi.decode(result, (uint256, uint256, bool));
             if (!isAsync) {
                 emit DefiBridgeProcessed(
-                    0,
-                    convertArgs.interactionNonce,
-                    convertArgs.totalInputValue,
-                    outputValueA,
-                    outputValueB,
-                    true
-                );
+                    0, convertArgs.interactionNonce, convertArgs.totalInputValue, outputValueA, outputValueB, true
+                    );
             } else {
                 emit AsyncDefiBridgeProcessed(0, convertArgs.interactionNonce, convertArgs.totalInputValue);
             }
@@ -253,14 +237,7 @@ contract RollupProcessor {
         uint256 totalInputValue,
         uint256 interactionNonce,
         uint256 auxInputData // (auxData)
-    )
-        external
-        returns (
-            uint256 outputValueA,
-            uint256 outputValueB,
-            bool isAsync
-        )
-    {
+    ) external returns (uint256 outputValueA, uint256 outputValueB, bool isAsync) {
         require(defiInteractions[interactionNonce].auxInputData == 0, "Rollup Contract: INTERACTION_ALREADY_EXISTS");
 
         uint256 ethPayments_slot;

--- a/src/test/bridges/element/aztecmocks/libraries/TokenTransfers.sol
+++ b/src/test/bridges/element/aztecmocks/libraries/TokenTransfers.sol
@@ -17,11 +17,7 @@ library TokenTransfers {
      * @param to Who are we sending tokens to?
      * @param amount How many tokens are we transferring?
      */
-    function safeTransferTo(
-        address tokenAddress,
-        address to,
-        uint256 amount
-    ) internal {
+    function safeTransferTo(address tokenAddress, address to, uint256 amount) internal {
         // The ERC20 token standard states that:
         // 1. failed transfers must throw
         // 2. the result of the transfer (success/fail) is returned as a boolean
@@ -62,12 +58,7 @@ library TokenTransfers {
      * @param target Who are we transferring tokens to?
      * @param amount How many tokens are being transferred?
      */
-    function safeTransferFrom(
-        address tokenAddress,
-        address source,
-        address target,
-        uint256 amount
-    ) internal {
+    function safeTransferFrom(address tokenAddress, address source, address target, uint256 amount) internal {
         assembly {
             // call tokenAddress.transferFrom(source, target, value)
             let mPtr := mload(0x40)
@@ -91,17 +82,12 @@ library TokenTransfers {
      * @param amount How many tokens are being transferred?
      * @param gasToSend Amount of gas to send the contract. If value is 0, function uses gas() instead
      */
-    function transferToDoNotBubbleErrors(
-        address tokenAddress,
-        address to,
-        uint256 amount,
-        uint256 gasToSend
-    ) internal {
+    function transferToDoNotBubbleErrors(address tokenAddress, address to, uint256 amount, uint256 gasToSend)
+        internal
+    {
         assembly {
             let callGas := gas()
-            if gasToSend {
-                callGas := gasToSend
-            }
+            if gasToSend { callGas := gasToSend }
             let ptr := mload(0x40)
             mstore(ptr, TRANSFER_SELECTOR)
             mstore(add(ptr, 0x4), to)
@@ -127,9 +113,7 @@ library TokenTransfers {
     ) internal {
         assembly {
             let callGas := gas()
-            if gasToSend {
-                callGas := gasToSend
-            }
+            if gasToSend { callGas := gasToSend }
             let mPtr := mload(0x40)
             mstore(mPtr, TRANSFER_FROM_SELECTOR)
             mstore(add(mPtr, 0x04), source)

--- a/src/test/bridges/erc4626/ERC4626.t.sol
+++ b/src/test/bridges/erc4626/ERC4626.t.sol
@@ -111,39 +111,24 @@ contract ERC4626Test is BridgeTestBase {
 
             bridge.listVault(shares[i].erc20Address);
 
-            uint256 bridgeCallData = ROLLUP_ENCODER.defiInteractionL2(
-                id,
-                assets[i],
-                emptyAsset,
-                shares[i],
-                emptyAsset,
-                0,
-                assetAmount
-            );
-            (uint256 outputValueA, uint256 outputValueB, bool isAsync) = ROLLUP_ENCODER
-                .processRollupAndGetBridgeResult();
+            uint256 bridgeCallData =
+                ROLLUP_ENCODER.defiInteractionL2(id, assets[i], emptyAsset, shares[i], emptyAsset, 0, assetAmount);
+            (uint256 outputValueA, uint256 outputValueB, bool isAsync) =
+                ROLLUP_ENCODER.processRollupAndGetBridgeResult();
 
             assertEq(outputValueA, expectedAmount, "Received amount of shares differs from the expected one");
             assertEq(outputValueB, 0, "Non-zero outputValueB");
             assertFalse(isAsync, "Bridge is not synchronous");
 
-            uint256 processorShareBalanceBeforeRedeem = IERC20(shares[i].erc20Address).balanceOf(
-                address(ROLLUP_PROCESSOR)
-            );
+            uint256 processorShareBalanceBeforeRedeem =
+                IERC20(shares[i].erc20Address).balanceOf(address(ROLLUP_PROCESSOR));
 
             // Immediately redeem the shares
             uint256 redeemAmount = bound(_shareAmount, 10, outputValueA);
             uint256 expectedAssetAmountReturned = IERC4626(shares[i].erc20Address).previewRedeem(redeemAmount);
 
-            bridgeCallData = ROLLUP_ENCODER.defiInteractionL2(
-                id,
-                shares[i],
-                emptyAsset,
-                assets[i],
-                emptyAsset,
-                1,
-                redeemAmount
-            );
+            bridgeCallData =
+                ROLLUP_ENCODER.defiInteractionL2(id, shares[i], emptyAsset, assets[i], emptyAsset, 1, redeemAmount);
             (outputValueA, outputValueB, isAsync) = ROLLUP_ENCODER.processRollupAndGetBridgeResult();
 
             assertEq(
@@ -152,9 +137,7 @@ contract ERC4626Test is BridgeTestBase {
                 "Incorrect RollupProcessor share balance after redeem"
             );
             assertEq(
-                outputValueA,
-                expectedAssetAmountReturned,
-                "Received amount of asset differs from the expected one"
+                outputValueA, expectedAssetAmountReturned, "Received amount of asset differs from the expected one"
             );
             assertEq(outputValueB, 0, "Non-zero outputValueB");
             assertFalse(isAsync, "Bridge is not synchronous");
@@ -175,15 +158,8 @@ contract ERC4626Test is BridgeTestBase {
 
         uint256 expectedAmount = IERC4626(shareAsset.erc20Address).previewDeposit(assetAmount);
 
-        uint256 bridgeCallData = ROLLUP_ENCODER.defiInteractionL2(
-            id,
-            ethAsset,
-            emptyAsset,
-            shareAsset,
-            emptyAsset,
-            0,
-            assetAmount
-        );
+        uint256 bridgeCallData =
+            ROLLUP_ENCODER.defiInteractionL2(id, ethAsset, emptyAsset, shareAsset, emptyAsset, 0, assetAmount);
         (uint256 outputValueA, uint256 outputValueB, bool isAsync) = ROLLUP_ENCODER.processRollupAndGetBridgeResult();
 
         assertEq(outputValueA, expectedAmount, "Received amount of shares differs from the expected one");
@@ -194,15 +170,8 @@ contract ERC4626Test is BridgeTestBase {
         // Immediately redeem the shares
         uint256 redeemAmount = outputValueA;
 
-        bridgeCallData = ROLLUP_ENCODER.defiInteractionL2(
-            id,
-            shareAsset,
-            emptyAsset,
-            ethAsset,
-            emptyAsset,
-            1,
-            redeemAmount
-        );
+        bridgeCallData =
+            ROLLUP_ENCODER.defiInteractionL2(id, shareAsset, emptyAsset, ethAsset, emptyAsset, 1, redeemAmount);
         (outputValueA, outputValueB, isAsync) = ROLLUP_ENCODER.processRollupAndGetBridgeResult();
 
         assertApproxEqAbs(outputValueA, assetAmount, 2, "Received amount of asset differs from the expected one");
@@ -216,11 +185,7 @@ contract ERC4626Test is BridgeTestBase {
         testFullFlowWithYieldAndSubsidy(1e18, 1e18, 1e18);
     }
 
-    function testFullFlowWithYieldAndSubsidy(
-        uint96 _assetAmount,
-        uint96 _shareAmount,
-        uint96 _yield
-    ) public {
+    function testFullFlowWithYieldAndSubsidy(uint96 _assetAmount, uint96 _shareAmount, uint96 _yield) public {
         uint256 assetAmount = bound(_assetAmount, 10, type(uint96).max);
         IERC20 weth = IERC20(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
 
@@ -254,15 +219,8 @@ contract ERC4626Test is BridgeTestBase {
 
         uint256 expectedAmount = IERC4626(shareAsset.erc20Address).previewDeposit(assetAmount);
 
-        uint256 bridgeCallData = ROLLUP_ENCODER.defiInteractionL2(
-            id,
-            ethAsset,
-            emptyAsset,
-            shareAsset,
-            emptyAsset,
-            0,
-            assetAmount
-        );
+        uint256 bridgeCallData =
+            ROLLUP_ENCODER.defiInteractionL2(id, ethAsset, emptyAsset, shareAsset, emptyAsset, 0, assetAmount);
         (uint256 outputValueA, uint256 outputValueB, bool isAsync) = ROLLUP_ENCODER.processRollupAndGetBridgeResult();
 
         assertEq(outputValueA, expectedAmount, "Received amount of shares differs from the expected one");
@@ -272,23 +230,14 @@ contract ERC4626Test is BridgeTestBase {
         uint256 newVaultBalance = bound(_yield, assetAmount, assetAmount + 100 ether);
         deal(address(weth), wethVault, newVaultBalance);
 
-        uint256 processorShareBalanceBeforeRedeem = IERC20(shareAsset.erc20Address).balanceOf(
-            address(ROLLUP_PROCESSOR)
-        );
+        uint256 processorShareBalanceBeforeRedeem = IERC20(shareAsset.erc20Address).balanceOf(address(ROLLUP_PROCESSOR));
 
         // Immediately redeem the shares
         uint256 redeemAmount = bound(_shareAmount, 1, outputValueA);
         uint256 expectedAssetAmountReturned = IERC4626(shareAsset.erc20Address).previewRedeem(redeemAmount);
 
-        bridgeCallData = ROLLUP_ENCODER.defiInteractionL2(
-            id,
-            shareAsset,
-            emptyAsset,
-            ethAsset,
-            emptyAsset,
-            1,
-            redeemAmount
-        );
+        bridgeCallData =
+            ROLLUP_ENCODER.defiInteractionL2(id, shareAsset, emptyAsset, ethAsset, emptyAsset, 1, redeemAmount);
         (outputValueA, outputValueB, isAsync) = ROLLUP_ENCODER.processRollupAndGetBridgeResult();
 
         assertEq(

--- a/src/test/bridges/example/ExampleUnit.t.sol
+++ b/src/test/bridges/example/ExampleUnit.t.sol
@@ -60,11 +60,8 @@ contract ExampleUnitTest is BridgeTestBase {
     }
 
     function testInvalidOutputAssetType() public {
-        AztecTypes.AztecAsset memory inputAssetA = AztecTypes.AztecAsset({
-            id: 1,
-            erc20Address: DAI,
-            assetType: AztecTypes.AztecAssetType.ERC20
-        });
+        AztecTypes.AztecAsset memory inputAssetA =
+            AztecTypes.AztecAsset({id: 1, erc20Address: DAI, assetType: AztecTypes.AztecAssetType.ERC20});
         vm.expectRevert(ErrorLib.InvalidOutputA.selector);
         bridge.convert(inputAssetA, emptyAsset, emptyAsset, emptyAsset, 0, 0, 0, address(0));
     }
@@ -79,11 +76,8 @@ contract ExampleUnitTest is BridgeTestBase {
         vm.warp(block.timestamp + 1 days);
 
         // Define input and output assets
-        AztecTypes.AztecAsset memory inputAssetA = AztecTypes.AztecAsset({
-            id: 1,
-            erc20Address: DAI,
-            assetType: AztecTypes.AztecAssetType.ERC20
-        });
+        AztecTypes.AztecAsset memory inputAssetA =
+            AztecTypes.AztecAsset({id: 1, erc20Address: DAI, assetType: AztecTypes.AztecAssetType.ERC20});
 
         AztecTypes.AztecAsset memory outputAssetA = inputAssetA;
 

--- a/src/test/bridges/lido/Lido.t.sol
+++ b/src/test/bridges/lido/Lido.t.sol
@@ -109,11 +109,11 @@ contract LidoTest is BridgeTestBase {
     }
 
     /**
-        Testing flow:
-        1. Send ETH to bridge
-        2. Get back wstETH
-        3. Send wstETH to bridge
-        4. Get back ETH
+     * Testing flow:
+     *     1. Send ETH to bridge
+     *     2. Get back wstETH
+     *     3. Send wstETH to bridge
+     *     4. Get back ETH
      */
     function validateLidoBridge(uint256 _balance, uint256 _depositAmount) public {
         // Send ETH to bridge
@@ -133,24 +133,11 @@ contract LidoTest is BridgeTestBase {
 
         uint256 wstEthIncrease = _computeEthToWST(_depositAmount);
 
-        uint256 bridgeCallData = ROLLUP_ENCODER.defiInteractionL2(
-            idIn,
-            ethAsset,
-            emptyAsset,
-            wstETHAsset,
-            emptyAsset,
-            0,
-            _depositAmount
-        );
+        uint256 bridgeCallData =
+            ROLLUP_ENCODER.defiInteractionL2(idIn, ethAsset, emptyAsset, wstETHAsset, emptyAsset, 0, _depositAmount);
 
         ROLLUP_ENCODER.registerEventToBeChecked(
-            bridgeCallData,
-            ROLLUP_ENCODER.getNextNonce(),
-            _depositAmount,
-            wstEthIncrease,
-            0,
-            true,
-            ""
+            bridgeCallData, ROLLUP_ENCODER.getNextNonce(), _depositAmount, wstEthIncrease, 0, true, ""
         );
         ROLLUP_ENCODER.processRollup();
 
@@ -170,24 +157,11 @@ contract LidoTest is BridgeTestBase {
 
         uint256 expectedEth = _computeWSTHToEth(_depositAmount);
 
-        uint256 bridgeCallData = ROLLUP_ENCODER.defiInteractionL2(
-            idOut,
-            wstETHAsset,
-            emptyAsset,
-            ethAsset,
-            emptyAsset,
-            0,
-            _depositAmount
-        );
+        uint256 bridgeCallData =
+            ROLLUP_ENCODER.defiInteractionL2(idOut, wstETHAsset, emptyAsset, ethAsset, emptyAsset, 0, _depositAmount);
 
         ROLLUP_ENCODER.registerEventToBeChecked(
-            bridgeCallData,
-            ROLLUP_ENCODER.getNextNonce(),
-            _depositAmount,
-            expectedEth,
-            0,
-            true,
-            ""
+            bridgeCallData, ROLLUP_ENCODER.getNextNonce(), _depositAmount, expectedEth, 0, true, ""
         );
         ROLLUP_ENCODER.processRollup();
 

--- a/src/test/bridges/liquity/StabilityPoolBridgeE2E.t.sol
+++ b/src/test/bridges/liquity/StabilityPoolBridgeE2E.t.sol
@@ -63,26 +63,13 @@ contract StabilityPoolBridgeE2ETest is BridgeTestBase {
         deal(address(LUSD), address(ROLLUP_PROCESSOR), _depositAmount);
 
         // Compute deposit calldata
-        uint256 bridgeCallData = ROLLUP_ENCODER.defiInteractionL2(
-            id,
-            lusdAsset,
-            emptyAsset,
-            spbAsset,
-            emptyAsset,
-            0,
-            _depositAmount
-        );
+        uint256 bridgeCallData =
+            ROLLUP_ENCODER.defiInteractionL2(id, lusdAsset, emptyAsset, spbAsset, emptyAsset, 0, _depositAmount);
 
         uint256 stabilityPoolBalanceBefore = LUSD.balanceOf(stabilityPool);
 
         ROLLUP_ENCODER.registerEventToBeChecked(
-            bridgeCallData,
-            ROLLUP_ENCODER.getNextNonce(),
-            _depositAmount,
-            _depositAmount,
-            0,
-            true,
-            ""
+            bridgeCallData, ROLLUP_ENCODER.getNextNonce(), _depositAmount, _depositAmount, 0, true, ""
         );
         ROLLUP_ENCODER.processRollup();
 
@@ -92,9 +79,7 @@ contract StabilityPoolBridgeE2ETest is BridgeTestBase {
             "Stability pool balance didn't rise enough"
         );
         assertEq(
-            bridge.balanceOf(address(ROLLUP_PROCESSOR)),
-            _depositAmount,
-            "Incorrect SPB balance of rollup processor"
+            bridge.balanceOf(address(ROLLUP_PROCESSOR)), _depositAmount, "Incorrect SPB balance of rollup processor"
         );
 
         // WITHDRAWAL
@@ -103,7 +88,7 @@ contract StabilityPoolBridgeE2ETest is BridgeTestBase {
 
         uint256 processorBalanceBefore = LUSD.balanceOf(address(ROLLUP_PROCESSOR));
 
-        (uint256 outputValueA, uint256 outputValueB, ) = ROLLUP_ENCODER.processRollupAndGetBridgeResult();
+        (uint256 outputValueA, uint256 outputValueB,) = ROLLUP_ENCODER.processRollupAndGetBridgeResult();
 
         assertGe(outputValueA, _depositAmount, "Output value not bigger than deposit");
         assertEq(outputValueB, 0, "Output value B is not 0");

--- a/src/test/bridges/liquity/StabilityPoolBridgeUnit.t.sol
+++ b/src/test/bridges/liquity/StabilityPoolBridgeUnit.t.sol
@@ -52,16 +52,10 @@ contract StabilityPoolBridgeUnitTest is TestUtil {
         uint256 depositAmount = bound(_depositAmount, 10, type(uint96).max);
         uint256 spbReceived = _deposit(depositAmount);
 
-        AztecTypes.AztecAsset memory inputAssetA = AztecTypes.AztecAsset(
-            2,
-            address(bridge),
-            AztecTypes.AztecAssetType.ERC20
-        );
-        AztecTypes.AztecAsset memory outputAssetA = AztecTypes.AztecAsset(
-            1,
-            tokens["LUSD"].addr,
-            AztecTypes.AztecAssetType.ERC20
-        );
+        AztecTypes.AztecAsset memory inputAssetA =
+            AztecTypes.AztecAsset(2, address(bridge), AztecTypes.AztecAssetType.ERC20);
+        AztecTypes.AztecAsset memory outputAssetA =
+            AztecTypes.AztecAsset(1, tokens["LUSD"].addr, AztecTypes.AztecAssetType.ERC20);
 
         // Transfer StabilityPoolBridge accounting token (SPB) back to the bridge
         IERC20(inputAssetA.erc20Address).transfer(address(bridge), spbReceived);
@@ -73,16 +67,8 @@ contract StabilityPoolBridgeUnitTest is TestUtil {
         // Withdraw LUSD from StabilityPool through the bridge
         uint256 withdrawalAmount = bound(_withdrawalAmount, 10, spbReceived);
 
-        (uint256 outputValueA, , ) = bridge.convert(
-            inputAssetA,
-            emptyAsset,
-            outputAssetA,
-            emptyAsset,
-            withdrawalAmount,
-            1,
-            0,
-            address(0)
-        );
+        (uint256 outputValueA,,) =
+            bridge.convert(inputAssetA, emptyAsset, outputAssetA, emptyAsset, withdrawalAmount, 1, 0, address(0));
 
         // Check the total supply of SPB token is spbReceived - withdrawalAmount
         assertEq(bridge.totalSupply(), spbReceived - withdrawalAmount);
@@ -177,7 +163,7 @@ contract StabilityPoolBridgeUnitTest is TestUtil {
         deal(tokens["LUSD"].addr, address(bridge), _depositAmount);
 
         // 2. Deposit LUSD to the StabilityPool contract through the bridge
-        (uint256 outputValueA, , ) = bridge.convert(
+        (uint256 outputValueA,,) = bridge.convert(
             AztecTypes.AztecAsset(1, tokens["LUSD"].addr, AztecTypes.AztecAssetType.ERC20),
             emptyAsset,
             AztecTypes.AztecAsset(2, address(bridge), AztecTypes.AztecAssetType.ERC20),

--- a/src/test/bridges/liquity/StakingBridgeE2E.t.sol
+++ b/src/test/bridges/liquity/StakingBridgeE2E.t.sol
@@ -60,26 +60,13 @@ contract StakingBridgeE2ETest is BridgeTestBase {
         deal(address(LQTY), address(ROLLUP_PROCESSOR), _depositAmount);
 
         // Compute deposit calldata
-        uint256 bridgeCallData = ROLLUP_ENCODER.defiInteractionL2(
-            id,
-            lqtyAsset,
-            emptyAsset,
-            sbAsset,
-            emptyAsset,
-            0,
-            _depositAmount
-        );
+        uint256 bridgeCallData =
+            ROLLUP_ENCODER.defiInteractionL2(id, lqtyAsset, emptyAsset, sbAsset, emptyAsset, 0, _depositAmount);
 
         uint256 stakingBalanceBefore = LQTY.balanceOf(stakingContract);
 
         ROLLUP_ENCODER.registerEventToBeChecked(
-            bridgeCallData,
-            ROLLUP_ENCODER.getNextNonce(),
-            _depositAmount,
-            _depositAmount,
-            0,
-            true,
-            ""
+            bridgeCallData, ROLLUP_ENCODER.getNextNonce(), _depositAmount, _depositAmount, 0, true, ""
         );
         ROLLUP_ENCODER.processRollup();
 
@@ -89,9 +76,7 @@ contract StakingBridgeE2ETest is BridgeTestBase {
             "Staking contract balance didn't rise enough"
         );
         assertEq(
-            bridge.balanceOf(address(ROLLUP_PROCESSOR)),
-            _depositAmount,
-            "Incorrect SB balance of rollup processor"
+            bridge.balanceOf(address(ROLLUP_PROCESSOR)), _depositAmount, "Incorrect SB balance of rollup processor"
         );
 
         // WITHDRAWAL
@@ -100,7 +85,7 @@ contract StakingBridgeE2ETest is BridgeTestBase {
 
         uint256 processorBalanceBefore = LQTY.balanceOf(address(ROLLUP_PROCESSOR));
 
-        (uint256 outputValueA, uint256 outputValueB, ) = ROLLUP_ENCODER.processRollupAndGetBridgeResult();
+        (uint256 outputValueA, uint256 outputValueB,) = ROLLUP_ENCODER.processRollupAndGetBridgeResult();
 
         assertGe(outputValueA, _depositAmount, "Output value not bigger than deposit");
         assertEq(outputValueB, 0, "Output value B is not 0");

--- a/src/test/bridges/liquity/StakingBridgeUnit.t.sol
+++ b/src/test/bridges/liquity/StakingBridgeUnit.t.sol
@@ -45,31 +45,17 @@ contract StakingBridgeUnitTest is TestUtil {
         uint256 inputValue = 1e24;
         _deposit(inputValue);
 
-        AztecTypes.AztecAsset memory inputAssetA = AztecTypes.AztecAsset(
-            2,
-            address(bridge),
-            AztecTypes.AztecAssetType.ERC20
-        );
-        AztecTypes.AztecAsset memory outputAssetA = AztecTypes.AztecAsset(
-            1,
-            tokens["LQTY"].addr,
-            AztecTypes.AztecAssetType.ERC20
-        );
+        AztecTypes.AztecAsset memory inputAssetA =
+            AztecTypes.AztecAsset(2, address(bridge), AztecTypes.AztecAssetType.ERC20);
+        AztecTypes.AztecAsset memory outputAssetA =
+            AztecTypes.AztecAsset(1, tokens["LQTY"].addr, AztecTypes.AztecAssetType.ERC20);
 
         // Transfer SB back to the bridge
         IERC20(inputAssetA.erc20Address).transfer(address(bridge), inputValue);
 
         // Withdraw LQTY from the staking contract through the bridge
-        (uint256 outputValueA, , ) = bridge.convert(
-            inputAssetA,
-            emptyAsset,
-            outputAssetA,
-            emptyAsset,
-            inputValue,
-            1,
-            0,
-            address(0)
-        );
+        (uint256 outputValueA,,) =
+            bridge.convert(inputAssetA, emptyAsset, outputAssetA, emptyAsset, inputValue, 1, 0, address(0));
 
         // Check the total supply of StakingBridge accounting token (SB) token is 0
         assertEq(bridge.totalSupply(), 0);
@@ -86,16 +72,10 @@ contract StakingBridgeUnitTest is TestUtil {
         uint256 numIters = 2;
         uint256[] memory sbBalances = new uint256[](numIters);
 
-        AztecTypes.AztecAsset memory inputAssetA = AztecTypes.AztecAsset(
-            1,
-            tokens["LQTY"].addr,
-            AztecTypes.AztecAssetType.ERC20
-        );
-        AztecTypes.AztecAsset memory outputAssetA = AztecTypes.AztecAsset(
-            2,
-            address(bridge),
-            AztecTypes.AztecAssetType.ERC20
-        );
+        AztecTypes.AztecAsset memory inputAssetA =
+            AztecTypes.AztecAsset(1, tokens["LQTY"].addr, AztecTypes.AztecAssetType.ERC20);
+        AztecTypes.AztecAsset memory outputAssetA =
+            AztecTypes.AztecAsset(2, address(bridge), AztecTypes.AztecAssetType.ERC20);
 
         while (i < numIters) {
             uint256 depositAmount = bound(_depositAmounts[i], 1e18, 1e25);
@@ -106,16 +86,8 @@ contract StakingBridgeUnitTest is TestUtil {
             deal(tokens["WETH"].addr, address(bridge), 1e18);
 
             // 3. Deposit LQTY to the staking contract through the bridge
-            (uint256 outputValueA, , ) = bridge.convert(
-                inputAssetA,
-                emptyAsset,
-                outputAssetA,
-                emptyAsset,
-                depositAmount,
-                i,
-                0,
-                address(0)
-            );
+            (uint256 outputValueA,,) =
+                bridge.convert(inputAssetA, emptyAsset, outputAssetA, emptyAsset, depositAmount, i, 0, address(0));
 
             // 4. Transfer SB back to RollupProcessor
             IERC20(outputAssetA.erc20Address).transferFrom(address(bridge), rollupProcessor, outputValueA);
@@ -135,15 +107,8 @@ contract StakingBridgeUnitTest is TestUtil {
             IERC20(inputAssetA.erc20Address).transfer(address(bridge), inputValue);
 
             // 7. Withdraw LQTY from staking contract through the bridge
-            (uint256 outputValueA, , ) = bridge.convert(
-                inputAssetA,
-                emptyAsset,
-                outputAssetA,
-                emptyAsset,
-                sbBalances[i],
-                numIters + i,
-                0,
-                address(0)
+            (uint256 outputValueA,,) = bridge.convert(
+                inputAssetA, emptyAsset, outputAssetA, emptyAsset, sbBalances[i], numIters + i, 0, address(0)
             );
 
             // 8. Transfer LQTY back to RollupProcessor
@@ -239,7 +204,7 @@ contract StakingBridgeUnitTest is TestUtil {
         deal(tokens["LQTY"].addr, address(bridge), _depositAmount);
 
         // 2. Deposit LQTY to the staking contract through the bridge
-        (uint256 outputValueA, , ) = bridge.convert(
+        (uint256 outputValueA,,) = bridge.convert(
             AztecTypes.AztecAsset(1, tokens["LQTY"].addr, AztecTypes.AztecAssetType.ERC20),
             emptyAsset,
             AztecTypes.AztecAsset(2, address(bridge), AztecTypes.AztecAssetType.ERC20),

--- a/src/test/bridges/liquity/TroveBridgeE2E.t.sol
+++ b/src/test/bridges/liquity/TroveBridgeE2E.t.sol
@@ -75,15 +75,12 @@ contract TroveBridgeE2ETest is BridgeTestBase, TroveBridgeTestBase {
         // Compute borrow calldata
         ROLLUP_ENCODER.defiInteractionL2(id, ethAsset, emptyAsset, tbAsset, lusdAsset, MAX_FEE, _collateral);
 
-        (uint256 debtBeforeBorrowing, uint256 collBeforeBorrowing, , ) = TROVE_MANAGER.getEntireDebtAndColl(
-            address(bridge)
-        );
+        (uint256 debtBeforeBorrowing, uint256 collBeforeBorrowing,,) =
+            TROVE_MANAGER.getEntireDebtAndColl(address(bridge));
 
-        (uint256 outputValueA, uint256 outputValueB, ) = ROLLUP_ENCODER.processRollupAndGetBridgeResult();
+        (uint256 outputValueA, uint256 outputValueB,) = ROLLUP_ENCODER.processRollupAndGetBridgeResult();
 
-        (uint256 debtAfterBorrowing, uint256 collAfterBorrowing, , ) = TROVE_MANAGER.getEntireDebtAndColl(
-            address(bridge)
-        );
+        (uint256 debtAfterBorrowing, uint256 collAfterBorrowing,,) = TROVE_MANAGER.getEntireDebtAndColl(address(bridge));
         assertEq(
             collAfterBorrowing - collBeforeBorrowing,
             _collateral,
@@ -97,9 +94,7 @@ contract TroveBridgeE2ETest is BridgeTestBase, TroveBridgeTestBase {
         );
         assertEq(outputValueA, tbBalanceAfterBorrowing, "Debt amount doesn't equal outputValueA");
         assertEq(
-            outputValueB,
-            bridge.computeAmtToBorrow(_collateral),
-            "Borrowed amount doesn't equal expected borrow amount"
+            outputValueB, bridge.computeAmtToBorrow(_collateral), "Borrowed amount doesn't equal expected borrow amount"
         );
     }
 
@@ -113,7 +108,7 @@ contract TroveBridgeE2ETest is BridgeTestBase, TroveBridgeTestBase {
         // Compute repay calldata
         ROLLUP_ENCODER.defiInteractionL2(id, tbAsset, lusdAsset, ethAsset, lusdAsset, 0, tbBalance);
 
-        (uint256 outputValueA, uint256 outputValueB, ) = ROLLUP_ENCODER.processRollupAndGetBridgeResult();
+        (uint256 outputValueA, uint256 outputValueB,) = ROLLUP_ENCODER.processRollupAndGetBridgeResult();
 
         assertApproxEqAbs(outputValueA, _collateral, 1, "output value differs from collateral by more than 1 wei");
         assertEq(outputValueB, 0, "Non-zero LUSD amount returned");
@@ -129,7 +124,7 @@ contract TroveBridgeE2ETest is BridgeTestBase, TroveBridgeTestBase {
         // Compute repay calldata
         ROLLUP_ENCODER.defiInteractionL2(id, tbAsset, emptyAsset, ethAsset, emptyAsset, _getPrice(-1e20), tbBalance);
 
-        (uint256 outputValueA, , ) = ROLLUP_ENCODER.processRollupAndGetBridgeResult();
+        (uint256 outputValueA,,) = ROLLUP_ENCODER.processRollupAndGetBridgeResult();
 
         // Given that ICR was set to 160% and the debt has been repaid with collateral, received collateral should be
         // approx. equal to (deposit collateral amount) * (100/160). Given that borrowing fee and fee for the flash

--- a/src/test/bridges/liquity/TroveBridgeTestBase.sol
+++ b/src/test/bridges/liquity/TroveBridgeTestBase.sol
@@ -80,7 +80,7 @@ contract TroveBridgeTestBase is TestUtil {
         // The following is Solidity implementation of https://github.com/liquity/dev#opening-a-trove
         uint256 numTrials = 15;
         uint256 randomSeed = 42;
-        (address approxHint, , ) = HINT_HELPERS.getApproxHint(nicr, numTrials, randomSeed);
+        (address approxHint,,) = HINT_HELPERS.getApproxHint(nicr, numTrials, randomSeed);
         (address upperHint, address lowerHint) = SORTED_TROVES.findInsertPosition(nicr, approxHint, approxHint);
 
         // Open the trove
@@ -90,9 +90,7 @@ contract TroveBridgeTestBase is TestUtil {
         uint256 icr = TROVE_MANAGER.getCurrentICR(address(bridge), price);
         assertEq(icr, bridge.INITIAL_ICR(), "ICR doesn't equal initial ICR");
 
-        (uint256 debtAfterBorrowing, uint256 collAfterBorrowing, , ) = TROVE_MANAGER.getEntireDebtAndColl(
-            address(bridge)
-        );
+        (uint256 debtAfterBorrowing, uint256 collAfterBorrowing,,) = TROVE_MANAGER.getEntireDebtAndColl(address(bridge));
         assertEq(bridge.totalSupply(), debtAfterBorrowing, "TB total supply doesn't equal totalDebt");
         assertEq(collAfterBorrowing, OWNER_ETH_BALANCE, "Trove's collateral doesn't equal deposit amount");
 
@@ -143,7 +141,7 @@ contract TroveBridgeTestBase is TestUtil {
         // Set msg.sender to OWNER
         vm.startPrank(OWNER);
 
-        (uint256 debtBeforeClosure, , , ) = TROVE_MANAGER.getEntireDebtAndColl(address(bridge));
+        (uint256 debtBeforeClosure,,,) = TROVE_MANAGER.getEntireDebtAndColl(address(bridge));
 
         uint256 amountToRepay = debtBeforeClosure - 200e18;
 

--- a/src/test/bridges/liquity/TroveBridgeUnit.t.sol
+++ b/src/test/bridges/liquity/TroveBridgeUnit.t.sol
@@ -93,11 +93,8 @@ contract TroveBridgeUnitTest is TroveBridgeTestBase {
         _borrow(ROLLUP_PROCESSOR_ETH_BALANCE);
 
         // Try repaying debt while setting too high minPrice
-        AztecTypes.AztecAsset memory inputAssetA = AztecTypes.AztecAsset(
-            2,
-            address(bridge),
-            AztecTypes.AztecAssetType.ERC20
-        );
+        AztecTypes.AztecAsset memory inputAssetA =
+            AztecTypes.AztecAsset(2, address(bridge), AztecTypes.AztecAssetType.ERC20);
         AztecTypes.AztecAsset memory outputAssetA = AztecTypes.AztecAsset(3, address(0), AztecTypes.AztecAssetType.ETH);
 
         // inputValue is equal to rollupProcessor TB balance --> we want to repay the debt in full
@@ -164,11 +161,7 @@ contract TroveBridgeUnitTest is TroveBridgeTestBase {
         vm.prank(OWNER);
         bridge.closeTrove();
         uint256 ownerEthBalanceAfter = OWNER.balance;
-        assertGt(
-            ownerEthBalanceAfter,
-            ownerEthBalanceBefore,
-            "Owner's ETH balance didn't rise after closing the trove"
-        );
+        assertGt(ownerEthBalanceAfter, ownerEthBalanceBefore, "Owner's ETH balance didn't rise after closing the trove");
 
         // Try reopening the trove
         deal(tokens["LUSD"].addr, OWNER, 0); // delete user's LUSD balance to make accounting easier in _openTrove(...)
@@ -185,15 +178,15 @@ contract TroveBridgeUnitTest is TroveBridgeTestBase {
         address lowestIcrTrove = SORTED_TROVES.getLast();
         assertEq(lowestIcrTrove, address(bridge), "Bridge's trove is not the first one to redeem.");
 
-        (uint256 debtBefore, , , ) = TROVE_MANAGER.getEntireDebtAndColl(address(bridge));
+        (uint256 debtBefore,,,) = TROVE_MANAGER.getEntireDebtAndColl(address(bridge));
 
         uint256 amountToRedeem = debtBefore * 2;
 
         uint256 price = TROVE_MANAGER.priceFeed().fetchPrice();
 
-        (, uint256 partialRedemptionHintNICR, ) = HINT_HELPERS.getRedemptionHints(amountToRedeem, price, 0);
+        (, uint256 partialRedemptionHintNICR,) = HINT_HELPERS.getRedemptionHints(amountToRedeem, price, 0);
 
-        (address approxPartialRedemptionHint, , ) = HINT_HELPERS.getApproxHint(partialRedemptionHintNICR, 50, 42);
+        (address approxPartialRedemptionHint,,) = HINT_HELPERS.getApproxHint(partialRedemptionHintNICR, 50, 42);
 
         (address exactUpperPartialRedemptionHint, address exactLowerPartialRedemptionHint) = SORTED_TROVES
             .findInsertPosition(partialRedemptionHintNICR, approxPartialRedemptionHint, approxPartialRedemptionHint);
@@ -230,15 +223,15 @@ contract TroveBridgeUnitTest is TroveBridgeTestBase {
         address lowestIcrTrove = SORTED_TROVES.getLast();
         assertEq(lowestIcrTrove, address(bridge), "Bridge's trove is not the first one to redeem.");
 
-        (uint256 debtBefore, , , ) = TROVE_MANAGER.getEntireDebtAndColl(address(bridge));
+        (uint256 debtBefore,,,) = TROVE_MANAGER.getEntireDebtAndColl(address(bridge));
 
         uint256 amountToRedeem = debtBefore / 2;
 
         uint256 price = TROVE_MANAGER.priceFeed().fetchPrice();
 
-        (, uint256 partialRedemptionHintNICR, ) = HINT_HELPERS.getRedemptionHints(amountToRedeem, price, 0);
+        (, uint256 partialRedemptionHintNICR,) = HINT_HELPERS.getRedemptionHints(amountToRedeem, price, 0);
 
-        (address approxPartialRedemptionHint, , ) = HINT_HELPERS.getApproxHint(partialRedemptionHintNICR, 50, 42);
+        (address approxPartialRedemptionHint,,) = HINT_HELPERS.getApproxHint(partialRedemptionHintNICR, 50, 42);
 
         (address exactUpperPartialRedemptionHint, address exactLowerPartialRedemptionHint) = SORTED_TROVES
             .findInsertPosition(partialRedemptionHintNICR, approxPartialRedemptionHint, approxPartialRedemptionHint);
@@ -256,7 +249,7 @@ contract TroveBridgeUnitTest is TroveBridgeTestBase {
 
         // Check the trove was partially redeemed by checking that the trove's debt amount dropped but the trove
         // stayed active - not closed by redemption
-        (uint256 debtAfterRedemption, , , ) = TROVE_MANAGER.getEntireDebtAndColl(address(bridge));
+        (uint256 debtAfterRedemption,,,) = TROVE_MANAGER.getEntireDebtAndColl(address(bridge));
         assertEq(
             debtAfterRedemption,
             debtBefore - amountToRedeem,
@@ -266,22 +259,13 @@ contract TroveBridgeUnitTest is TroveBridgeTestBase {
         uint256 status = TROVE_MANAGER.getTroveStatus(address(bridge));
         assertEq(status, uint256(Status.active), "Status is not active");
 
-        AztecTypes.AztecAsset memory inputAssetA = AztecTypes.AztecAsset(
-            2,
-            address(bridge),
-            AztecTypes.AztecAssetType.ERC20
-        );
-        AztecTypes.AztecAsset memory inputAssetB = AztecTypes.AztecAsset(
-            1,
-            tokens["LUSD"].addr,
-            AztecTypes.AztecAssetType.ERC20
-        );
+        AztecTypes.AztecAsset memory inputAssetA =
+            AztecTypes.AztecAsset(2, address(bridge), AztecTypes.AztecAssetType.ERC20);
+        AztecTypes.AztecAsset memory inputAssetB =
+            AztecTypes.AztecAsset(1, tokens["LUSD"].addr, AztecTypes.AztecAssetType.ERC20);
         AztecTypes.AztecAsset memory outputAssetA = AztecTypes.AztecAsset(3, address(0), AztecTypes.AztecAssetType.ETH);
-        AztecTypes.AztecAsset memory outputAssetB = AztecTypes.AztecAsset(
-            1,
-            tokens["LUSD"].addr,
-            AztecTypes.AztecAssetType.ERC20
-        );
+        AztecTypes.AztecAsset memory outputAssetB =
+            AztecTypes.AztecAsset(1, tokens["LUSD"].addr, AztecTypes.AztecAssetType.ERC20);
 
         // inputValue is equal to rollupProcessor's TroveBridge accounting token (TB) balance --> we want to repay
         // the debt in full
@@ -292,21 +276,13 @@ contract TroveBridgeUnitTest is TroveBridgeTestBase {
         // Mint the debt amount of LUSD to the bridge
         deal(inputAssetB.erc20Address, address(bridge), inputValue + bridge.DUST());
 
-        (, uint256 outputValueB, ) = bridge.convert(
-            inputAssetA,
-            inputAssetB,
-            outputAssetA,
-            outputAssetB,
-            inputValue,
-            1,
-            0,
-            address(0)
-        );
+        (, uint256 outputValueB,) =
+            bridge.convert(inputAssetA, inputAssetB, outputAssetA, outputAssetB, inputValue, 1, 0, address(0));
 
         // Transfer LUSD back to the rollupProcessor
         IERC20(outputAssetB.erc20Address).transferFrom(address(bridge), rollupProcessor, outputValueB);
 
-        (uint256 debtAfterRepaying, , , ) = TROVE_MANAGER.getEntireDebtAndColl(address(bridge));
+        (uint256 debtAfterRepaying,,,) = TROVE_MANAGER.getEntireDebtAndColl(address(bridge));
         uint256 expectedAmtLusdReturned = inputValue - (debtAfterRedemption - debtAfterRepaying);
 
         // Check the bridge doesn't hold any ETH or LUSD
@@ -316,7 +292,7 @@ contract TroveBridgeUnitTest is TroveBridgeTestBase {
         assertEq(outputValueB, expectedAmtLusdReturned, "Amount of LUSD returned doesn't equal expected amount");
 
         // Close the trove
-        (uint256 remainingDebt, , , ) = TROVE_MANAGER.getEntireDebtAndColl(address(bridge));
+        (uint256 remainingDebt,,,) = TROVE_MANAGER.getEntireDebtAndColl(address(bridge));
         uint256 ownerEthBalanceBefore = OWNER.balance;
 
         vm.startPrank(OWNER);
@@ -325,11 +301,7 @@ contract TroveBridgeUnitTest is TroveBridgeTestBase {
         vm.stopPrank();
 
         uint256 ownerEthBalanceAfter = OWNER.balance;
-        assertGt(
-            ownerEthBalanceAfter,
-            ownerEthBalanceBefore,
-            "Owner's ETH balance didn't rise after closing the trove"
-        );
+        assertGt(ownerEthBalanceAfter, ownerEthBalanceBefore, "Owner's ETH balance didn't rise after closing the trove");
 
         // Try reopening the trove
         deal(tokens["LUSD"].addr, OWNER, 0); // delete user's LUSD balance to make accounting easier in _openTrove(...)
@@ -358,16 +330,10 @@ contract TroveBridgeUnitTest is TroveBridgeTestBase {
         deal(address(bridge), 100e18);
 
         // Repay
-        AztecTypes.AztecAsset memory tbAsset = AztecTypes.AztecAsset(
-            2,
-            address(bridge),
-            AztecTypes.AztecAssetType.ERC20
-        );
-        AztecTypes.AztecAsset memory lusdAsset = AztecTypes.AztecAsset(
-            1,
-            tokens["LUSD"].addr,
-            AztecTypes.AztecAssetType.ERC20
-        );
+        AztecTypes.AztecAsset memory tbAsset =
+            AztecTypes.AztecAsset(2, address(bridge), AztecTypes.AztecAssetType.ERC20);
+        AztecTypes.AztecAsset memory lusdAsset =
+            AztecTypes.AztecAsset(1, tokens["LUSD"].addr, AztecTypes.AztecAssetType.ERC20);
         AztecTypes.AztecAsset memory ethAsset = AztecTypes.AztecAsset(3, address(0), AztecTypes.AztecAssetType.ETH);
 
         // inputValue is equal to rollupProcessor TB balance --> we want to repay the debt in full
@@ -385,22 +351,13 @@ contract TroveBridgeUnitTest is TroveBridgeTestBase {
     function testRepayingAfterRedistributionRevertsWhenMaxCostExceeded() public {
         _setUpRedistribution();
 
-        AztecTypes.AztecAsset memory inputAssetA = AztecTypes.AztecAsset(
-            2,
-            address(bridge),
-            AztecTypes.AztecAssetType.ERC20
-        );
-        AztecTypes.AztecAsset memory inputAssetB = AztecTypes.AztecAsset(
-            1,
-            tokens["LUSD"].addr,
-            AztecTypes.AztecAssetType.ERC20
-        );
+        AztecTypes.AztecAsset memory inputAssetA =
+            AztecTypes.AztecAsset(2, address(bridge), AztecTypes.AztecAssetType.ERC20);
+        AztecTypes.AztecAsset memory inputAssetB =
+            AztecTypes.AztecAsset(1, tokens["LUSD"].addr, AztecTypes.AztecAssetType.ERC20);
         AztecTypes.AztecAsset memory outputAssetA = AztecTypes.AztecAsset(3, address(0), AztecTypes.AztecAssetType.ETH);
-        AztecTypes.AztecAsset memory outputAssetB = AztecTypes.AztecAsset(
-            2,
-            address(bridge),
-            AztecTypes.AztecAssetType.ERC20
-        );
+        AztecTypes.AztecAsset memory outputAssetB =
+            AztecTypes.AztecAsset(2, address(bridge), AztecTypes.AztecAssetType.ERC20);
 
         // inputValue is equal to rollupProcessor TB balance --> we want to repay the debt in full
         uint256 inputValue = bridge.balanceOf(rollupProcessor);
@@ -439,7 +396,7 @@ contract TroveBridgeUnitTest is TroveBridgeTestBase {
         _setLiquityPrice(priceBeforeDrop);
 
         // Drop Trove's CR to MCR by impersonating the bridge and directly withdrawing collateral
-        (uint256 debt, uint256 coll, , ) = TROVE_MANAGER.getEntireDebtAndColl(address(bridge));
+        (uint256 debt, uint256 coll,,) = TROVE_MANAGER.getEntireDebtAndColl(address(bridge));
 
         uint256 icrAfterRedistribution = (coll * priceBeforeDrop) / debt;
 
@@ -454,7 +411,7 @@ contract TroveBridgeUnitTest is TroveBridgeTestBase {
         // Erase withdrawn collateral from the bridge
         vm.deal(address(bridge), 0);
 
-        (debt, coll, , ) = TROVE_MANAGER.getEntireDebtAndColl(address(bridge));
+        (debt, coll,,) = TROVE_MANAGER.getEntireDebtAndColl(address(bridge));
         uint256 icrAfterWithdrawal = (coll * priceBeforeDrop) / debt;
 
         assertEq(icrAfterWithdrawal, MCR, "ICR after withdrawal doesn't equal MCR");
@@ -463,7 +420,7 @@ contract TroveBridgeUnitTest is TroveBridgeTestBase {
         uint256 expectedBalance = (coll * bridge.balanceOf(rollupProcessor)) / bridge.totalSupply();
         _repay(expectedBalance, 5e16, true, 1);
 
-        (, coll, , ) = TROVE_MANAGER.getEntireDebtAndColl(address(bridge));
+        (, coll,,) = TROVE_MANAGER.getEntireDebtAndColl(address(bridge));
         uint256 expectedOwnerBalance = (coll * bridge.balanceOf(OWNER)) / bridge.totalSupply();
         _closeTroveAfterRedistribution(expectedOwnerBalance);
 
@@ -509,39 +466,23 @@ contract TroveBridgeUnitTest is TroveBridgeTestBase {
         uint256 price = TROVE_MANAGER.priceFeed().fetchPrice();
         uint256 icrBeforeBorrowing = TROVE_MANAGER.getCurrentICR(address(bridge), price);
 
-        (, uint256 collBeforeBorrowing, , ) = TROVE_MANAGER.getEntireDebtAndColl(address(bridge));
+        (, uint256 collBeforeBorrowing,,) = TROVE_MANAGER.getEntireDebtAndColl(address(bridge));
 
         AztecTypes.AztecAsset memory inputAssetA = AztecTypes.AztecAsset(3, address(0), AztecTypes.AztecAssetType.ETH);
-        AztecTypes.AztecAsset memory outputAssetA = AztecTypes.AztecAsset(
-            2,
-            address(bridge),
-            AztecTypes.AztecAssetType.ERC20
-        );
-        AztecTypes.AztecAsset memory outputAssetB = AztecTypes.AztecAsset(
-            1,
-            tokens["LUSD"].addr,
-            AztecTypes.AztecAssetType.ERC20
-        );
+        AztecTypes.AztecAsset memory outputAssetA =
+            AztecTypes.AztecAsset(2, address(bridge), AztecTypes.AztecAssetType.ERC20);
+        AztecTypes.AztecAsset memory outputAssetB =
+            AztecTypes.AztecAsset(1, tokens["LUSD"].addr, AztecTypes.AztecAssetType.ERC20);
 
         // Borrow against collateral
-        (uint256 outputValueA, uint256 outputValueB, ) = bridge.convert(
-            inputAssetA,
-            emptyAsset,
-            outputAssetA,
-            outputAssetB,
-            _collateral,
-            0,
-            MAX_FEE,
-            address(0)
-        );
+        (uint256 outputValueA, uint256 outputValueB,) =
+            bridge.convert(inputAssetA, emptyAsset, outputAssetA, outputAssetB, _collateral, 0, MAX_FEE, address(0));
 
         // Transfer TB and LUSD back to the rollupProcessor
         IERC20(outputAssetA.erc20Address).transferFrom(address(bridge), rollupProcessor, outputValueA);
         IERC20(outputAssetB.erc20Address).transferFrom(address(bridge), rollupProcessor, outputValueB);
 
-        (uint256 debtAfterBorrowing, uint256 collAfterBorrowing, , ) = TROVE_MANAGER.getEntireDebtAndColl(
-            address(bridge)
-        );
+        (uint256 debtAfterBorrowing, uint256 collAfterBorrowing,,) = TROVE_MANAGER.getEntireDebtAndColl(address(bridge));
         assertEq(
             collAfterBorrowing - collBeforeBorrowing,
             _collateral,
@@ -568,7 +509,7 @@ contract TroveBridgeUnitTest is TroveBridgeTestBase {
         _openTrove();
         _borrow(ROLLUP_PROCESSOR_ETH_BALANCE);
 
-        (uint256 debtBefore, uint256 collBefore, , ) = TROVE_MANAGER.getEntireDebtAndColl(address(bridge));
+        (uint256 debtBefore, uint256 collBefore,,) = TROVE_MANAGER.getEntireDebtAndColl(address(bridge));
 
         // Erase stability pool's LUSD balance in order to force redistribution
         deal(tokens["LUSD"].addr, STABILITY_POOL, 0);
@@ -578,7 +519,7 @@ contract TroveBridgeUnitTest is TroveBridgeTestBase {
         _setLiquityPrice(LIQUITY_PRICE_FEED.fetchPrice() / 2);
         TROVE_MANAGER.liquidateTroves(10);
 
-        (uint256 debtAfter, uint256 collAfter, , ) = TROVE_MANAGER.getEntireDebtAndColl(address(bridge));
+        (uint256 debtAfter, uint256 collAfter,,) = TROVE_MANAGER.getEntireDebtAndColl(address(bridge));
 
         assertGt(debtAfter, debtBefore, "Debt hasn't increased after liquidations");
         assertGt(collAfter, collBefore, "Collateral hasn't increased after liquidations");
@@ -595,16 +536,10 @@ contract TroveBridgeUnitTest is TroveBridgeTestBase {
         bool _afterRedistribution,
         uint256 _interactionNonce
     ) private {
-        AztecTypes.AztecAsset memory inputAssetA = AztecTypes.AztecAsset(
-            2,
-            address(bridge),
-            AztecTypes.AztecAssetType.ERC20
-        );
-        AztecTypes.AztecAsset memory inputAssetB = AztecTypes.AztecAsset(
-            1,
-            tokens["LUSD"].addr,
-            AztecTypes.AztecAssetType.ERC20
-        );
+        AztecTypes.AztecAsset memory inputAssetA =
+            AztecTypes.AztecAsset(2, address(bridge), AztecTypes.AztecAssetType.ERC20);
+        AztecTypes.AztecAsset memory inputAssetB =
+            AztecTypes.AztecAsset(1, tokens["LUSD"].addr, AztecTypes.AztecAssetType.ERC20);
         AztecTypes.AztecAsset memory outputAssetA = AztecTypes.AztecAsset(3, address(0), AztecTypes.AztecAssetType.ETH);
         AztecTypes.AztecAsset memory outputAssetB = _afterRedistribution
             ? AztecTypes.AztecAsset(2, address(bridge), AztecTypes.AztecAssetType.ERC20)
@@ -620,7 +555,7 @@ contract TroveBridgeUnitTest is TroveBridgeTestBase {
 
         uint256 rollupProcessorEthBalanceBefore = rollupProcessor.balance;
 
-        (uint256 outputValueA, uint256 outputValueB, ) = bridge.convert(
+        (uint256 outputValueA, uint256 outputValueB,) = bridge.convert(
             inputAssetA,
             inputAssetB,
             outputAssetA,
@@ -650,11 +585,8 @@ contract TroveBridgeUnitTest is TroveBridgeTestBase {
     }
 
     function _repayWithCollateral() private {
-        AztecTypes.AztecAsset memory inputAssetA = AztecTypes.AztecAsset(
-            2,
-            address(bridge),
-            AztecTypes.AztecAssetType.ERC20
-        );
+        AztecTypes.AztecAsset memory inputAssetA =
+            AztecTypes.AztecAsset(2, address(bridge), AztecTypes.AztecAssetType.ERC20);
         AztecTypes.AztecAsset memory outputAssetA = AztecTypes.AztecAsset(3, address(0), AztecTypes.AztecAssetType.ETH);
 
         // inputValue is equal to rollupProcessor TB balance --> we want to repay the debt in full
@@ -664,15 +596,8 @@ contract TroveBridgeUnitTest is TroveBridgeTestBase {
 
         uint256 rollupProcessorEthBalanceBefore = rollupProcessor.balance;
 
-        (uint256 outputValueA, uint256 outputValueB, ) = bridge.convert(
-            inputAssetA,
-            emptyAsset,
-            outputAssetA,
-            emptyAsset,
-            inputValue,
-            1,
-            _getPrice(-1e20),
-            address(0)
+        (uint256 outputValueA, uint256 outputValueB,) = bridge.convert(
+            inputAssetA, emptyAsset, outputAssetA, emptyAsset, inputValue, 1, _getPrice(-1e20), address(0)
         );
 
         uint256 rollupProcessorEthBalanceDiff = rollupProcessor.balance - rollupProcessorEthBalanceBefore;
@@ -694,11 +619,8 @@ contract TroveBridgeUnitTest is TroveBridgeTestBase {
     }
 
     function _redeem() private {
-        AztecTypes.AztecAsset memory inputAssetA = AztecTypes.AztecAsset(
-            2,
-            address(bridge),
-            AztecTypes.AztecAssetType.ERC20
-        );
+        AztecTypes.AztecAsset memory inputAssetA =
+            AztecTypes.AztecAsset(2, address(bridge), AztecTypes.AztecAssetType.ERC20);
         AztecTypes.AztecAsset memory outputAssetA = AztecTypes.AztecAsset(3, address(0), AztecTypes.AztecAssetType.ETH);
 
         // inputValue is equal to rollupProcessor TB balance --> we want to redeem remaining collateral in full
@@ -718,43 +640,26 @@ contract TroveBridgeUnitTest is TroveBridgeTestBase {
         uint256 price = TROVE_MANAGER.priceFeed().fetchPrice();
         uint256 icrBeforeBorrowing = TROVE_MANAGER.getCurrentICR(address(bridge), price);
 
-        (, uint256 collBeforeBorrowing, , ) = TROVE_MANAGER.getEntireDebtAndColl(address(bridge));
+        (, uint256 collBeforeBorrowing,,) = TROVE_MANAGER.getEntireDebtAndColl(address(bridge));
 
         AztecTypes.AztecAsset memory inputAssetA = AztecTypes.AztecAsset(3, address(0), AztecTypes.AztecAssetType.ETH);
-        AztecTypes.AztecAsset memory outputAssetA = AztecTypes.AztecAsset(
-            2,
-            address(bridge),
-            AztecTypes.AztecAssetType.ERC20
-        );
-        AztecTypes.AztecAsset memory outputAssetB = AztecTypes.AztecAsset(
-            1,
-            tokens["LUSD"].addr,
-            AztecTypes.AztecAssetType.ERC20
-        );
+        AztecTypes.AztecAsset memory outputAssetA =
+            AztecTypes.AztecAsset(2, address(bridge), AztecTypes.AztecAssetType.ERC20);
+        AztecTypes.AztecAsset memory outputAssetB =
+            AztecTypes.AztecAsset(1, tokens["LUSD"].addr, AztecTypes.AztecAssetType.ERC20);
 
         // Borrow against ROLLUP_PROCESSOR_ETH_BALANCE
-        (uint256 outputValueA, uint256 outputValueB, ) = bridge.convert{value: depositAmount}(
-            inputAssetA,
-            emptyAsset,
-            outputAssetA,
-            outputAssetB,
-            depositAmount,
-            2,
-            MAX_FEE,
-            address(0)
+        (uint256 outputValueA, uint256 outputValueB,) = bridge.convert{value: depositAmount}(
+            inputAssetA, emptyAsset, outputAssetA, outputAssetB, depositAmount, 2, MAX_FEE, address(0)
         );
 
         // Transfer TB and LUSD back to the rollupProcessor
         IERC20(outputAssetA.erc20Address).transferFrom(address(bridge), rollupProcessor, outputValueA);
         IERC20(outputAssetB.erc20Address).transferFrom(address(bridge), rollupProcessor, outputValueB);
 
-        (uint256 debtAfterBorrowing, uint256 collAfterBorrowing, , ) = TROVE_MANAGER.getEntireDebtAndColl(
-            address(bridge)
-        );
+        (uint256 debtAfterBorrowing, uint256 collAfterBorrowing,,) = TROVE_MANAGER.getEntireDebtAndColl(address(bridge));
         assertEq(
-            collAfterBorrowing - collBeforeBorrowing,
-            depositAmount,
-            "Collateral increase differs from depositAmount"
+            collAfterBorrowing - collBeforeBorrowing, depositAmount, "Collateral increase differs from depositAmount"
         );
 
         uint256 icrAfterBorrowing = TROVE_MANAGER.getCurrentICR(address(bridge), price);

--- a/src/test/bridges/liquity/utils/MockPriceFeed.sol
+++ b/src/test/bridges/liquity/utils/MockPriceFeed.sol
@@ -12,7 +12,7 @@ contract MockPriceFeed is IPriceFeed {
         lastGoodPrice = _price;
     }
 
-    function fetchPrice() external override(IPriceFeed) returns (uint256) {
+    function fetchPrice() external override (IPriceFeed) returns (uint256) {
         return lastGoodPrice;
     }
 }

--- a/src/test/bridges/uniswap/UniswapBridgeE2E.t.sol
+++ b/src/test/bridges/uniswap/UniswapBridgeE2E.t.sol
@@ -97,24 +97,11 @@ contract UniswapBridgeE2ETest is BridgeTestBase {
         quote += QUOTER.quoteExactInput(referenceSplitPath2, swapAmount - swapAmountSplitPath1);
 
         // Computes the encoded data for the specific bridge interaction
-        uint256 bridgeCallData = ROLLUP_ENCODER.defiInteractionL2(
-            id,
-            lusdAsset,
-            emptyAsset,
-            lqtyAsset,
-            emptyAsset,
-            encodedPath,
-            swapAmount
-        );
+        uint256 bridgeCallData =
+            ROLLUP_ENCODER.defiInteractionL2(id, lusdAsset, emptyAsset, lqtyAsset, emptyAsset, encodedPath, swapAmount);
 
         ROLLUP_ENCODER.registerEventToBeChecked(
-            bridgeCallData,
-            ROLLUP_ENCODER.getNextNonce(),
-            swapAmount,
-            quote,
-            0,
-            true,
-            ""
+            bridgeCallData, ROLLUP_ENCODER.getNextNonce(), swapAmount, quote, 0, true, ""
         );
         ROLLUP_ENCODER.processRollup();
     }

--- a/src/test/bridges/uniswap/UniswapBridgeInternal.t.sol
+++ b/src/test/bridges/uniswap/UniswapBridgeInternal.t.sol
@@ -15,8 +15,7 @@ contract UniswapBridgeInternalTest is Test, UniswapBridge(address(0)) {
 
     bytes private referenceSplitPath1 =
         abi.encodePacked(LUSD, uint24(500), USDC, uint24(3000), WETH, uint24(3000), LQTY);
-    bytes private referenceSplitPath2 =
-        abi.encodePacked(LUSD, uint24(500), DAI, uint24(3000), WETH, uint24(3000), LQTY);
+    bytes private referenceSplitPath2 = abi.encodePacked(LUSD, uint24(500), DAI, uint24(3000), WETH, uint24(3000), LQTY);
 
     function setUp() public {}
 
@@ -35,18 +34,14 @@ contract UniswapBridgeInternalTest is Test, UniswapBridge(address(0)) {
         // 111101000010010000000 01100 | 1000110 01 010 10 001 10 | 0011110 01 100 10 001 10
         uint64 referenceEncodedPath = 0xF42403232A31E646;
         uint64 encodedPath = this.encodePath(
-            100e18,
-            200e18,
-            LUSD,
-            SplitPath(70, 500, USDC, 3000, WETH, 3000),
-            SplitPath(30, 500, DAI, 3000, WETH, 3000)
+            100e18, 200e18, LUSD, SplitPath(70, 500, USDC, 3000, WETH, 3000), SplitPath(30, 500, DAI, 3000, WETH, 3000)
         );
 
         assertEq(encodedPath, referenceEncodedPath, "Encoded path is not equal to reference");
     }
 
     function testEncodeMinPriceForValuesWithoutPrecisionLoss(uint24 _price) public {
-        uint256 price = bound(_price, 0, 2**21 - 1);
+        uint256 price = bound(_price, 0, 2 ** 21 - 1);
         uint256 encodedMinPrice = _computeEncodedMinPrice(1, price, 0);
         uint256 decodedMinPrice = _decodeMinPrice(encodedMinPrice);
         assertEq(decodedMinPrice, price);
@@ -54,24 +49,22 @@ contract UniswapBridgeInternalTest is Test, UniswapBridge(address(0)) {
 
     function testMinPriceNever0DueToPrecisionLoss(uint24 _price, uint8 _decimals) public {
         uint256 decimals = bound(_decimals, 0, 24);
-        uint256 price = bound(_price, 1, maxMinPrice / 10**decimals);
+        uint256 price = bound(_price, 1, maxMinPrice / 10 ** decimals);
         uint256 encodedMinPrice = _computeEncodedMinPrice(1, price, decimals);
         uint256 decodedMinPrice = _decodeMinPrice(encodedMinPrice);
         assertGt(decodedMinPrice, 0);
     }
 
-    function testPrecisionLossNeverBiggerThan1Bps(
-        uint80 _totalInputValue,
-        uint24 _price,
-        uint8 _tokenInDecimals
-    ) public {
+    function testPrecisionLossNeverBiggerThan1Bps(uint80 _totalInputValue, uint24 _price, uint8 _tokenInDecimals)
+        public
+    {
         uint256 decimals = bound(_tokenInDecimals, 0, 24);
-        uint256 price = bound(_price, 1, maxMinPrice / 10**decimals);
+        uint256 price = bound(_price, 1, maxMinPrice / 10 ** decimals);
         uint256 quote = _totalInputValue * price;
 
         uint256 encodedMinPrice = _computeEncodedMinPrice(1, price, decimals);
         uint256 decodedMinPrice = _decodeMinPrice(encodedMinPrice);
-        uint256 amountOutMinimum = (_totalInputValue * decodedMinPrice) / 10**decimals;
+        uint256 amountOutMinimum = (_totalInputValue * decodedMinPrice) / 10 ** decimals;
 
         assertApproxEqRel(quote, amountOutMinimum, 1e16);
     }
@@ -81,9 +74,7 @@ contract UniswapBridgeInternalTest is Test, UniswapBridge(address(0)) {
         assertEq(encoded, maxEncodedMinPrice, "Encoded price doesn't equal max encoded price");
         uint256 decoded = _decodeMinPrice(uint64(encoded));
         assertEq(
-            decoded,
-            maxDecodedMinPriceAfterEncoding,
-            "Decoded max encoded doesn't equal max decoded after encoding"
+            decoded, maxDecodedMinPriceAfterEncoding, "Decoded max encoded doesn't equal max decoded after encoding"
         );
     }
 
@@ -106,7 +97,7 @@ contract UniswapBridgeInternalTest is Test, UniswapBridge(address(0)) {
         assertEq(string(path.splitPath1), string(referenceSplitPath1), "Split path 1 incorrectly encoded");
         assertEq(path.percentage2, 30, "Incorrect percentage 2");
         assertEq(string(path.splitPath2), string(referenceSplitPath2), "Split path 2 incorrectly encoded");
-        assertEq(path.minPrice, 2031142 * 10**27);
+        assertEq(path.minPrice, 2031142 * 10 ** 27);
     }
 
     function testDecodePathOnly1SplitPath() public {
@@ -120,7 +111,7 @@ contract UniswapBridgeInternalTest is Test, UniswapBridge(address(0)) {
         assertEq(path.percentage1, 100, "Incorrect percentage 1");
         assertEq(string(path.splitPath1), string(referenceSplitPath1), "Split path 1 incorrectly encoded");
         assertEq(path.percentage2, 0, "Incorrect percentage 2");
-        assertEq(path.minPrice, 2031142 * 10**27);
+        assertEq(path.minPrice, 2031142 * 10 ** 27);
     }
 
     function testDecodePathOnly1SplitPathInPositionOfSplitPath2() public {
@@ -134,7 +125,7 @@ contract UniswapBridgeInternalTest is Test, UniswapBridge(address(0)) {
         assertEq(path.percentage1, 0, "Incorrect percentage 1");
         assertEq(path.percentage2, 100, "Incorrect percentage 2");
         assertEq(string(path.splitPath2), string(referenceSplitPath2), "Split path 2 incorrectly encoded");
-        assertEq(path.minPrice, 2031142 * 10**27);
+        assertEq(path.minPrice, 2031142 * 10 ** 27);
     }
 
     function testDecodeSplitPathAllMiddleTokensUsed() public {
@@ -173,17 +164,17 @@ contract UniswapBridgeInternalTest is Test, UniswapBridge(address(0)) {
         uint8 exponent = 27;
         // |111101111111000100110| [11011|
         uint64 referenceEncodedMinPrice = 0x3DFC4DB;
-        uint256 referenceDecodedMinPrice = significand * 10**exponent;
+        uint256 referenceDecodedMinPrice = significand * 10 ** exponent;
 
         uint256 decodedMinPrice = _decodeMinPrice(referenceEncodedMinPrice);
         assertEq(decodedMinPrice, referenceDecodedMinPrice, "Incorrect min price");
     }
 
     function testDecodeMinPriceFuzz(uint24 _significand, uint8 _exponent) public {
-        _significand = uint24(bound(_significand, 0, 2**21 - 1));
-        _exponent = uint8(bound(_exponent, 0, 2**5 - 1));
+        _significand = uint24(bound(_significand, 0, 2 ** 21 - 1));
+        _exponent = uint8(bound(_exponent, 0, 2 ** 5 - 1));
         uint64 referenceEncodedMinPrice = (uint64(_significand) << 5) + _exponent;
-        uint256 referenceDecodedMinPrice = _significand * 10**_exponent;
+        uint256 referenceDecodedMinPrice = _significand * 10 ** _exponent;
 
         uint256 decodedMinPrice = _decodeMinPrice(referenceEncodedMinPrice);
         assertEq(decodedMinPrice, referenceDecodedMinPrice, "Incorrect min price");

--- a/src/test/bridges/uniswap/UniswapBridgeUnit.t.sol
+++ b/src/test/bridges/uniswap/UniswapBridgeUnit.t.sol
@@ -80,30 +80,16 @@ contract UniswapBridgeUnitTest is Test {
         bridge.preApproveTokens(tokensIn, tokensOut);
 
         // Define input and output assets
-        AztecTypes.AztecAsset memory inputAssetA = AztecTypes.AztecAsset({
-            id: 1,
-            erc20Address: LUSD,
-            assetType: AztecTypes.AztecAssetType.ERC20
-        });
+        AztecTypes.AztecAsset memory inputAssetA =
+            AztecTypes.AztecAsset({id: 1, erc20Address: LUSD, assetType: AztecTypes.AztecAssetType.ERC20});
 
-        AztecTypes.AztecAsset memory outputAssetA = AztecTypes.AztecAsset({
-            id: 2,
-            erc20Address: LQTY,
-            assetType: AztecTypes.AztecAssetType.ERC20
-        });
+        AztecTypes.AztecAsset memory outputAssetA =
+            AztecTypes.AztecAsset({id: 2, erc20Address: LQTY, assetType: AztecTypes.AztecAssetType.ERC20});
 
         deal(LUSD, address(bridge), swapAmount);
 
-        (uint256 outputValueA, , ) = bridge.convert(
-            inputAssetA,
-            emptyAsset,
-            outputAssetA,
-            emptyAsset,
-            swapAmount,
-            0,
-            encodedPath,
-            address(0)
-        );
+        (uint256 outputValueA,,) =
+            bridge.convert(inputAssetA, emptyAsset, outputAssetA, emptyAsset, swapAmount, 0, encodedPath, address(0));
 
         IERC20(outputAssetA.erc20Address).transferFrom(address(bridge), rollupProcessor, outputValueA);
 
@@ -128,29 +114,16 @@ contract UniswapBridgeUnitTest is Test {
         bridge.preApproveTokens(tokensIn, tokensOut);
 
         // Define input and output assets
-        AztecTypes.AztecAsset memory inputAssetA = AztecTypes.AztecAsset({
-            id: 0,
-            erc20Address: address(0),
-            assetType: AztecTypes.AztecAssetType.ETH
-        });
+        AztecTypes.AztecAsset memory inputAssetA =
+            AztecTypes.AztecAsset({id: 0, erc20Address: address(0), assetType: AztecTypes.AztecAssetType.ETH});
 
-        AztecTypes.AztecAsset memory outputAssetA = AztecTypes.AztecAsset({
-            id: 2,
-            erc20Address: LQTY,
-            assetType: AztecTypes.AztecAssetType.ERC20
-        });
+        AztecTypes.AztecAsset memory outputAssetA =
+            AztecTypes.AztecAsset({id: 2, erc20Address: LQTY, assetType: AztecTypes.AztecAssetType.ERC20});
 
         deal(rollupProcessor, swapAmount);
 
-        (uint256 outputValueA, , ) = bridge.convert{value: swapAmount}(
-            inputAssetA,
-            emptyAsset,
-            outputAssetA,
-            emptyAsset,
-            swapAmount,
-            0,
-            encodedPath,
-            address(0)
+        (uint256 outputValueA,,) = bridge.convert{value: swapAmount}(
+            inputAssetA, emptyAsset, outputAssetA, emptyAsset, swapAmount, 0, encodedPath, address(0)
         );
 
         IERC20(outputAssetA.erc20Address).transferFrom(address(bridge), rollupProcessor, outputValueA);
@@ -174,30 +147,16 @@ contract UniswapBridgeUnitTest is Test {
         bridge.preApproveTokens(tokensIn, tokensOut);
 
         // Define input and output assets
-        AztecTypes.AztecAsset memory inputAssetA = AztecTypes.AztecAsset({
-            id: 2,
-            erc20Address: LQTY,
-            assetType: AztecTypes.AztecAssetType.ERC20
-        });
+        AztecTypes.AztecAsset memory inputAssetA =
+            AztecTypes.AztecAsset({id: 2, erc20Address: LQTY, assetType: AztecTypes.AztecAssetType.ERC20});
 
-        AztecTypes.AztecAsset memory outputAssetA = AztecTypes.AztecAsset({
-            id: 0,
-            erc20Address: address(0),
-            assetType: AztecTypes.AztecAssetType.ETH
-        });
+        AztecTypes.AztecAsset memory outputAssetA =
+            AztecTypes.AztecAsset({id: 0, erc20Address: address(0), assetType: AztecTypes.AztecAssetType.ETH});
 
         deal(LQTY, address(bridge), swapAmount);
 
-        (uint256 outputValueA, , ) = bridge.convert(
-            inputAssetA,
-            emptyAsset,
-            outputAssetA,
-            emptyAsset,
-            swapAmount,
-            0,
-            encodedPath,
-            address(0)
-        );
+        (uint256 outputValueA,,) =
+            bridge.convert(inputAssetA, emptyAsset, outputAssetA, emptyAsset, swapAmount, 0, encodedPath, address(0));
 
         assertGt(outputValueA, 0);
     }
@@ -206,16 +165,10 @@ contract UniswapBridgeUnitTest is Test {
         // Trying to swap anywhere from 0.1 ETH to 10 thousand ETH
         uint256 swapAmount = bound(_swapAmount, 1e17, 1e22);
 
-        uint256 quote = QUOTER.quoteExactInput(
-            abi.encodePacked(WETH, uint24(500), USDC, uint24(3000), GUSD),
-            swapAmount
-        );
+        uint256 quote =
+            QUOTER.quoteExactInput(abi.encodePacked(WETH, uint24(500), USDC, uint24(3000), GUSD), swapAmount);
         uint64 encodedPath = bridge.encodePath(
-            swapAmount,
-            quote,
-            WETH,
-            emptySplitPath,
-            UniswapBridge.SplitPath(100, 500, USDC, 100, address(0), 3000)
+            swapAmount, quote, WETH, emptySplitPath, UniswapBridge.SplitPath(100, 500, USDC, 100, address(0), 3000)
         );
 
         address[] memory tokensIn = new address[](1);
@@ -227,30 +180,16 @@ contract UniswapBridgeUnitTest is Test {
         bridge.preApproveTokens(tokensIn, tokensOut);
 
         // Define input and output assets
-        AztecTypes.AztecAsset memory inputAssetA = AztecTypes.AztecAsset({
-            id: 2,
-            erc20Address: WETH,
-            assetType: AztecTypes.AztecAssetType.ERC20
-        });
+        AztecTypes.AztecAsset memory inputAssetA =
+            AztecTypes.AztecAsset({id: 2, erc20Address: WETH, assetType: AztecTypes.AztecAssetType.ERC20});
 
-        AztecTypes.AztecAsset memory outputAssetA = AztecTypes.AztecAsset({
-            id: 4,
-            erc20Address: GUSD,
-            assetType: AztecTypes.AztecAssetType.ERC20
-        });
+        AztecTypes.AztecAsset memory outputAssetA =
+            AztecTypes.AztecAsset({id: 4, erc20Address: GUSD, assetType: AztecTypes.AztecAssetType.ERC20});
 
         deal(WETH, address(bridge), swapAmount);
 
-        (uint256 outputValueA, , ) = bridge.convert(
-            inputAssetA,
-            emptyAsset,
-            outputAssetA,
-            emptyAsset,
-            swapAmount,
-            0,
-            encodedPath,
-            address(0)
-        );
+        (uint256 outputValueA,,) =
+            bridge.convert(inputAssetA, emptyAsset, outputAssetA, emptyAsset, swapAmount, 0, encodedPath, address(0));
 
         IERC20(outputAssetA.erc20Address).transferFrom(address(bridge), rollupProcessor, outputValueA);
 
@@ -263,11 +202,7 @@ contract UniswapBridgeUnitTest is Test {
 
         uint256 quote = QUOTER.quoteExactInput(abi.encodePacked(USDC, uint24(500), WETH), swapAmount);
         uint64 encodedPath = bridge.encodePath(
-            swapAmount,
-            quote,
-            USDC,
-            emptySplitPath,
-            UniswapBridge.SplitPath(100, 100, address(0), 100, address(0), 500)
+            swapAmount, quote, USDC, emptySplitPath, UniswapBridge.SplitPath(100, 100, address(0), 100, address(0), 500)
         );
 
         address[] memory tokensIn = new address[](1);
@@ -279,30 +214,16 @@ contract UniswapBridgeUnitTest is Test {
         bridge.preApproveTokens(tokensIn, tokensOut);
 
         // Define input and output assets
-        AztecTypes.AztecAsset memory inputAssetA = AztecTypes.AztecAsset({
-            id: 4,
-            erc20Address: USDC,
-            assetType: AztecTypes.AztecAssetType.ERC20
-        });
+        AztecTypes.AztecAsset memory inputAssetA =
+            AztecTypes.AztecAsset({id: 4, erc20Address: USDC, assetType: AztecTypes.AztecAssetType.ERC20});
 
-        AztecTypes.AztecAsset memory outputAssetA = AztecTypes.AztecAsset({
-            id: 2,
-            erc20Address: WETH,
-            assetType: AztecTypes.AztecAssetType.ERC20
-        });
+        AztecTypes.AztecAsset memory outputAssetA =
+            AztecTypes.AztecAsset({id: 2, erc20Address: WETH, assetType: AztecTypes.AztecAssetType.ERC20});
 
         deal(USDC, address(bridge), swapAmount);
 
-        (uint256 outputValueA, , ) = bridge.convert(
-            inputAssetA,
-            emptyAsset,
-            outputAssetA,
-            emptyAsset,
-            swapAmount,
-            0,
-            encodedPath,
-            address(0)
-        );
+        (uint256 outputValueA,,) =
+            bridge.convert(inputAssetA, emptyAsset, outputAssetA, emptyAsset, swapAmount, 0, encodedPath, address(0));
 
         IERC20(outputAssetA.erc20Address).transferFrom(address(bridge), rollupProcessor, outputValueA);
 
@@ -315,11 +236,7 @@ contract UniswapBridgeUnitTest is Test {
 
         uint256 quote = QUOTER.quoteExactInput(abi.encodePacked(USDT, uint24(500), WETH), swapAmount);
         uint64 encodedPath = bridge.encodePath(
-            swapAmount,
-            quote,
-            USDT,
-            emptySplitPath,
-            UniswapBridge.SplitPath(100, 100, address(0), 100, address(0), 500)
+            swapAmount, quote, USDT, emptySplitPath, UniswapBridge.SplitPath(100, 100, address(0), 100, address(0), 500)
         );
 
         address[] memory tokensIn = new address[](1);
@@ -331,30 +248,16 @@ contract UniswapBridgeUnitTest is Test {
         bridge.preApproveTokens(tokensIn, tokensOut);
 
         // Define input and output assets
-        AztecTypes.AztecAsset memory inputAssetA = AztecTypes.AztecAsset({
-            id: 4,
-            erc20Address: USDT,
-            assetType: AztecTypes.AztecAssetType.ERC20
-        });
+        AztecTypes.AztecAsset memory inputAssetA =
+            AztecTypes.AztecAsset({id: 4, erc20Address: USDT, assetType: AztecTypes.AztecAssetType.ERC20});
 
-        AztecTypes.AztecAsset memory outputAssetA = AztecTypes.AztecAsset({
-            id: 2,
-            erc20Address: WETH,
-            assetType: AztecTypes.AztecAssetType.ERC20
-        });
+        AztecTypes.AztecAsset memory outputAssetA =
+            AztecTypes.AztecAsset({id: 2, erc20Address: WETH, assetType: AztecTypes.AztecAssetType.ERC20});
 
         deal(USDT, address(bridge), swapAmount);
 
-        (uint256 outputValueA, , ) = bridge.convert(
-            inputAssetA,
-            emptyAsset,
-            outputAssetA,
-            emptyAsset,
-            swapAmount,
-            0,
-            encodedPath,
-            address(0)
-        );
+        (uint256 outputValueA,,) =
+            bridge.convert(inputAssetA, emptyAsset, outputAssetA, emptyAsset, swapAmount, 0, encodedPath, address(0));
 
         IERC20(outputAssetA.erc20Address).transferFrom(address(bridge), rollupProcessor, outputValueA);
 
@@ -378,30 +281,17 @@ contract UniswapBridgeUnitTest is Test {
         bridge.preApproveTokens(tokensIn, tokensOut);
 
         // Define input and output assets
-        AztecTypes.AztecAsset memory inputAssetA = AztecTypes.AztecAsset({
-            id: 0,
-            erc20Address: address(0),
-            assetType: AztecTypes.AztecAssetType.ETH
-        });
+        AztecTypes.AztecAsset memory inputAssetA =
+            AztecTypes.AztecAsset({id: 0, erc20Address: address(0), assetType: AztecTypes.AztecAssetType.ETH});
 
-        AztecTypes.AztecAsset memory outputAssetA = AztecTypes.AztecAsset({
-            id: 2,
-            erc20Address: DAI,
-            assetType: AztecTypes.AztecAssetType.ERC20
-        });
+        AztecTypes.AztecAsset memory outputAssetA =
+            AztecTypes.AztecAsset({id: 2, erc20Address: DAI, assetType: AztecTypes.AztecAssetType.ERC20});
 
         deal(rollupProcessor, swapAmount);
 
         vm.expectRevert(UniswapBridge.InsufficientAmountOut.selector);
         bridge.convert{value: swapAmount}(
-            inputAssetA,
-            emptyAsset,
-            outputAssetA,
-            emptyAsset,
-            swapAmount,
-            0,
-            encodedPath,
-            address(0)
+            inputAssetA, emptyAsset, outputAssetA, emptyAsset, swapAmount, 0, encodedPath, address(0)
         );
     }
 
@@ -410,11 +300,7 @@ contract UniswapBridgeUnitTest is Test {
         uint256 swapAmount = bound(_swapAmount, 1e17, 1e22);
 
         uint64 encodedPath = bridge.encodePath(
-            swapAmount,
-            0,
-            WETH,
-            emptySplitPath,
-            UniswapBridge.SplitPath(100, 500, USDC, 100, address(0), 3000)
+            swapAmount, 0, WETH, emptySplitPath, UniswapBridge.SplitPath(100, 500, USDC, 100, address(0), 3000)
         );
 
         address[] memory tokensIn = new address[](1);
@@ -426,32 +312,18 @@ contract UniswapBridgeUnitTest is Test {
         bridge.preApproveTokens(tokensIn, tokensOut);
 
         // Define input and output assets
-        AztecTypes.AztecAsset memory inputAssetA = AztecTypes.AztecAsset({
-            id: 2,
-            erc20Address: WETH,
-            assetType: AztecTypes.AztecAssetType.ERC20
-        });
+        AztecTypes.AztecAsset memory inputAssetA =
+            AztecTypes.AztecAsset({id: 2, erc20Address: WETH, assetType: AztecTypes.AztecAssetType.ERC20});
 
-        AztecTypes.AztecAsset memory outputAssetA = AztecTypes.AztecAsset({
-            id: 4,
-            erc20Address: GUSD,
-            assetType: AztecTypes.AztecAssetType.ERC20
-        });
+        AztecTypes.AztecAsset memory outputAssetA =
+            AztecTypes.AztecAsset({id: 4, erc20Address: GUSD, assetType: AztecTypes.AztecAssetType.ERC20});
 
         uint256 quote = bridge.quote(swapAmount, inputAssetA.erc20Address, encodedPath, outputAssetA.erc20Address);
 
         deal(WETH, address(bridge), swapAmount);
 
-        (uint256 outputValueA, , ) = bridge.convert(
-            inputAssetA,
-            emptyAsset,
-            outputAssetA,
-            emptyAsset,
-            swapAmount,
-            0,
-            encodedPath,
-            address(0)
-        );
+        (uint256 outputValueA,,) =
+            bridge.convert(inputAssetA, emptyAsset, outputAssetA, emptyAsset, swapAmount, 0, encodedPath, address(0));
 
         IERC20(outputAssetA.erc20Address).transferFrom(address(bridge), rollupProcessor, outputValueA);
 

--- a/src/test/bridges/yearn/YearnBridgeE2E.t.sol
+++ b/src/test/bridges/yearn/YearnBridgeE2E.t.sol
@@ -82,7 +82,7 @@ contract YearnBridgeE2ETest is BridgeTestBase {
     function testMoreERC20DepositAndWithdrawal() public {
         IYearnRegistry _registry = bridge.YEARN_REGISTRY();
         uint256 numTokens = _registry.numTokens();
-        for (uint256 i; i < numTokens; ) {
+        for (uint256 i; i < numTokens;) {
             address token = _registry.tokens(i);
             if (
                 token == address(WETH) || token == 0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F //SNX, packed slot not supported
@@ -119,11 +119,7 @@ contract YearnBridgeE2ETest is BridgeTestBase {
         bridge.finalise(emptyAsset, emptyAsset, emptyAsset, emptyAsset, 0, 0);
     }
 
-    function _depositAndWithdrawERC20(
-        address _vault,
-        uint256 _depositAmount,
-        bool _reduceVault
-    ) internal {
+    function _depositAndWithdrawERC20(address _vault, uint256 _depositAmount, bool _reduceVault) internal {
         address underlyingToken = IYearnVault(_vault).token();
 
         if (underlyingToken == 0xc5bDdf9843308380375a611c18B50Fb9341f502A) {
@@ -151,13 +147,7 @@ contract YearnBridgeE2ETest is BridgeTestBase {
         uint256 outputAssetABefore = IERC20(address(_vault)).balanceOf(address(ROLLUP_PROCESSOR));
         // Computes the encoded data for the specific bridge interaction
         uint256 bridgeCallData = ROLLUP_ENCODER.defiInteractionL2(
-            depositBridgeId,
-            depositInputAssetA,
-            emptyAsset,
-            depositOutputAssetA,
-            emptyAsset,
-            0,
-            _depositAmount
+            depositBridgeId, depositInputAssetA, emptyAsset, depositOutputAssetA, emptyAsset, 0, _depositAmount
         );
         vm.expectEmit(true, true, false, false); //Log 1 -> transfer _depositAmount from ROLLUP_PROCESSOR to bridge
         emit Transfer(address(ROLLUP_PROCESSOR), address(bridge), _depositAmount);
@@ -169,13 +159,7 @@ contract YearnBridgeE2ETest is BridgeTestBase {
         emit Transfer(address(bridge), address(ROLLUP_PROCESSOR), _depositAmount);
 
         ROLLUP_ENCODER.registerEventToBeChecked(
-            bridgeCallData,
-            ROLLUP_ENCODER.getNextNonce(),
-            _depositAmount,
-            _depositAmount,
-            0,
-            true,
-            ""
+            bridgeCallData, ROLLUP_ENCODER.getNextNonce(), _depositAmount, _depositAmount, 0, true, ""
         );
         ROLLUP_ENCODER.processRollup();
 
@@ -195,13 +179,7 @@ contract YearnBridgeE2ETest is BridgeTestBase {
         uint256 withdrawAmount = outputAssetAMid;
 
         bridgeCallData = ROLLUP_ENCODER.defiInteractionL2(
-            withdrawBridgeId,
-            depositOutputAssetA,
-            emptyAsset,
-            depositInputAssetA,
-            emptyAsset,
-            1,
-            withdrawAmount
+            withdrawBridgeId, depositOutputAssetA, emptyAsset, depositInputAssetA, emptyAsset, 1, withdrawAmount
         );
 
         vm.expectEmit(true, true, false, false); //Log 1 -> transfer _withdrawAmount from Rollup to bridge
@@ -214,13 +192,7 @@ contract YearnBridgeE2ETest is BridgeTestBase {
         emit Transfer(address(bridge), address(ROLLUP_PROCESSOR), withdrawAmount);
 
         ROLLUP_ENCODER.registerEventToBeChecked(
-            bridgeCallData,
-            ROLLUP_ENCODER.getNextNonce(),
-            withdrawAmount,
-            withdrawAmount,
-            1,
-            true,
-            ""
+            bridgeCallData, ROLLUP_ENCODER.getNextNonce(), withdrawAmount, withdrawAmount, 1, true, ""
         );
         ROLLUP_ENCODER.processRollup();
         uint256 inputAssetAAfter = IERC20(underlyingToken).balanceOf(address(ROLLUP_PROCESSOR));
@@ -228,9 +200,7 @@ contract YearnBridgeE2ETest is BridgeTestBase {
 
         assertGt(inputAssetAAfter, inputAssetAMid, "Balance missmatch after withdrawal");
         assertEq(
-            outputAssetAAfter,
-            outputAssetAMid - withdrawAmount,
-            "No change in output asset balance after withdraw"
+            outputAssetAAfter, outputAssetAMid - withdrawAmount, "No change in output asset balance after withdraw"
         );
 
         assertEq(
@@ -240,11 +210,7 @@ contract YearnBridgeE2ETest is BridgeTestBase {
         );
     }
 
-    function _depositAndWithdrawETH(
-        address _vault,
-        uint256 _depositAmount,
-        uint256 _withdrawAmount
-    ) internal {
+    function _depositAndWithdrawETH(address _vault, uint256 _depositAmount, uint256 _withdrawAmount) internal {
         vm.deal(address(ROLLUP_PROCESSOR), _depositAmount);
         _addSupportedIfNotAdded(address(_vault));
 
@@ -255,13 +221,7 @@ contract YearnBridgeE2ETest is BridgeTestBase {
         uint256 outputAssetABefore = IERC20(address(_vault)).balanceOf(address(ROLLUP_PROCESSOR));
 
         ROLLUP_ENCODER.defiInteractionL2(
-            depositBridgeId,
-            depositInputAssetA,
-            emptyAsset,
-            depositOutputAssetA,
-            emptyAsset,
-            0,
-            _depositAmount
+            depositBridgeId, depositInputAssetA, emptyAsset, depositOutputAssetA, emptyAsset, 0, _depositAmount
         );
         ROLLUP_ENCODER.processRollup();
         uint256 inputAssetAMid = address(ROLLUP_PROCESSOR).balance;
@@ -270,13 +230,7 @@ contract YearnBridgeE2ETest is BridgeTestBase {
         assertGt(outputAssetAMid, outputAssetABefore, "deposit eth - output asset balance too low");
 
         ROLLUP_ENCODER.defiInteractionL2(
-            withdrawBridgeId,
-            depositOutputAssetA,
-            emptyAsset,
-            depositInputAssetA,
-            emptyAsset,
-            1,
-            _withdrawAmount
+            withdrawBridgeId, depositOutputAssetA, emptyAsset, depositInputAssetA, emptyAsset, 1, _withdrawAmount
         );
         vm.assume(_withdrawAmount > 1 && _withdrawAmount <= outputAssetAMid);
         ROLLUP_ENCODER.processRollup();

--- a/src/test/bridges/yearn/YearnUnit.t.sol
+++ b/src/test/bridges/yearn/YearnUnit.t.sol
@@ -61,16 +61,10 @@ contract YearnBridgeUnitTest is Test {
     }
 
     function testInvalidNoValueETH() public {
-        AztecTypes.AztecAsset memory depositInputAssetA = AztecTypes.AztecAsset({
-            id: 0,
-            erc20Address: address(0),
-            assetType: AztecTypes.AztecAssetType.ETH
-        });
-        AztecTypes.AztecAsset memory depositOutputAssetA = AztecTypes.AztecAsset({
-            id: 100,
-            erc20Address: address(YVETH),
-            assetType: AztecTypes.AztecAssetType.ERC20
-        });
+        AztecTypes.AztecAsset memory depositInputAssetA =
+            AztecTypes.AztecAsset({id: 0, erc20Address: address(0), assetType: AztecTypes.AztecAssetType.ETH});
+        AztecTypes.AztecAsset memory depositOutputAssetA =
+            AztecTypes.AztecAsset({id: 100, erc20Address: address(YVETH), assetType: AztecTypes.AztecAssetType.ERC20});
 
         vm.prank(rollupProcessor);
         vm.expectRevert();
@@ -90,27 +84,14 @@ contract YearnBridgeUnitTest is Test {
         deal(address(DAI), address(bridge), _depositAmount);
         uint256 daiBalanceBefore = DAI.balanceOf(address(bridge));
 
-        AztecTypes.AztecAsset memory depositInputAssetA = AztecTypes.AztecAsset({
-            id: 1,
-            erc20Address: address(DAI),
-            assetType: AztecTypes.AztecAssetType.ERC20
-        });
-        AztecTypes.AztecAsset memory depositOutputAssetA = AztecTypes.AztecAsset({
-            id: 1,
-            erc20Address: address(vault),
-            assetType: AztecTypes.AztecAssetType.ERC20
-        });
+        AztecTypes.AztecAsset memory depositInputAssetA =
+            AztecTypes.AztecAsset({id: 1, erc20Address: address(DAI), assetType: AztecTypes.AztecAssetType.ERC20});
+        AztecTypes.AztecAsset memory depositOutputAssetA =
+            AztecTypes.AztecAsset({id: 1, erc20Address: address(vault), assetType: AztecTypes.AztecAssetType.ERC20});
 
         // Deposit
-        (uint256 outputValueA, , ) = bridge.convert(
-            depositInputAssetA,
-            emptyAsset,
-            depositOutputAssetA,
-            emptyAsset,
-            _depositAmount,
-            0,
-            0,
-            address(0)
+        (uint256 outputValueA,,) = bridge.convert(
+            depositInputAssetA, emptyAsset, depositOutputAssetA, emptyAsset, _depositAmount, 0, 0, address(0)
         );
         uint256 daiBalanceMid = DAI.balanceOf(address(bridge));
         uint256 shareAmountMid = IERC20(address(vault)).balanceOf(address(bridge));
@@ -120,15 +101,8 @@ contract YearnBridgeUnitTest is Test {
 
         // Withdraw
         _withdrawAmount = bound(_withdrawAmount, 1, outputValueA);
-        (uint256 outputValueA2, , ) = bridge.convert(
-            depositOutputAssetA,
-            emptyAsset,
-            depositInputAssetA,
-            emptyAsset,
-            _withdrawAmount,
-            0,
-            1,
-            address(0)
+        (uint256 outputValueA2,,) = bridge.convert(
+            depositOutputAssetA, emptyAsset, depositInputAssetA, emptyAsset, _withdrawAmount, 0, 1, address(0)
         );
         uint256 daiBalanceAfter = DAI.balanceOf(address(bridge));
         uint256 shareAmountAfter = IERC20(address(vault)).balanceOf(address(bridge));
@@ -144,27 +118,14 @@ contract YearnBridgeUnitTest is Test {
         vm.deal(address(rollupProcessor), _depositAmount);
         uint256 ethBalanceBefore = address(rollupProcessor).balance;
 
-        AztecTypes.AztecAsset memory depositInputAssetA = AztecTypes.AztecAsset({
-            id: 1,
-            erc20Address: address(0),
-            assetType: AztecTypes.AztecAssetType.ETH
-        });
-        AztecTypes.AztecAsset memory depositOutputAssetA = AztecTypes.AztecAsset({
-            id: 2,
-            erc20Address: address(vault),
-            assetType: AztecTypes.AztecAssetType.ERC20
-        });
+        AztecTypes.AztecAsset memory depositInputAssetA =
+            AztecTypes.AztecAsset({id: 1, erc20Address: address(0), assetType: AztecTypes.AztecAssetType.ETH});
+        AztecTypes.AztecAsset memory depositOutputAssetA =
+            AztecTypes.AztecAsset({id: 2, erc20Address: address(vault), assetType: AztecTypes.AztecAssetType.ERC20});
 
         // Deposit
-        (uint256 outputValueA, , ) = bridge.convert{value: _depositAmount}(
-            depositInputAssetA,
-            emptyAsset,
-            depositOutputAssetA,
-            emptyAsset,
-            _depositAmount,
-            0,
-            0,
-            address(0)
+        (uint256 outputValueA,,) = bridge.convert{value: _depositAmount}(
+            depositInputAssetA, emptyAsset, depositOutputAssetA, emptyAsset, _depositAmount, 0, 0, address(0)
         );
         uint256 ethBalanceMid = address(rollupProcessor).balance;
         uint256 shareAmountMid = IERC20(address(vault)).balanceOf(address(bridge));
@@ -174,15 +135,8 @@ contract YearnBridgeUnitTest is Test {
 
         // Withdraw
         _withdrawAmount = bound(_withdrawAmount, 1, outputValueA);
-        (uint256 outputValueA2, , ) = bridge.convert(
-            depositOutputAssetA,
-            emptyAsset,
-            depositInputAssetA,
-            emptyAsset,
-            _withdrawAmount,
-            0,
-            1,
-            address(0)
+        (uint256 outputValueA2,,) = bridge.convert(
+            depositOutputAssetA, emptyAsset, depositInputAssetA, emptyAsset, _withdrawAmount, 0, 1, address(0)
         );
         assertGt(outputValueA2, 0, "ETH receive should not be 0");
         assertLt(IERC20(address(vault)).balanceOf(address(bridge)), shareAmountMid, "Invalid share amount");


### PR DESCRIPTION
# Description

Replace prettier with forge fmt.

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] There are no unexpected formatting changes, or superfluous debug logs.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewers next convenience.
- [x] NatSpec documentation of all the non-test functions is present and is complete.
- [x] Continuous integration (CI) passes.
- [ ] Command `forge coverage --match-contract MyContract` returns 100% line coverage.
- [ ] All the possible reverts are tested.
