### PR TITLE
Setting slippage in TroveBridge's client

### DIFF
--- a/src/client/bridge-data.ts
+++ b/src/client/bridge-data.ts
@@ -153,6 +153,6 @@ export interface BridgeDataFieldGetters {
   getCurrentCR?(): Promise<bigint>;
   getUserDebtAndCollateral?(tbAmount: bigint): Promise<[bigint, bigint]>;
 
-  // User in TroveBridge client
+  // Used in TroveBridge client
   getCustomMaxPrice?(slippage: bigint): Promise<bigint>;
 }

--- a/src/client/bridge-data.ts
+++ b/src/client/bridge-data.ts
@@ -152,4 +152,7 @@ export interface BridgeDataFieldGetters {
   getBorrowingFee?(borrowAmount: bigint): Promise<bigint>;
   getCurrentCR?(): Promise<bigint>;
   getUserDebtAndCollateral?(tbAmount: bigint): Promise<[bigint, bigint]>;
+
+  // User in TroveBridge client
+  getCustomMaxPrice?(slippage: bigint): Promise<bigint>;
 }

--- a/src/client/liquity/trove-bridge-data.test.ts
+++ b/src/client/liquity/trove-bridge-data.test.ts
@@ -18,6 +18,8 @@ type Mockify<T> = {
 };
 
 describe("Liquity trove bridge data", () => {
+  const bridgeAddressId = 17;
+
   let troveBridge: Mockify<TroveBridge>;
   let troveManager: Mockify<ITroveManager>;
   let priceFeed: Mockify<IPriceFeed>;
@@ -62,14 +64,14 @@ describe("Liquity trove bridge data", () => {
 
     ITroveManager__factory.connect = () => troveManager as any;
 
-    const troveBridgeData = TroveBridgeData.create(provider, tbAsset.erc20Address);
+    const troveBridgeData = TroveBridgeData.create(provider, bridgeAddressId, tbAsset.erc20Address);
 
     const auxDataBorrow = await troveBridgeData.getAuxData(ethAsset, emptyAsset, tbAsset, lusdAsset);
     expect(auxDataBorrow[0]).toBe(6000000000000000n);
   });
 
   it("should correctly fetch auxData when not borrowing", async () => {
-    const troveBridgeData = TroveBridgeData.create(provider, tbAsset.erc20Address);
+    const troveBridgeData = TroveBridgeData.create(provider, bridgeAddressId, tbAsset.erc20Address);
 
     const auxDataBorrow = await troveBridgeData.getAuxData(tbAsset, lusdAsset, ethAsset, lusdAsset);
     expect(auxDataBorrow[0]).toBe(0n);
@@ -86,7 +88,7 @@ describe("Liquity trove bridge data", () => {
     };
     TroveBridge__factory.connect = () => troveBridge as any;
 
-    const troveBridgeData = TroveBridgeData.create(provider, tbAsset.erc20Address);
+    const troveBridgeData = TroveBridgeData.create(provider, bridgeAddressId, tbAsset.erc20Address);
 
     const outputBorrow = await troveBridgeData.getExpectedOutput(
       ethAsset,
@@ -120,7 +122,7 @@ describe("Liquity trove bridge data", () => {
 
     ITroveManager__factory.connect = () => troveManager as any;
 
-    const troveBridgeData = TroveBridgeData.create(provider, tbAsset.erc20Address);
+    const troveBridgeData = TroveBridgeData.create(provider, bridgeAddressId, tbAsset.erc20Address);
 
     const inputValue = 10n ** 18n;
     const output = await troveBridgeData.getExpectedOutput(tbAsset, lusdAsset, ethAsset, lusdAsset, 0n, inputValue);
@@ -144,7 +146,7 @@ describe("Liquity trove bridge data", () => {
 
     ITroveManager__factory.connect = () => troveManager as any;
 
-    const troveBridgeData = TroveBridgeData.create(provider, tbAsset.erc20Address);
+    const troveBridgeData = TroveBridgeData.create(provider, bridgeAddressId, tbAsset.erc20Address);
 
     const output = await troveBridgeData.getMarketSize(emptyAsset, emptyAsset, emptyAsset, emptyAsset, 0n);
     const marketSize = output[0];
@@ -171,7 +173,7 @@ describe("Liquity trove bridge data", () => {
     };
     IPriceFeed__factory.connect = () => priceFeed as any;
 
-    const troveBridgeData = TroveBridgeData.create(provider, tbAsset.erc20Address);
+    const troveBridgeData = TroveBridgeData.create(provider, bridgeAddressId, tbAsset.erc20Address);
 
     const borrowAmount = 1000n * 10n ** 18n; // 1000 LUSD
     const borrowingFee = await troveBridgeData.getBorrowingFee(borrowAmount);
@@ -197,7 +199,7 @@ describe("Liquity trove bridge data", () => {
     };
     IPriceFeed__factory.connect = () => priceFeed as any;
 
-    const troveBridgeData = TroveBridgeData.create(provider, tbAsset.erc20Address);
+    const troveBridgeData = TroveBridgeData.create(provider, bridgeAddressId, tbAsset.erc20Address);
 
     const borrowAmount = 1000n * 10n ** 18n; // 1000 LUSD
     const borrowingFee = await troveBridgeData.getBorrowingFee(borrowAmount);
@@ -222,7 +224,7 @@ describe("Liquity trove bridge data", () => {
     };
     IPriceFeed__factory.connect = () => priceFeed as any;
 
-    const troveBridgeData = TroveBridgeData.create(provider, tbAsset.erc20Address);
+    const troveBridgeData = TroveBridgeData.create(provider, bridgeAddressId, tbAsset.erc20Address);
 
     const currentCR = await troveBridgeData.getCurrentCR();
     expect(currentCR).toBe(250n);
@@ -248,7 +250,7 @@ describe("Liquity trove bridge data", () => {
 
     ITroveManager__factory.connect = () => troveManager as any;
 
-    const troveBridgeData = TroveBridgeData.create(provider, tbAsset.erc20Address);
+    const troveBridgeData = TroveBridgeData.create(provider, bridgeAddressId, tbAsset.erc20Address);
 
     const inputValue = 10n ** 18n; // 1 TB
     const output = await troveBridgeData.getUserDebtAndCollateral(inputValue);

--- a/src/client/liquity/trove-bridge-data.test.ts
+++ b/src/client/liquity/trove-bridge-data.test.ts
@@ -70,11 +70,25 @@ describe("Liquity trove bridge data", () => {
     expect(auxDataBorrow[0]).toBe(6000000000000000n);
   });
 
-  it("should correctly fetch auxData when not borrowing", async () => {
+  it("should correctly fetch auxData when repaying", async () => {
     const troveBridgeData = TroveBridgeData.create(provider, bridgeAddressId, tbAsset.erc20Address);
 
     const auxDataBorrow = await troveBridgeData.getAuxData(tbAsset, lusdAsset, ethAsset, lusdAsset);
     expect(auxDataBorrow[0]).toBe(0n);
+  });
+
+  it("should correctly set auxData from Falafel when repaying with collateral and there is a batch with acceptable price", async () => {
+    const troveBridgeData = TroveBridgeData.create(provider, bridgeAddressId, tbAsset.erc20Address);
+
+    const auxData = await troveBridgeData.getAuxData(tbAsset, lusdAsset, ethAsset, emptyAsset);
+    // TODO setup mocks and check the auxData was selected as expected
+  });
+
+  it("should correctly set custom auxData when repaying with collateral and there is not a batch with acceptable price", async () => {
+    const troveBridgeData = TroveBridgeData.create(provider, bridgeAddressId, tbAsset.erc20Address);
+
+    const auxData = await troveBridgeData.getAuxData(tbAsset, lusdAsset, ethAsset, emptyAsset);
+    // TODO setup mocks and check the auxData was selected as expected
   });
 
   it("should correctly get expected output when borrowing", async () => {

--- a/src/client/liquity/trove-bridge-data.ts
+++ b/src/client/liquity/trove-bridge-data.ts
@@ -39,6 +39,7 @@ export class TroveBridgeData implements BridgeDataFieldGetters {
 
   /**
    * @param provider Ethereum provider
+   * @param bridgeAddressId An id representing bridge address in the RollupProcessor contract
    * @param bridgeAddress Address of the bridge address (and the corresponding accounting token)
    */
   static create(provider: EthereumProvider, bridgeAddressId: number, bridgeAddress: EthAddress) {

--- a/src/client/liquity/trove-bridge-data.ts
+++ b/src/client/liquity/trove-bridge-data.ts
@@ -22,6 +22,7 @@ export class TroveBridgeData implements BridgeDataFieldGetters {
   // Price precision
   public readonly PRECISION = 10n ** 18n;
 
+  // Note: max setting has to be set significantly higher than the ideal setting in order for the aggregation to work
   public readonly IDEAL_SLIPPAGE_SETTING = 200n; // Denominated in basis points
   public readonly MAX_ACCEPTABLE_BATCH_SLIPPAGE_SETTING = 500n; // Denominated in basis points
 

--- a/src/client/liquity/trove-bridge-data.ts
+++ b/src/client/liquity/trove-bridge-data.ts
@@ -22,8 +22,8 @@ export class TroveBridgeData implements BridgeDataFieldGetters {
   // Price precision
   public readonly PRECISION = 10n ** 18n;
 
-  public readonly MAX_ACCEPTABLE_SLIPPAGE = 500n; // Denominated in basis points
-  public readonly IDEAL_SLIPPAGE = 200n; // Denominated in basis points
+  public readonly IDEAL_SLIPPAGE_SETTING = 200n; // Denominated in basis points
+  public readonly MAX_ACCEPTABLE_BATCH_SLIPPAGE_SETTING = 500n; // Denominated in basis points
 
   private price?: BigNumber;
 
@@ -45,6 +45,7 @@ export class TroveBridgeData implements BridgeDataFieldGetters {
     const troveManager = ITroveManager__factory.connect("0xA39739EF8b0231DbFA0DcdA07d7e29faAbCf4bb2", ethersProvider);
     const bridge = TroveBridge__factory.connect(bridgeAddress.toString(), ethersProvider);
 
+    // Precision of the feeds is 1e8
     const ethUsdOracle = IChainlinkOracle__factory.connect(
       "0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419",
       ethersProvider,
@@ -229,7 +230,7 @@ export class TroveBridgeData implements BridgeDataFieldGetters {
    * @return Maximum acceptable price of LUSD
    */
   async getCustomMaxPrice(slippage: bigint): Promise<bigint> {
-    const lusdPriceInEth = await this.getLusdPrice();
+    const lusdPriceInEth = await this.getLusdPriceInEth();
 
     return (lusdPriceInEth * (10000n + slippage)) / 10000n;
   }
@@ -257,8 +258,8 @@ export class TroveBridgeData implements BridgeDataFieldGetters {
       outputAssetIdB,
     );
 
-    const lusdPriceInEth = await this.getLusdPrice();
-    const maxPrice = (lusdPriceInEth * (10000n + this.MAX_ACCEPTABLE_SLIPPAGE)) / 10000n;
+    const lusdPriceInEth = await this.getLusdPriceInEth();
+    const maxPrice = (lusdPriceInEth * (10000n + this.MAX_ACCEPTABLE_BATCH_SLIPPAGE_SETTING)) / 10000n;
 
     for (const existingBatchPrice of relevantAuxDatas) {
       if (lusdPriceInEth < existingBatchPrice && existingBatchPrice < maxPrice) {
@@ -266,7 +267,7 @@ export class TroveBridgeData implements BridgeDataFieldGetters {
       }
     }
 
-    return (lusdPriceInEth * (10000n + this.IDEAL_SLIPPAGE)) / 10000n;
+    return (lusdPriceInEth * (10000n + this.IDEAL_SLIPPAGE_SETTING)) / 10000n;
   }
 
   private async fetchRelevantAuxDataFromFalafel(
@@ -305,7 +306,10 @@ export class TroveBridgeData implements BridgeDataFieldGetters {
     return auxDatas;
   }
 
-  private async getLusdPrice(): Promise<bigint> {
+  /**
+   * @return LUSD price denominated in ETH using a 1e18 precision
+   */
+  private async getLusdPriceInEth(): Promise<bigint> {
     // Both feeds use 8 decimals
     const [, ethPrice, , ,] = await this.ethUsdOracle.latestRoundData();
     const [, lusdPrice, , ,] = await this.lusdUsdOracle.latestRoundData();


### PR DESCRIPTION
# Description

Setting slippage in TroveBridge's client based on Oracle price and existing batches in Falafel.

@joss-aztec Added `getCustomMaxPrice` function to the interface which is expected to be used when the user wants to set a custom slippage.

@LHerskind Pls check if you think that how I compute LUSD price denominated in ETH in the `getLusdPrice` is ok with you. I am combining the 2 prices there. I think it's probably necessary to combine both price feeds but curious if you agree (official Liquity oracle assumes 1 LUSD is equal to 1 USD).

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] There are no unexpected formatting changes, or superfluous debug logs.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewers next convenience.
- [x] NatSpec documentation of all the non-test functions is present and is complete.
- [ ] Continuous integration (CI) passes.
- [ ] Command `forge coverage --match-contract MyContract` returns 100% line coverage.
- [ ] All the possible reverts are tested.
