### PR TITLE
Subsidy support in UniswapBridge

### DIFF
--- a/src/bridges/uniswap/UniswapBridge.sol
+++ b/src/bridges/uniswap/UniswapBridge.sol
@@ -155,6 +155,11 @@ contract UniswapBridge is BridgeBase {
         }
     }
 
+    /**
+     * @notice Registers subsidy criteria for a given token pair.
+     * @param _tokenIn - Input token to swap
+     * @param _tokenOut - Output token to swap
+     */
     function registerSubsidyCriteria(address _tokenIn, address _tokenOut) external {
         SUBSIDY.setGasUsageAndMinGasPerMinute({
             _criteria: _computeCriteria(_tokenIn, _tokenOut),

--- a/src/bridges/uniswap/UniswapBridge.sol
+++ b/src/bridges/uniswap/UniswapBridge.sol
@@ -156,11 +156,10 @@ contract UniswapBridge is BridgeBase {
     }
 
     function registerSubsidyCriteria(address _tokenIn, address _tokenOut) external {
-        // TODO: gas measurements and updating these values
         SUBSIDY.setGasUsageAndMinGasPerMinute({
             _criteria: _computeCriteria(_tokenIn, _tokenOut),
-            _gasUsage: uint32(100000),
-            _minGasPerMinute: uint32(170)
+            _gasUsage: uint32(300000), // 300k gas (Note: this is a gas usage when only 1 split path is used)
+            _minGasPerMinute: uint32(100) // 1 fully subsidized call per 2 days (300k / (24 * 60) / 2)
         });
     }
 

--- a/src/bridges/uniswap/UniswapBridge.sol
+++ b/src/bridges/uniswap/UniswapBridge.sol
@@ -155,6 +155,15 @@ contract UniswapBridge is BridgeBase {
         }
     }
 
+    function registerSubsidyCriteria(address _tokenIn, address _tokenOut) external {
+        // TODO: gas measurements and updating these values
+        SUBSIDY.setGasUsageAndMinGasPerMinute({
+            _criteria: _computeCriteria(_tokenIn, _tokenOut),
+            _gasUsage: uint32(100000),
+            _minGasPerMinute: uint32(170)
+        });
+    }
+
     /**
      * @notice A function which swaps input token for output token along the path encoded in _auxData.
      * @param _inputAssetA - Input ERC20 token
@@ -162,6 +171,7 @@ contract UniswapBridge is BridgeBase {
      * @param _totalInputValue - Amount of input token to swap
      * @param _interactionNonce - Interaction nonce
      * @param _auxData - Encoded path (gets decoded to Path struct)
+     * @param _rollupBeneficiary - Address which receives subsidy if the call is eligible for it
      * @return outputValueA - The amount of output token received
      */
     function convert(
@@ -172,8 +182,13 @@ contract UniswapBridge is BridgeBase {
         uint256 _totalInputValue,
         uint256 _interactionNonce,
         uint64 _auxData,
-        address
+        address _rollupBeneficiary
     ) external payable override (BridgeBase) onlyRollup returns (uint256 outputValueA, uint256, bool) {
+        // Accumulate subsidy to _rollupBeneficiary
+        SUBSIDY.claimSubsidy(
+            _computeCriteria(_inputAssetA.erc20Address, _outputAssetA.erc20Address), _rollupBeneficiary
+        );
+
         bool inputIsEth = _inputAssetA.assetType == AztecTypes.AztecAssetType.ETH;
         bool outputIsEth = _outputAssetA.assetType == AztecTypes.AztecAssetType.ETH;
 
@@ -286,6 +301,26 @@ contract UniswapBridge is BridgeBase {
             // Swap using the second swap path
             amountOut += QUOTER.quoteExactInput(path.splitPath2, _amountIn - inputValueSplitPath1);
         }
+    }
+
+    /**
+     * @notice Computes the criteria that is passed when claiming subsidy.
+     * @param _inputAssetA The input asset
+     * @param _outputAssetA The output asset
+     * @return The criteria
+     */
+    function computeCriteria(
+        AztecTypes.AztecAsset calldata _inputAssetA,
+        AztecTypes.AztecAsset calldata,
+        AztecTypes.AztecAsset calldata _outputAssetA,
+        AztecTypes.AztecAsset calldata,
+        uint64
+    ) public pure override (BridgeBase) returns (uint256) {
+        return _computeCriteria(_inputAssetA.erc20Address, _outputAssetA.erc20Address);
+    }
+
+    function _computeCriteria(address _inputToken, address _outputToken) internal pure returns (uint256) {
+        return uint256(keccak256(abi.encodePacked(_inputToken, _outputToken)));
     }
 
     /**

--- a/src/gas/uniswap/UniswapGas.s.sol
+++ b/src/gas/uniswap/UniswapGas.s.sol
@@ -20,6 +20,8 @@ contract UniswapMeasure is UniswapDeployment {
     address private constant BENEFICIARY = address(uint160(uint256(keccak256(abi.encodePacked("_BENEFICIARY")))));
 
     address public constant USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
+    address public constant USDT = 0xdAC17F958D2ee523a2206206994597C13D831ec7;
+    address public constant FRAX = 0x853d955aCEf822Db058eb8505911ED77F175b99e;
 
     GasBase internal gasBase;
     UniswapBridge internal bridge;
@@ -92,13 +94,13 @@ contract UniswapMeasure is UniswapDeployment {
         emit log_named_uint("Claimable subsidy after deposit", claimableSubsidyAfterDeposit);
     }
 
-    function measure2SplitPathsSwap() public {
+    function measureMaxComplexPath() public {
         uint64 path = bridge.encodePath(
             1 ether,
             1e20,
             WETH,
-            UniswapBridge.SplitPath(50, 500, USDC, 100, address(0), 100),
-            UniswapBridge.SplitPath(50, 500, USDC, 100, address(0), 100)
+            UniswapBridge.SplitPath(50, 500, USDC, 100, FRAX, 500),
+            UniswapBridge.SplitPath(50, 3000, USDT, 100, USDC, 500)
         );
 
         vm.broadcast();
@@ -108,7 +110,7 @@ contract UniswapMeasure is UniswapDeployment {
         {
             vm.broadcast();
             gasBase.convert(
-                address(bridge), ethAsset, emptyAsset, daiAsset, emptyAsset, 1 ether, 0, path, BENEFICIARY, 430000
+                address(bridge), ethAsset, emptyAsset, daiAsset, emptyAsset, 1 ether, 0, path, BENEFICIARY, 660000
             );
         }
 

--- a/src/gas/uniswap/UniswapGas.s.sol
+++ b/src/gas/uniswap/UniswapGas.s.sol
@@ -80,11 +80,35 @@ contract UniswapMeasure is UniswapDeployment {
         address(gasBase).call{value: 2 ether}("");
         emit log_named_uint("ETH balance of gasBase", address(gasBase).balance);
 
-        // Deposit
         {
             vm.broadcast();
             gasBase.convert(
                 address(bridge), ethAsset, emptyAsset, daiAsset, emptyAsset, 1 ether, 0, path, BENEFICIARY, 300000
+            );
+        }
+
+        uint256 claimableSubsidyAfterDeposit = SUBSIDY.claimableAmount(BENEFICIARY);
+        assertGt(claimableSubsidyAfterDeposit, 0, "Subsidy was not claimed during deposit");
+        emit log_named_uint("Claimable subsidy after deposit", claimableSubsidyAfterDeposit);
+    }
+
+    function measure2SplitPathsSwap() public {
+        uint64 path = bridge.encodePath(
+            1 ether,
+            1e20,
+            WETH,
+            UniswapBridge.SplitPath(50, 500, USDC, 100, address(0), 100),
+            UniswapBridge.SplitPath(50, 500, USDC, 100, address(0), 100)
+        );
+
+        vm.broadcast();
+        address(gasBase).call{value: 2 ether}("");
+        emit log_named_uint("ETH balance of gasBase", address(gasBase).balance);
+
+        {
+            vm.broadcast();
+            gasBase.convert(
+                address(bridge), ethAsset, emptyAsset, daiAsset, emptyAsset, 1 ether, 0, path, BENEFICIARY, 430000
             );
         }
 

--- a/src/gas/uniswap/UniswapGas.s.sol
+++ b/src/gas/uniswap/UniswapGas.s.sol
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2022 Aztec.
+pragma solidity >=0.8.4;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {UniswapBridge} from "../../bridges/uniswap/UniswapBridge.sol";
+import {AztecTypes} from "rollup-encoder/libraries/AztecTypes.sol";
+import {ISubsidy} from "../../aztec/interfaces/ISubsidy.sol";
+import {IWETH} from "../../interfaces/IWETH.sol";
+
+import {UniswapDeployment, BaseDeployment} from "../../deployment/uniswap/UniswapDeployment.s.sol";
+import {GasBase} from "../base/GasBase.sol";
+
+interface IRead {
+    function defiBridgeProxy() external view returns (address);
+}
+
+contract UniswapMeasure is UniswapDeployment {
+    ISubsidy private constant SUBSIDY = ISubsidy(0xABc30E831B5Cc173A9Ed5941714A7845c909e7fA);
+    address private constant BENEFICIARY = address(uint160(uint256(keccak256(abi.encodePacked("_BENEFICIARY")))));
+
+    address public constant USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
+
+    GasBase internal gasBase;
+    UniswapBridge internal bridge;
+
+    AztecTypes.AztecAsset internal emptyAsset;
+    AztecTypes.AztecAsset internal ethAsset;
+    AztecTypes.AztecAsset internal wethAsset;
+    AztecTypes.AztecAsset internal daiAsset;
+
+    UniswapBridge.SplitPath internal emptySplitPath;
+
+    function setUp() public override (BaseDeployment) {
+        super.setUp();
+
+        address defiProxy = IRead(ROLLUP_PROCESSOR).defiBridgeProxy();
+        vm.label(defiProxy, "DefiProxy");
+
+        vm.broadcast();
+        gasBase = new GasBase(defiProxy);
+
+        address temp = ROLLUP_PROCESSOR;
+        ROLLUP_PROCESSOR = address(gasBase);
+        bridge = UniswapBridge(payable(deploy()));
+        ROLLUP_PROCESSOR = temp;
+
+        ethAsset = AztecTypes.AztecAsset({id: 0, erc20Address: address(0), assetType: AztecTypes.AztecAssetType.ETH});
+        wethAsset =
+            AztecTypes.AztecAsset({id: 2, erc20Address: address(WETH), assetType: AztecTypes.AztecAssetType.ERC20});
+        daiAsset = AztecTypes.AztecAsset({
+            id: 1,
+            erc20Address: 0x6B175474E89094C44Da98b954EedeAC495271d0F,
+            assetType: AztecTypes.AztecAssetType.ERC20
+        });
+
+        // List vaults and fund subsidy
+        vm.startBroadcast();
+        bridge.registerSubsidyCriteria(ethAsset.erc20Address, daiAsset.erc20Address);
+        bridge.registerSubsidyCriteria(daiAsset.erc20Address, ethAsset.erc20Address);
+        SUBSIDY.subsidize{value: 1e17}(
+            address(bridge), bridge.computeCriteria(ethAsset, emptyAsset, daiAsset, emptyAsset, 0), 500
+        );
+        SUBSIDY.subsidize{value: 1e17}(
+            address(bridge), bridge.computeCriteria(daiAsset, emptyAsset, ethAsset, emptyAsset, 0), 500
+        );
+        SUBSIDY.registerBeneficiary(BENEFICIARY);
+        vm.stopBroadcast();
+
+        // Warp time to increase subsidy
+        vm.warp(block.timestamp + 10 days);
+    }
+
+    function measure1SplitPathSwap() public {
+        uint64 path = bridge.encodePath(
+            1 ether, 1e20, WETH, UniswapBridge.SplitPath(100, 500, USDC, 100, address(0), 100), emptySplitPath
+        );
+
+        vm.broadcast();
+        address(gasBase).call{value: 2 ether}("");
+        emit log_named_uint("ETH balance of gasBase", address(gasBase).balance);
+
+        // Deposit
+        {
+            vm.broadcast();
+            gasBase.convert(
+                address(bridge), ethAsset, emptyAsset, daiAsset, emptyAsset, 1 ether, 0, path, BENEFICIARY, 300000
+            );
+        }
+
+        uint256 claimableSubsidyAfterDeposit = SUBSIDY.claimableAmount(BENEFICIARY);
+        assertGt(claimableSubsidyAfterDeposit, 0, "Subsidy was not claimed during deposit");
+        emit log_named_uint("Claimable subsidy after deposit", claimableSubsidyAfterDeposit);
+    }
+}


### PR DESCRIPTION
# Description

Implemented Subsidy support in UniswapBridge + gas measurement.

@LHerskind I set the subsidy params (gasUsage, minGasPerMinute) based on the 1 split path swap gas usage which is 300k gas. When 2 split paths are used the bridge consumes 430k gas. I think it's ok to have it based only on the 1 split path swap since it will be the most common case and it's not so important to have the subsidy params precise. If you disagree I could work around that by having a different set of criteria for 1 split path swaps and 2 split path swaps.

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] There are no unexpected formatting changes, or superfluous debug logs.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewers next convenience.
- [x] NatSpec documentation of all the non-test functions is present and is complete.
- [ ] Continuous integration (CI) passes.
- [ ] Command `forge coverage --match-contract MyContract` returns 100% line coverage.
- [ ] All the possible reverts are tested.
