### PR TITLE
Updated TroveBridge measurements

### DIFF
--- a/src/gas/liquity/TroveBridgeGas.s.sol
+++ b/src/gas/liquity/TroveBridgeGas.s.sol
@@ -74,7 +74,7 @@ contract TroveBridgeMeasure is LiquityTroveDeployment {
         {
             vm.broadcast();
             gasBase.convert(
-                address(bridge), ethAsset, emptyAsset, tbAsset, lusdAsset, 1 ether, 0, MAX_FEE, BENEFICIARY, 520000
+                address(bridge), ethAsset, emptyAsset, tbAsset, lusdAsset, 1 ether, 0, MAX_FEE, BENEFICIARY, 630000
             );
         }
 
@@ -92,7 +92,7 @@ contract TroveBridgeMeasure is LiquityTroveDeployment {
 
             vm.broadcast();
             gasBase.convert(
-                address(bridge), tbAsset, lusdAsset, ethAsset, lusdAsset, lusdBalance / 2, 0, 0, BENEFICIARY, 410000
+                address(bridge), tbAsset, lusdAsset, ethAsset, lusdAsset, lusdBalance / 2, 0, 0, BENEFICIARY, 480000
             );
         }
 

--- a/src/test/bridges/liquity/TroveBridgeE2E.t.sol
+++ b/src/test/bridges/liquity/TroveBridgeE2E.t.sol
@@ -34,7 +34,7 @@ contract TroveBridgeE2ETest is BridgeTestBase, TroveBridgeTestBase {
         vm.startPrank(MULTI_SIG);
 
         // List trove bridge with a gasLimit of 500k
-        ROLLUP_PROCESSOR.setSupportedBridge(address(bridge), 550_000);
+        ROLLUP_PROCESSOR.setSupportedBridge(address(bridge), 600_000);
 
         // List the assets with a gasLimit of 100k
         ROLLUP_PROCESSOR.setSupportedAsset(tokens["LUSD"].addr, 100000);


### PR DESCRIPTION
# Description

Unfortunately interactions with Liquity are not constant gas-wise. The cause of this might be the fact that upon trove adjustment Liquity is looking for a new position in the sorted list of troves (on [this line](https://github.com/PolyQuity/contracts/blob/main/BorrowerOperations.sol#L303)). In this PR I adjusted the measurements to the current value. If the gas consumption rises again TroveBridge test should fail.