### PR TITLE
cleanup: capitalize env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ To get started follow the steps below:
 
 6. Write a deployment script.
    Make a script that inherits from the `BaseDeployment.s.sol` file. The base provides helper functions for listing assets/bridges and a getter for the rollup address.  
-   Use the env variables `simulateAdmin=false|true` and `network=mainnet|devnet|testnet` to specify how to run it.  
-   With `simulateAdmin=true`, the `listBridge` and `listAsset` helpers will be impersonating an account with access to list, otherwise they are broadcasted. See the example scripts from other bridges for inspiration on how to write the scripts.
+   Use the env variables `SIMULATE_ADMIN=false|true` and `NETWORK=mainnet|devnet|testnet` to specify how to run it.  
+   With `SIMULATE_ADMIN=true`, the `listBridge` and `listAsset` helpers will be impersonating an account with access to list, otherwise they are broadcasted. See the example scripts from other bridges for inspiration on how to write the scripts.
 
 7. Testing/using your deployment script
    To run your deployment script, you need to set the environment up first, this include specifying the RPC you will be sending the transactions to and the environment variables from above. You can do it using a private key, or even with a Ledger or Trezor, see the foundry book for more info on using hardware wallets.
@@ -62,8 +62,8 @@ To get started follow the steps below:
    # on testnet this will fetch from the Aztec endpoints, on mainnet, this will lookup the `rollup.aztec.eth` ens
    export RPC=https://aztec-connect-testnet-eth-host.aztec.network:8545
    export PRIV_KEY=<DEV_KEY> # If using a private-key directly
-   export network=testnet # When using the testnet
-   export simulateAdmin=false # When you want to broadcast, use `true` if simulating admin
+   export NETWORK=testnet # When using the testnet
+   export SIMULATE_ADMIN=false # When you want to broadcast, use `true` if simulating admin
    forge script --fork-url $RPC --ffi --legacy --private-key $PRIV <NAME_OF_DEPLOYMENT_SCRIPT> --sig "<FUNCTION_SIG>" --broadcast
 
    # Example script reading the current assets and bridges:

--- a/specs/aztec/dataprovider/readme.md
+++ b/specs/aztec/dataprovider/readme.md
@@ -19,17 +19,17 @@ function getAssets() public view returns (AssetData[] memory);
 function getBridges() public view returns (BridgeData[] memory);
 ```
 
-The easiest way to access it, if already using this repository is to execute the `read()` script in the DataProviderDeployment solidity file. It holds addresses for mainnet, testnet and devnet. 
+The easiest way to access it, if already using this repository is to execute the `read()` script in the DataProviderDeployment solidity file. It holds addresses for mainnet, testnet and devnet.
 
 ```bash
-export network=<mainnet|testnet|devnet> && export simulateAdmin=false
+export NETWORK=<mainnet|testnet|devnet> && export SIMULATE_ADMIN=false
 export ETH_RPC_URL=<INSERT_URL>
 forge script DataProviderDeployment --rpc-url $ETH_RPC_URL --sig "read()"
 ```
 
 ## Usage by owner
 
-Updating values stored in the data provider is only possible by the owner of the contract. 
+Updating values stored in the data provider is only possible by the owner of the contract.
 
 Before running the commands bellow export relevant environment variables:
 

--- a/src/deployment/base/BaseDeployment.s.sol
+++ b/src/deployment/base/BaseDeployment.s.sol
@@ -45,7 +45,7 @@ abstract contract BaseDeployment is Test {
 
     function setUp() public virtual {
         // Read from the .env
-        string memory networkKey = "network";
+        string memory networkKey = "NETWORK";
 
         string memory envNetwork = vm.envString(networkKey);
         bytes32 envNetworkHash = keccak256(abi.encodePacked(envNetwork));
@@ -72,7 +72,7 @@ abstract contract BaseDeployment is Test {
             return;
         }
 
-        string memory modeKey = "simulateAdmin";
+        string memory modeKey = "SIMULATE_ADMIN";
         bool envMode = vm.envBool(modeKey);
         MODE = envMode ? Mode.SIMULATE_ADMIN : Mode.BROADCAST;
 


### PR DESCRIPTION
# Description

Small tidy-up pr to capitalise the two env vars:
- simulateAdmin -> SIMULATE_ADMIN
- network -> NETWORK

## TODO
- [ ] Update values in circleci

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] There are no unexpected formatting changes, or superfluous debug logs.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewers next convenience.
- [x] NatSpec documentation of all the non-test functions is present and is complete.
- [ ] Continuous integration (CI) passes.
- [ ] Command `forge coverage --match-contract MyContract` returns 100% line coverage.
- [ ] All the possible reverts are tested.
