### PR TITLE
style: updated formatting

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -11,7 +11,4 @@ ffi = true
 optimizer = true
 optimizer_runs = 100000
 
-[fmt]
-variable_override_spacing=false
-
 # See more config options https://github.com/gakonst/foundry/tree/master/config

--- a/src/aztec/Subsidy.sol
+++ b/src/aztec/Subsidy.sol
@@ -73,7 +73,7 @@ contract Subsidy is ISubsidy {
      * @param _beneficiary The address of the beneficiary to query
      * @return The amount of claimable ETH for `_beneficiary`
      */
-    function claimableAmount(address _beneficiary) external view override (ISubsidy) returns (uint256) {
+    function claimableAmount(address _beneficiary) external view override(ISubsidy) returns (uint256) {
         return beneficiaries[_beneficiary].claimable;
     }
 
@@ -82,7 +82,7 @@ contract Subsidy is ISubsidy {
      * @param _beneficiary The address of the beneficiary to check
      * @return True if the `_beneficiary` is registered, false otherwise
      */
-    function isRegistered(address _beneficiary) external view override (ISubsidy) returns (bool) {
+    function isRegistered(address _beneficiary) external view override(ISubsidy) returns (bool) {
         return beneficiaries[_beneficiary].registered;
     }
 
@@ -92,12 +92,7 @@ contract Subsidy is ISubsidy {
      * @param _criteria The criteria of the subsidy
      * @return The subsidy data object
      */
-    function getSubsidy(address _bridge, uint256 _criteria)
-        external
-        view
-        override (ISubsidy)
-        returns (Subsidy memory)
-    {
+    function getSubsidy(address _bridge, uint256 _criteria) external view override(ISubsidy) returns (Subsidy memory) {
         return subsidies[_bridge][_criteria];
     }
 
@@ -114,7 +109,7 @@ contract Subsidy is ISubsidy {
         uint256[] calldata _criteria,
         uint32[] calldata _gasUsage,
         uint32[] calldata _minGasPerMinute
-    ) external override (ISubsidy) {
+    ) external override(ISubsidy) {
         uint256 criteriasLength = _criteria.length;
         if (criteriasLength != _gasUsage.length || criteriasLength != _minGasPerMinute.length) {
             revert ArrayLengthsDoNotMatch();
@@ -137,7 +132,7 @@ contract Subsidy is ISubsidy {
      *      IDefiBridge.convert(...) function to be as predictable as possible. If the cost is too variable users would
      *      overpay since RollupProcessor works with constant gas limits.
      */
-    function registerBeneficiary(address _beneficiary) external override (ISubsidy) {
+    function registerBeneficiary(address _beneficiary) external override(ISubsidy) {
         beneficiaries[_beneficiary].registered = true;
         emit BeneficiaryRegistered(_beneficiary);
     }
@@ -152,7 +147,7 @@ contract Subsidy is ISubsidy {
      *                                       3) subsidy.gasUsage not set: `subsidy.gasUsage` == 0,
      *                                       4) ETH value sent too low: `msg.value` < `MIN_SUBSIDY_VALUE`.
      */
-    function subsidize(address _bridge, uint256 _criteria, uint32 _gasPerMinute) external payable override (ISubsidy) {
+    function subsidize(address _bridge, uint256 _criteria, uint32 _gasPerMinute) external payable override(ISubsidy) {
         if (msg.value < MIN_SUBSIDY_VALUE) {
             revert SubsidyTooLow();
         }
@@ -185,7 +180,7 @@ contract Subsidy is ISubsidy {
      * @param _criteria A value defining the specific bridge call to subsidize
      * @dev Reverts if `available` is 0.
      */
-    function topUp(address _bridge, uint256 _criteria) external payable override (ISubsidy) {
+    function topUp(address _bridge, uint256 _criteria) external payable override(ISubsidy) {
         // Caching subsidy in order to minimize number of SLOADs and SSTOREs
         Subsidy memory sub = subsidies[_bridge][_criteria];
 
@@ -207,7 +202,7 @@ contract Subsidy is ISubsidy {
      * @param _beneficiary Address which is going to receive the subsidy
      * @return subsidy ETH amount which was added to the `_beneficiary` claimable balance
      */
-    function claimSubsidy(uint256 _criteria, address _beneficiary) external override (ISubsidy) returns (uint256) {
+    function claimSubsidy(uint256 _criteria, address _beneficiary) external override(ISubsidy) returns (uint256) {
         if (_beneficiary == address(0)) {
             return 0;
         }
@@ -250,7 +245,7 @@ contract Subsidy is ISubsidy {
      * @param _beneficiary Address which is going to receive the subsidy
      * @return - ETH amount which was sent to the `_beneficiary`
      */
-    function withdraw(address _beneficiary) external override (ISubsidy) returns (uint256) {
+    function withdraw(address _beneficiary) external override(ISubsidy) returns (uint256) {
         uint256 withdrawableBalance = beneficiaries[_beneficiary].claimable;
         // Immediately updating the balance to avoid re-entrancy attack
         beneficiaries[_beneficiary].claimable = 0;
@@ -284,7 +279,7 @@ contract Subsidy is ISubsidy {
      */
     function setGasUsageAndMinGasPerMinute(uint256 _criteria, uint32 _gasUsage, uint32 _minGasPerMinute)
         public
-        override (ISubsidy)
+        override(ISubsidy)
     {
         // Loading `sub` first in order to not overwrite `sub.available` in case this function was already called
         // and a subsidy was set.

--- a/src/bridges/angle/AngleSLPBridge.sol
+++ b/src/bridges/angle/AngleSLPBridge.sol
@@ -89,7 +89,7 @@ contract AngleSLPBridge is BridgeBase {
         uint256 _interactionNonce,
         uint64 _auxData,
         address _rollupBeneficiary
-    ) external payable override (BridgeBase) onlyRollup returns (uint256 outputValueA, uint256, bool) {
+    ) external payable override(BridgeBase) onlyRollup returns (uint256 outputValueA, uint256, bool) {
         address inputAssetA;
         address outputAssetA;
 
@@ -144,7 +144,7 @@ contract AngleSLPBridge is BridgeBase {
         AztecTypes.AztecAsset calldata,
         AztecTypes.AztecAsset calldata,
         uint64 _auxData
-    ) public pure override (BridgeBase) returns (uint256) {
+    ) public pure override(BridgeBase) returns (uint256) {
         if (_auxData > 1) {
             revert ErrorLib.InvalidAuxData();
         }

--- a/src/bridges/base/BridgeBase.sol
+++ b/src/bridges/base/BridgeBase.sol
@@ -39,7 +39,7 @@ abstract contract BridgeBase is IDefiBridge {
         uint256,
         uint64,
         address
-    ) external payable virtual override (IDefiBridge) returns (uint256, uint256, bool) {
+    ) external payable virtual override(IDefiBridge) returns (uint256, uint256, bool) {
         revert MissingImplementation();
     }
 
@@ -50,7 +50,7 @@ abstract contract BridgeBase is IDefiBridge {
         AztecTypes.AztecAsset calldata,
         uint256,
         uint64
-    ) external payable virtual override (IDefiBridge) returns (uint256, uint256, bool) {
+    ) external payable virtual override(IDefiBridge) returns (uint256, uint256, bool) {
         revert ErrorLib.AsyncDisabled();
     }
 

--- a/src/bridges/curve/CurveStEthBridge.sol
+++ b/src/bridges/curve/CurveStEthBridge.sol
@@ -71,7 +71,7 @@ contract CurveStEthBridge is BridgeBase {
         uint256 _interactionNonce,
         uint64 _auxData,
         address
-    ) external payable override (BridgeBase) onlyRollup returns (uint256 outputValueA, uint256, bool) {
+    ) external payable override(BridgeBase) onlyRollup returns (uint256 outputValueA, uint256, bool) {
         bool isETHInput = _inputAssetA.assetType == AztecTypes.AztecAssetType.ETH;
         bool isWstETHInput = _inputAssetA.assetType == AztecTypes.AztecAssetType.ERC20
             && _inputAssetA.erc20Address == address(WRAPPED_STETH);

--- a/src/bridges/dca/BiDCABridge.sol
+++ b/src/bridges/dca/BiDCABridge.sol
@@ -243,7 +243,7 @@ abstract contract BiDCABridge is BridgeBase {
         uint256 _interactionNonce,
         uint64 _numTicks,
         address
-    ) external payable override (BridgeBase) onlyRollup returns (uint256, uint256, bool) {
+    ) external payable override(BridgeBase) onlyRollup returns (uint256, uint256, bool) {
         address inputAssetAddress = _inputAssetA.erc20Address;
         address outputAssetAddress = _outputAssetA.erc20Address;
 
@@ -289,7 +289,7 @@ abstract contract BiDCABridge is BridgeBase {
         external
         payable
         virtual
-        override (BridgeBase)
+        override(BridgeBase)
         onlyRollup
         returns (uint256 outputValueA, uint256, bool interactionComplete)
     {

--- a/src/bridges/dca/UniswapDCABridge.sol
+++ b/src/bridges/dca/UniswapDCABridge.sol
@@ -109,7 +109,7 @@ contract UniswapDCABridge is BiDCABridge {
      * @dev Reverts if the price is stale or negative
      * @return Price
      */
-    function getPrice() public virtual override (BiDCABridge) returns (uint256) {
+    function getPrice() public virtual override(BiDCABridge) returns (uint256) {
         (, int256 answer,,,) = ORACLE.latestRoundData();
         if (answer < 0) {
             revert NegativePrice();

--- a/src/bridges/donation/DonationBridge.sol
+++ b/src/bridges/donation/DonationBridge.sol
@@ -57,7 +57,7 @@ contract DonationBridge is BridgeBase {
         uint256,
         uint64 _auxData,
         address
-    ) external payable override (BridgeBase) onlyRollup returns (uint256, uint256, bool) {
+    ) external payable override(BridgeBase) onlyRollup returns (uint256, uint256, bool) {
         address receiver = donees[_auxData];
 
         if (receiver == address(0)) {

--- a/src/bridges/element/ElementBridge.sol
+++ b/src/bridges/element/ElementBridge.sol
@@ -428,7 +428,7 @@ contract ElementBridge is BridgeBase {
     )
         external
         payable
-        override (BridgeBase)
+        override(BridgeBase)
         onlyRollup
         returns (uint256 outputValueA, uint256 outputValueB, bool isAsync)
     {
@@ -602,7 +602,7 @@ contract ElementBridge is BridgeBase {
     )
         external
         payable
-        override (BridgeBase)
+        override(BridgeBase)
         onlyRollup
         returns (uint256 outputValueA, uint256 outputValueB, bool interactionCompleted)
     {

--- a/src/bridges/erc4626/ERC4626Bridge.sol
+++ b/src/bridges/erc4626/ERC4626Bridge.sol
@@ -87,7 +87,7 @@ contract ERC4626Bridge is BridgeBase {
         uint256 _interactionNonce,
         uint64 _auxData,
         address _rollupBeneficiary
-    ) external payable override (BridgeBase) onlyRollup returns (uint256 outputValueA, uint256, bool) {
+    ) external payable override(BridgeBase) onlyRollup returns (uint256 outputValueA, uint256, bool) {
         address inputToken = _inputAssetA.erc20Address;
         address outputToken = _outputAssetA.erc20Address;
 
@@ -131,7 +131,7 @@ contract ERC4626Bridge is BridgeBase {
         AztecTypes.AztecAsset calldata _outputAssetA,
         AztecTypes.AztecAsset calldata,
         uint64
-    ) public pure override (BridgeBase) returns (uint256) {
+    ) public pure override(BridgeBase) returns (uint256) {
         return _computeCriteria(_inputAssetA.erc20Address, _outputAssetA.erc20Address);
     }
 

--- a/src/bridges/example/ExampleBridge.sol
+++ b/src/bridges/example/ExampleBridge.sol
@@ -59,7 +59,7 @@ contract ExampleBridge is BridgeBase {
         uint256,
         uint64 _auxData,
         address _rollupBeneficiary
-    ) external payable override (BridgeBase) onlyRollup returns (uint256 outputValueA, uint256, bool) {
+    ) external payable override(BridgeBase) onlyRollup returns (uint256 outputValueA, uint256, bool) {
         // Check the input asset is ERC20
         if (_inputAssetA.assetType != AztecTypes.AztecAssetType.ERC20) revert ErrorLib.InvalidInputA();
         if (_outputAssetA.erc20Address != _inputAssetA.erc20Address) revert ErrorLib.InvalidOutputA();
@@ -86,7 +86,7 @@ contract ExampleBridge is BridgeBase {
         AztecTypes.AztecAsset calldata _outputAssetA,
         AztecTypes.AztecAsset calldata,
         uint64
-    ) public view override (BridgeBase) returns (uint256) {
+    ) public view override(BridgeBase) returns (uint256) {
         return uint256(keccak256(abi.encodePacked(_inputAssetA.erc20Address, _outputAssetA.erc20Address)));
     }
 }

--- a/src/bridges/lido/LidoBridge.sol
+++ b/src/bridges/lido/LidoBridge.sol
@@ -56,7 +56,7 @@ contract LidoBridge is BridgeBase {
         uint256 _interactionNonce,
         uint64,
         address
-    ) external payable override (BridgeBase) onlyRollup returns (uint256 outputValueA, uint256, bool isAsync) {
+    ) external payable override(BridgeBase) onlyRollup returns (uint256 outputValueA, uint256, bool isAsync) {
         bool isETHInput = _inputAssetA.assetType == AztecTypes.AztecAssetType.ETH;
         bool isWstETHInput = _inputAssetA.assetType == AztecTypes.AztecAssetType.ERC20
             && _inputAssetA.erc20Address == address(WRAPPED_STETH);

--- a/src/bridges/liquity/StabilityPoolBridge.sol
+++ b/src/bridges/liquity/StabilityPoolBridge.sol
@@ -113,7 +113,7 @@ contract StabilityPoolBridge is BridgeBase, ERC20("StabilityPoolBridge", "SPB") 
         uint256,
         uint64 _auxData,
         address
-    ) external payable override (BridgeBase) onlyRollup returns (uint256 outputValueA, uint256, bool) {
+    ) external payable override(BridgeBase) onlyRollup returns (uint256 outputValueA, uint256, bool) {
         if (_inputAssetA.erc20Address == LUSD && _outputAssetA.erc20Address == address(this)) {
             // Deposit
             // Provides LUSD to the pool and claim rewards.
@@ -151,7 +151,7 @@ contract StabilityPoolBridge is BridgeBase, ERC20("StabilityPoolBridge", "SPB") 
     /**
      * @dev See {IERC20-totalSupply}.
      */
-    function totalSupply() public view override (ERC20) returns (uint256) {
+    function totalSupply() public view override(ERC20) returns (uint256) {
         return super.totalSupply() - DUST;
     }
 

--- a/src/bridges/liquity/StakingBridge.sol
+++ b/src/bridges/liquity/StakingBridge.sol
@@ -104,7 +104,7 @@ contract StakingBridge is BridgeBase, ERC20("StakingBridge", "SB") {
         uint256,
         uint64 _auxData,
         address
-    ) external payable override (BridgeBase) onlyRollup returns (uint256 outputValueA, uint256, bool) {
+    ) external payable override(BridgeBase) onlyRollup returns (uint256 outputValueA, uint256, bool) {
         if (_inputAssetA.erc20Address == LQTY && _outputAssetA.erc20Address == address(this)) {
             // Deposit
             // Stake and claim rewards
@@ -141,7 +141,7 @@ contract StakingBridge is BridgeBase, ERC20("StakingBridge", "SB") {
     /**
      * @dev See {IERC20-totalSupply}.
      */
-    function totalSupply() public view override (ERC20) returns (uint256) {
+    function totalSupply() public view override(ERC20) returns (uint256) {
         return super.totalSupply() - DUST;
     }
 

--- a/src/bridges/liquity/TroveBridge.sol
+++ b/src/bridges/liquity/TroveBridge.sol
@@ -193,7 +193,7 @@ contract TroveBridge is BridgeBase, ERC20, Ownable, IUniswapV3SwapCallback {
         uint256 _interactionNonce,
         uint64 _auxData,
         address _rollupBeneficiary
-    ) external payable override (BridgeBase) onlyRollup returns (uint256 outputValueA, uint256 outputValueB, bool) {
+    ) external payable override(BridgeBase) onlyRollup returns (uint256 outputValueA, uint256 outputValueB, bool) {
         Status troveStatus = Status(TROVE_MANAGER.getTroveStatus(address(this)));
 
         uint256 subsidyCriteria;
@@ -283,7 +283,7 @@ contract TroveBridge is BridgeBase, ERC20, Ownable, IUniswapV3SwapCallback {
     // @dev See _repayWithCollateral(...) method for more information about how this callback is entered.
     function uniswapV3SwapCallback(int256 _amount0Delta, int256 _amount1Delta, bytes calldata _data)
         external
-        override (IUniswapV3SwapCallback)
+        override(IUniswapV3SwapCallback)
     {
         // Swaps entirely within 0-liquidity regions are not supported
         if (_amount0Delta <= 0 && _amount1Delta <= 0) revert InvalidDeltaAmounts();
@@ -353,7 +353,7 @@ contract TroveBridge is BridgeBase, ERC20, Ownable, IUniswapV3SwapCallback {
     /**
      * @dev See {IERC20-totalSupply}.
      */
-    function totalSupply() public view override (ERC20) returns (uint256) {
+    function totalSupply() public view override(ERC20) returns (uint256) {
         return super.totalSupply() - DUST;
     }
 

--- a/src/bridges/uniswap/UniswapBridge.sol
+++ b/src/bridges/uniswap/UniswapBridge.sol
@@ -187,7 +187,7 @@ contract UniswapBridge is BridgeBase {
         uint256 _interactionNonce,
         uint64 _auxData,
         address _rollupBeneficiary
-    ) external payable override (BridgeBase) onlyRollup returns (uint256 outputValueA, uint256, bool) {
+    ) external payable override(BridgeBase) onlyRollup returns (uint256 outputValueA, uint256, bool) {
         // Accumulate subsidy to _rollupBeneficiary
         SUBSIDY.claimSubsidy(
             _computeCriteria(_inputAssetA.erc20Address, _outputAssetA.erc20Address), _rollupBeneficiary
@@ -319,7 +319,7 @@ contract UniswapBridge is BridgeBase {
         AztecTypes.AztecAsset calldata _outputAssetA,
         AztecTypes.AztecAsset calldata,
         uint64
-    ) public pure override (BridgeBase) returns (uint256) {
+    ) public pure override(BridgeBase) returns (uint256) {
         return _computeCriteria(_inputAssetA.erc20Address, _outputAssetA.erc20Address);
     }
 

--- a/src/bridges/yearn/YearnBridge.sol
+++ b/src/bridges/yearn/YearnBridge.sol
@@ -109,7 +109,7 @@ contract YearnBridge is BridgeBase {
         uint256 _interactionNonce,
         uint64 _auxData,
         address _rollupBeneficiary
-    ) external payable override (BridgeBase) onlyRollup returns (uint256 outputValueA, uint256, bool) {
+    ) external payable override(BridgeBase) onlyRollup returns (uint256 outputValueA, uint256, bool) {
         if (_auxData == 0) {
             if (_outputAssetA.assetType != AztecTypes.AztecAssetType.ERC20) {
                 revert ErrorLib.InvalidOutputA();
@@ -192,7 +192,7 @@ contract YearnBridge is BridgeBase {
         AztecTypes.AztecAsset calldata,
         AztecTypes.AztecAsset calldata,
         uint64 _auxData
-    ) public pure override (BridgeBase) returns (uint256) {
+    ) public pure override(BridgeBase) returns (uint256) {
         if (_auxData > 1) {
             revert ErrorLib.InvalidAuxData();
         }

--- a/src/deployment/liquity/LiquityTroveDeployment.s.sol
+++ b/src/deployment/liquity/LiquityTroveDeployment.s.sol
@@ -30,7 +30,7 @@ contract LiquityTroveDeployment is BaseDeployment {
 
     function deployAndList(uint256 _initialCr) public {
         address bridge = deploy(_initialCr);
-        uint256 addressId = listBridge(bridge, 550_000);
+        uint256 addressId = listBridge(bridge, 700_000);
         emit log_named_uint("Trove bridge address id", addressId);
 
         listAsset(TroveBridge(payable(bridge)).LUSD(), 55_000);

--- a/src/gas/angle/AngleSLPGas.s.sol
+++ b/src/gas/angle/AngleSLPGas.s.sol
@@ -28,7 +28,7 @@ contract AngleMeasure is AngleSLPDeployment {
     AztecTypes.AztecAsset internal wethAsset;
     AztecTypes.AztecAsset internal sanWethAsset;
 
-    function setUp() public override (BaseDeployment) {
+    function setUp() public override(BaseDeployment) {
         super.setUp();
 
         address defiProxy = IRead(ROLLUP_PROCESSOR).defiBridgeProxy();

--- a/src/gas/erc4626/ERC4626Gas.s.sol
+++ b/src/gas/erc4626/ERC4626Gas.s.sol
@@ -36,7 +36,7 @@ contract ERC4626Measure is ERC4626Deployment {
     AztecTypes.AztecAsset internal daiAsset;
     AztecTypes.AztecAsset internal wcDaiAsset; // ERC4626-Wrapped Compound Dai
 
-    function setUp() public override (BaseDeployment) {
+    function setUp() public override(BaseDeployment) {
         super.setUp();
 
         address defiProxy = IRead(ROLLUP_PROCESSOR).defiBridgeProxy();

--- a/src/gas/liquity/TroveBridgeGas.s.sol
+++ b/src/gas/liquity/TroveBridgeGas.s.sol
@@ -26,7 +26,7 @@ contract TroveBridgeMeasure is LiquityTroveDeployment {
     AztecTypes.AztecAsset internal lusdAsset;
     AztecTypes.AztecAsset internal tbAsset; // Accounting token
 
-    function setUp() public override (BaseDeployment) {
+    function setUp() public override(BaseDeployment) {
         super.setUp();
 
         address defiProxy = IRead(ROLLUP_PROCESSOR).defiBridgeProxy();

--- a/src/gas/uniswap/UniswapGas.s.sol
+++ b/src/gas/uniswap/UniswapGas.s.sol
@@ -33,7 +33,7 @@ contract UniswapMeasure is UniswapDeployment {
 
     UniswapBridge.SplitPath internal emptySplitPath;
 
-    function setUp() public override (BaseDeployment) {
+    function setUp() public override(BaseDeployment) {
         super.setUp();
 
         address defiProxy = IRead(ROLLUP_PROCESSOR).defiBridgeProxy();

--- a/src/test/bridges/erc4626/mocks/WETHVault.sol
+++ b/src/test/bridges/erc4626/mocks/WETHVault.sol
@@ -10,7 +10,7 @@ contract WETHVault is
     ERC20("WETH vault", "vWETH"),
     ERC4626(IERC20Metadata(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2))
 {
-    function decimals() public pure override (ERC20, ERC4626) returns (uint8) {
+    function decimals() public pure override(ERC20, ERC4626) returns (uint8) {
         return 18;
     }
 }

--- a/src/test/bridges/liquity/TroveBridgeE2E.t.sol
+++ b/src/test/bridges/liquity/TroveBridgeE2E.t.sol
@@ -34,11 +34,11 @@ contract TroveBridgeE2ETest is BridgeTestBase, TroveBridgeTestBase {
         vm.startPrank(MULTI_SIG);
 
         // List trove bridge with a gasLimit of 500k
-        ROLLUP_PROCESSOR.setSupportedBridge(address(bridge), 600_000);
+        ROLLUP_PROCESSOR.setSupportedBridge(address(bridge), 700_000);
 
         // List the assets with a gasLimit of 100k
-        ROLLUP_PROCESSOR.setSupportedAsset(tokens["LUSD"].addr, 100000);
-        ROLLUP_PROCESSOR.setSupportedAsset(address(bridge), 100000);
+        ROLLUP_PROCESSOR.setSupportedAsset(tokens["LUSD"].addr, 55_000);
+        ROLLUP_PROCESSOR.setSupportedAsset(address(bridge), 55_000);
 
         vm.stopPrank();
 

--- a/src/test/bridges/liquity/utils/MockPriceFeed.sol
+++ b/src/test/bridges/liquity/utils/MockPriceFeed.sol
@@ -12,7 +12,7 @@ contract MockPriceFeed is IPriceFeed {
         lastGoodPrice = _price;
     }
 
-    function fetchPrice() external override (IPriceFeed) returns (uint256) {
+    function fetchPrice() external override(IPriceFeed) returns (uint256) {
         return lastGoodPrice;
     }
 }


### PR DESCRIPTION
# Description

With the new foundry version there is no longer a space after override anywhere. This caused grantee's CI to not pass. I think it makes sense to use the new default style.

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] There are no unexpected formatting changes, or superfluous debug logs.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewers next convenience.
- [x] NatSpec documentation of all the non-test functions is present and is complete.
- [ ] Continuous integration (CI) passes.
- [ ] Command `forge coverage --match-contract MyContract` returns 100% line coverage.
- [ ] All the possible reverts are tested.
