### PR TITLE
fix: pin block for tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
     "test:pinned:14950000": "forge test --fork-block-number 14950000 --match-contract 'BiDCA' --fork-url https://mainnet.infura.io/v3/9928b52099854248b3a096be07a6b23c",
     "test:pinned:14970000": "forge test --fork-block-number 14970000 -m 'testRedistributionSuccessfulSwap|testRedistributionExitWhenICREqualsMCR' --fork-url https://mainnet.infura.io/v3/9928b52099854248b3a096be07a6b23c",
     "test:pinned:14972000": "forge test --fork-block-number 14972000 -m 'testRedistributionFailingSwap' --fork-url https://mainnet.infura.io/v3/9928b52099854248b3a096be07a6b23c",
-    "test:pinned:15500000": "forge test --fork-block-number 16000000 --match-contract 'Yearn' --fork-url https://mainnet.infura.io/v3/9928b52099854248b3a096be07a6b23c",
-    "test:pinned": "yarn test:pinned:14000000 && yarn test:pinned:15500000 && yarn test:pinned:14950000 && yarn test:pinned:14970000 && yarn test:pinned:14972000",
-    "test": "forge test --no-match-contract 'Element|BiDCA|Yearn' --no-match-test 'testRedistribution' && yarn test:pinned",
+    "test:pinned:16000000": "forge test --fork-block-number 16000000 --match-contract 'Yearn' --fork-url https://mainnet.infura.io/v3/9928b52099854248b3a096be07a6b23c",
+    "test:pinned": "yarn test:pinned:14000000 && yarn test:pinned:16000000 && yarn test:pinned:14950000 && yarn test:pinned:14970000 && yarn test:pinned:14972000",
+    "test": "forge test --fork-block-number 16000000 --no-match-contract 'Element|BiDCA|Yearn' --no-match-test 'testRedistribution' --fork-url https://mainnet.infura.io/v3/9928b52099854248b3a096be07a6b23c && yarn test:pinned",
     "formatting": "forge fmt",
     "formatting:check": "forge fmt --check",
     "lint": "solhint --config ./.solhint.json --fix \"src/**/*.sol\""


### PR DESCRIPTION
# Description

Pins the tests that were not already pinned to get around the hurdle of property tests exhausting liquidity pools etc. 

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] There are no unexpected formatting changes, or superfluous debug logs.
- [ ] The branch has been rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewers next convenience.
- [ ] NatSpec documentation of all the non-test functions is present and is complete.
- [ ] Continuous integration (CI) passes.
- [ ] Command `forge coverage --match-contract MyContract` returns 100% line coverage.
- [ ] All the possible reverts are tested.
